### PR TITLE
[FIX] udes_stock: Do not use translatable strings in xpath expressions

### DIFF
--- a/addons/udes_stock/views/stock_picking.xml
+++ b/addons/udes_stock/views/stock_picking.xml
@@ -108,7 +108,7 @@
         <field name="inherit_id" ref="stock.stock_picking_type_kanban"/>
         <field name="arch" type="xml">
             <!-- Add option to remove immediate transfer button -->
-            <xpath expr="//a[contains(., 'Immediate Transfer')]" position="attributes">
+            <xpath expr="//a[@name='%(stock.action_picking_form)d' and not(@context)]" position="attributes">
                 <attribute name="invisible">1</attribute>
             </xpath>
         </field>


### PR DESCRIPTION
XPath expressions must not use human-readable text strings to locate
elements to be modified since these are likely to be changed.  In
particular, the expression will fail if it refers to a text string
subject to language translation.

Fix by matching on the "name" attribute value (and absence of the
"context" attribute) instead of matching on the element text contents.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>