### PR TITLE
[FIX] udes_core: always use code128 for product barcodes

### DIFF
--- a/addons/udes_stock/__manifest__.py
+++ b/addons/udes_stock/__manifest__.py
@@ -19,6 +19,9 @@
     ],
     'data': [
         'data/stock_config.xml',
+        'data/stock_config.xml',
+        'report/product_product_templates.xml',
+        'report/report_stockpicking_operations.xml',
         'views/product_template.xml',
         'views/stock_inventory.xml',
         'views/stock_location.xml',

--- a/addons/udes_stock/report/product_product_templates.xml
+++ b/addons/udes_stock/report/product_product_templates.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <!-- Override product label report to always use code128 for product barcodes -->
+        <template id="product.report_simple_label">
+            <div class="col-xs-4" style="padding:0;">
+                <table style="border-spacing:0;margin-bottom:0;height:122px;" class="table">
+                    <thead>
+                        <tr style="width: 3in;">
+                            <td style="border: 2px solid black;width: 2.63in;" colspan="2" class="col-xs-8 danger">
+                                <t t-if="product.default_code">
+                                    [<strong t-field="product.default_code"/>]
+                                </t>
+                                <strong t-field="product.name"/>
+                            </td>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr style="width: 1in;">
+                            <td style="border: 2px solid black;text-align: center; vertical-align: middle;" class="col-xs-5">
+                                <img t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('Code128', product.barcode, 600, 150)" style="width:100%;height:20%;"/>
+                                <span t-field="product.barcode"/>
+                            </td>
+                            <td style="border: 2px solid black; text-align: center;" class="col-xs-7">
+                                <h4>
+                                    <strong t-field="product.company_id.currency_id.symbol"/>
+                                    <strong t-field="product.list_price"/>
+                                </h4>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </template>
+    </data>
+</odoo>

--- a/addons/udes_stock/report/report_stockpicking_operations.xml
+++ b/addons/udes_stock/report/report_stockpicking_operations.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <!-- Extend report_picking to always use code128 for product barcodes-->
+        <template id="my_report_picking" inherit_id="stock.report_picking">
+            <!-- There are two references t[@t-if='has_barcode'], only replace the second one -->
+            <xpath expr="(//t[@t-if='has_barcode'])[2]" position="replace">
+                <t t-if="has_barcode">
+                    <span t-if="move.product_id and move.product_id.barcode">
+                        <img t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('Code128', move.product_id.barcode, 600, 100)" style="width:100%;height:50px" />
+                    </span>
+                </t>
+            </xpath>
+        </template>
+    </data>
+</odoo>


### PR DESCRIPTION
Default stock/product reports use EAN8 and EAN13 encodings by default
when length of the barcode is 8 or 13 respectively, otherwise it uses
code128. In some cases the barcodes of length 8 are not compatible with
EAN8, therefore we override it to always use code128.

Signed-off-by: Miquel PS <miquel.palahi.sitges@unipart.io>