### PR TITLE
Story/1699

### DIFF
--- a/addons/udes_stock/models/stock_picking_batch.py
+++ b/addons/udes_stock/models/stock_picking_batch.py
@@ -157,17 +157,17 @@ class StockPickingBatch(models.Model):
                                            ('state', '=', 'in_progress')])
 
         if batches:
-            draft_picks = Picking.browse()
+            not_ready_picks = Picking.browse()
             incomplete_picks = Picking.browse()
 
             for pick in batches.mapped('picking_ids'):
-                if pick.state == 'draft':
-                    draft_picks += pick
+                if pick.state in ['draft', 'waiting', 'confirmed']:
+                    not_ready_picks += pick
                 elif pick.state not in ['done', 'cancel']:
                     incomplete_picks += pick
 
-            if draft_picks:
-                draft_picks.write({'batch_id': None})
+            if not_ready_picks:
+                not_ready_picks.write({'batch_id': None})
 
             if incomplete_picks and raise_error:
                 picks_txt = ','.join([x.name for x in incomplete_picks])

--- a/addons/udes_stock/tests/test_picking_batch.py
+++ b/addons/udes_stock/tests/test_picking_batch.py
@@ -88,6 +88,11 @@ class TestGoodsInPickingBatch(common.BaseUDES):
         Batch = self.env['stock.picking.batch']
         Batch = Batch.sudo(self.outbound_user)
 
+        self.create_quant(self.apple.id, self.test_location_01.id, 4,
+                          package_id=self.package_one.id)
+        self.create_quant(self.apple.id, self.test_location_01.id, 4,
+                          package_id=self.package_two.id)
+
         batch01 = self.create_batch(user=self.outbound_user)
         self.create_picking(self.picking_type_pick,
                             products_info=self.pack_4apples_info,

--- a/addons/udes_stock/tests/test_picking_batch.py
+++ b/addons/udes_stock/tests/test_picking_batch.py
@@ -175,9 +175,11 @@ class TestGoodsInPickingBatch(common.BaseUDES):
 
     def test09_create_batch_user_already_has_completed_batch(self):
         """
-        Should create a new batch in case the user already has a
-        batch assigned to him but all the included pickings are
-        complete.
+        When dropping off a partially reserved picking, a backorder in state
+        confirmed is created and remains in the batch. This backorder should
+        be removed from the batch, allowing the batch to be automatically
+        completed and the user should be able to create a new batch without
+        any problem.
 
         """
         Batch = self.env['stock.picking.batch']
@@ -185,15 +187,26 @@ class TestGoodsInPickingBatch(common.BaseUDES):
         Batch = Batch.sudo(self.outbound_user)
 
         # set a batch with a complete picking
-        self.create_quant(self.apple.id, self.test_location_01.id, 4,
+        self.create_quant(self.apple.id, self.test_location_01.id, 2,
                           package_id=self.package_one.id)
+        # Create a picking partially reserved
         picking = self.create_picking(self.picking_type_pick,
                                       products_info=self.pack_4apples_info,
                                       confirm=True,
                                       assign=True)
         batch = Batch.create_batch(None)
-        picking.update_picking(force_validate=True,
-                               location_dest_id=self.test_output_location_01.id)
+        for ml in picking.move_line_ids:
+            ml.qty_done = ml.product_qty
+        # On drop off a backorder is created for the remaining 2 units,
+        # but _check_batches() removes it from the batch since it is not ready
+        batch.drop_off_picked(continue_batch=True,
+                              location_barcode=self.test_output_location_01.name)
+
+        # check the picking is done and the backorder is not in the batch
+        self.assertEqual(picking.state, 'done')
+        self.assertEqual(len(batch.picking_ids), 1)
+        self.assertEqual(batch.state, 'done')
+        self.assertEqual(batch.picking_ids[0].state, 'done')
 
         # create a new picking to be included in the new batch
         other_pack = Package.get_package("test_other_package", create=True)
@@ -204,13 +217,6 @@ class TestGoodsInPickingBatch(common.BaseUDES):
                                             confirm=True,
                                             assign=True)
 
-        # check pre-conditions
-        self.assertEqual(picking.state, 'done')
-        self.assertEqual(len(batch.picking_ids), 1)
-        self.assertEqual(batch.state, 'done')
-        self.assertEqual(batch.picking_ids[0].state, 'done')
-
-        # method under test
         new_batch = Batch.create_batch(None)
 
         # check outcome


### PR DESCRIPTION
Remove pickings in state not ready (draft, confirmed, waiting) from batches, to allow the batch to be finished. This usually happens with pickings partially assigned and after validating them a backorder is created and remains in the same batch but in state waiting.