### PR TITLE
[IMP] udes_stock: Allow to use same lot twice

### DIFF
--- a/addons/udes_stock/models/stock_move_line.py
+++ b/addons/udes_stock/models/stock_move_line.py
@@ -234,9 +234,9 @@ class StockMoveLine(models.Model):
             elif mls_with_lot_name:
                 # none of them has lot id, so they are new lot numbers
                 product_mls_in_lot_numbers = mls_with_lot_name.filtered(lambda ml: ml.lot_name in lot_numbers)
-                if product_mls_in_lot_numbers:
+                if product.tracking == 'serial' and product_mls_in_lot_numbers:
                     raise ValidationError(
-                        _('Lot numbers %s already exist in picking %s') %
+                        _('Serial numbers %s already exist in picking %s') %
                         (' '.join(product_mls_in_lot_numbers.mapped('lot_name')),
                          product_mls.mapped('picking_id').name))
                 product.assert_serial_numbers(lot_numbers)


### PR DESCRIPTION
Products tracked by lot should be able to use the same lot number when
receiving stock, either because they are in the different packages or
because they are received in different transfers.
This is related to Odoo core fix:
f7715e18aa8a159ddd48c46c65de7a821ffe6c52

Signed-off-by: Miquel PS <miquel.palahi.sitges@unipart.io>