### PR TITLE
[IMP] udes_stock: Extend stock.move.line location_dest_id constraint

### DIFF
--- a/addons/udes_sale_stock/tests/__init__.py
+++ b/addons/udes_sale_stock/tests/__init__.py
@@ -1,3 +1,4 @@
 """UDES sale_Stock tests"""
 
+from . import common
 # from . import test_sale_order

--- a/addons/udes_sale_stock/tests/common.py
+++ b/addons/udes_sale_stock/tests/common.py
@@ -1,0 +1,35 @@
+from odoo.addons.udes_stock.tests import common
+
+
+class BaseSaleUDES(common.BaseUDES):
+
+    @classmethod
+    def setUpClass(cls):
+        super(BaseSaleUDES, cls).setUpClass()
+        cls.customer = cls.env.ref('base.public_partner')
+
+    @classmethod
+    def create_sale_line(cls, sale, product, qty, **kwargs):
+        """Create a sale order line and attach it a sale order"""
+        create_values = {
+            'name': product.name,
+            'order_id': sale.id,
+            'product_id': product.id,
+            'product_uom_qty': qty,
+            'product_uom': product.uom_id.id,
+            'price_unit': product.list_price,
+        }
+        create_values.update(kwargs)
+        return cls.env['sale.order.line'].create(create_values)
+
+    @classmethod
+    def create_sale(cls, customer, **kwargs):
+        """Create a sale order"""
+        create_values = {
+            'partner_id': customer.id,
+            'partner_invoice_id': customer.id,
+            'partner_shipping_id': customer.id,
+            'pricelist_id': cls.env.ref('product.list0').id,
+        }
+        create_values.update(kwargs)
+        return cls.env['sale.order'].create(create_values)

--- a/addons/udes_stock/models/stock_move_line.py
+++ b/addons/udes_stock/models/stock_move_line.py
@@ -661,6 +661,8 @@ class StockMoveLine(models.Model):
 
         # HERE(ale): iterating picking_id even if it's a many2one
         # because the constraint can be triggered anywhere
+
+        # TODO(ale): consider using `picking::groupby` once available
         for picking in self.mapped('picking_id'):
             if not picking.is_valid_location_dest_id(location=location):
                 raise ValidationError(

--- a/addons/udes_stock/models/stock_move_line.py
+++ b/addons/udes_stock/models/stock_move_line.py
@@ -672,12 +672,12 @@ class StockMoveLine(models.Model):
             if picking.picking_type_id.u_drop_location_constraint == 'enforce':
                 mls = self.filtered(lambda ml: ml.picking_id == picking)
                 locations = picking.get_suggested_locations(mls)
-                # location should be one of the suggested locations if there
-                # are any
+
+                # location should be one of the suggested locations, if any
                 if locations and location not in locations:
                     raise ValidationError(
                         _("Drop off location must be one of the suggested "
-                          "locations."))
+                          "locations"))
 
     def any_destination_locations_default(self):
         """Checks if all location_dest_id's are default_location_dest_id of

--- a/addons/udes_stock/tests/__init__.py
+++ b/addons/udes_stock/tests/__init__.py
@@ -7,6 +7,7 @@ from . import test_create_procurement_group
 from . import test_handle_partials
 from . import test_location_pi
 from . import test_location_policy
+from . import test_move_line
 from . import test_package_reservation
 from . import test_package_swap
 from . import test_picking

--- a/addons/udes_stock/tests/common.py
+++ b/addons/udes_stock/tests/common.py
@@ -109,6 +109,14 @@ class BaseUDES(common.SavepointCase):
             'barcode': "LTESTOUT01",
             'location_id': cls.out_location.id})
 
+        cls.test_output_location_02 = Location.create({
+            'name': "Test output location 02",
+            'barcode': "LTESTOUT02",
+            'location_id': cls.out_location.id})
+
+        cls.test_output_locations = cls.test_output_location_01 + \
+            cls.test_output_location_02
+
     @classmethod
     def _setup_check_location(cls):
         Location = cls.env['stock.location']

--- a/addons/udes_stock/tests/test_move_line.py
+++ b/addons/udes_stock/tests/test_move_line.py
@@ -1,0 +1,101 @@
+from . import common
+from odoo.exceptions import ValidationError
+
+
+# NB(ale): the drop location constraint is also tested in
+# test_update_picking::TestUpdatePickingMarksMoveLinesAsDone
+# via Picking::update_picking
+
+class TestValidateLocationDest(common.BaseUDES):
+    ''' Tests the drop location constraint '''
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestValidateLocationDest, cls).setUpClass()
+        cls.picking_type_in.u_target_storage_format = 'product'
+        cls._pick_info = [{'product': cls.apple, 'qty': 4}]
+
+    def test01_drop_location_not_suggeested_enforced_failure(self):
+        """ When the policy is `enforce`, an error is thrown when a
+            valid, but not suggested, drop off location is used.
+        """
+        self.picking_type_putaway.u_drop_location_constraint = 'enforce'
+        self.picking_type_putaway.u_drop_location_policy     = 'by_products'
+
+        self.create_quant(self.apple.id, self.test_location_01.id, 4)
+        self.create_quant(self.apple.id,
+                          self.picking_type_putaway.default_location_src_id.id,
+                          4)
+        picking = self.create_picking(self.picking_type_putaway,
+                                      products_info=self._pick_info,
+                                      confirm=True,
+                                      assign=True)
+        mls = picking.move_line_ids
+        locations = picking.get_suggested_locations(mls)
+
+        # We'll use loc 02 to drop off, so we check the assumption
+        self.assertEqual(locations, self.test_location_01)
+        err_msg = "Drop off location must be one of the suggested locations"
+
+        for ml in mls:
+            e = None
+
+            with self.assertRaises(ValidationError) as e:
+                ml.write({'location_dest_id': self.test_location_02.id})
+
+            self.assertEqual(e.exception.name, err_msg)
+
+    def test02_drop_location_not_suggeested_not_enforced(self):
+        """ When the policy is `suggest`, NO error is thrown when a
+            valid, but not suggested, drop off location is used.
+            NB: same as test01, but with 'suggest' constraint.
+        """
+        self.picking_type_putaway.u_drop_location_constraint = 'suggest'
+        self.picking_type_putaway.u_drop_location_policy = 'by_products'
+
+        self.create_quant(self.apple.id, self.test_location_01.id, 4)
+
+        self.create_quant(self.apple.id,
+                          self.picking_type_putaway.default_location_src_id.id,
+                          4)
+        picking = self.create_picking(self.picking_type_putaway,
+                                      products_info=self._pick_info,
+                                      confirm=True,
+                                      assign=True)
+        mls = picking.move_line_ids
+        locations = picking.get_suggested_locations(mls)
+
+        # We'll use loc 02 to drop off, so we check the assumption
+        self.assertEqual(locations, self.test_location_01)
+
+        for ml in mls:
+            # Expecting no error
+            ml.write({'location_dest_id': self.test_location_02.id})
+
+
+    def test03_suggested_drop_location_enforced_success(self):
+        """ When the policy is `enforce`, NO error is thrown when a
+            suggested drop off location is used.
+            NB: same as test01, but using a suggested location.
+        """
+        self.picking_type_putaway.u_drop_location_constraint = 'enforce'
+        self.picking_type_putaway.u_drop_location_policy = 'by_products'
+
+        self.create_quant(self.apple.id, self.test_location_01.id, 4)
+
+        self.create_quant(self.apple.id,
+                          self.picking_type_putaway.default_location_src_id.id,
+                          4)
+        picking = self.create_picking(self.picking_type_putaway,
+                                      products_info=self._pick_info,
+                                      confirm=True,
+                                      assign=True)
+        mls = picking.move_line_ids
+        locations = picking.get_suggested_locations(mls)
+
+        # We'll use loc 01 to drop off, so we check the assumption
+        self.assertEqual(locations, self.test_location_01)
+
+        for ml in mls:
+            # Expecting no error
+            ml.write({'location_dest_id': self.test_location_01.id})

--- a/addons/udes_stock/tests/test_update_picking.py
+++ b/addons/udes_stock/tests/test_update_picking.py
@@ -735,6 +735,8 @@ class TestGoodsInUpdatePickingPallet(common.BaseUDES):
                          'Stock picking is not in state done after validation.')
 
 
+# NB(ale): more tests for drop off location validation in test_move_line.py
+
 class TestUpdatePickingMarksMoveLinesAsDone(common.BaseUDES):
 
     @classmethod


### PR DESCRIPTION
The constraint is also now triggered by onchange and checks if the
location is one of the suggested locations when the drop off constraint
is set to enforce at the picking type.

Signed-off-by: Miquel PS <miquel.palahi.sitges@unipart.io>