### PR TITLE
[FIX] udes_sale_stock: Cancel related moves on sale.order.action_cancel()

### DIFF
--- a/addons/udes_sale_stock/models/sale_order.py
+++ b/addons/udes_sale_stock/models/sale_order.py
@@ -36,3 +36,8 @@ class SaleOrder(models.Model):
                 order.action_done()
             if len(order.picking_ids) == len(cancel_pickings):
                 order.with_context(from_sale=True).action_cancel()
+
+    def action_cancel(self):
+        """Override to cancel by moves instead of by pickings"""
+        self.mapped('order_line.move_ids')._action_cancel()
+        return self.write({'state': 'cancel'})


### PR DESCRIPTION

By default when canceling a sale order, sale_stock module cancels the
related stock.pickings, but when several orders share pickings that
ends up canceling stock.moves of other sale orders.
This is addressed by canceling by stock.moe instead of stock.picking.

Signed-off-by: Miquel PS <miquel.palahi.sitges@unipart.io>