### PR TITLE
story/1688: Putaway suggestions preprocessing

### DIFF
--- a/addons/udes_stock/README.md
+++ b/addons/udes_stock/README.md
@@ -115,6 +115,7 @@ A lot of custom UDES functionality is specfied at the picking type level. This i
 | u_validate_real_time       | boolean | Do we validate move lines in real time. |
 | u_drop_location_constraint | string  | Whether drop location should be scanned, suggested and, then, enforced (enum: 'dont_scan', 'scan', 'enforce', 'suggest'); default: 'scan'. |
 | u_drop_location_policy     | string  | To indicate the policy for suggesting drop locations (enum: 'exactly_match_move_line', 'by_products', 'by_packages'); default: 'exactly_match_move_line'. |
+| u_drop_location_preprocess  | boolean | Selects if suggestions u_drop_location_policy should be added on assignment. If this is set will apply the u_drop_location_policy and the first location is set as location_dest_id for the set of move_lines. This can only be used with polcies decorated with allow_preprocess, usage on other polcies will result in an ValidationError.|
 | u_display_summary          | string  | How to display the Source Document and a summary of all Package Names associated with that Source Document number at Goods-Out (enum: 'none', 'list', 'list_contents'). |
 | u_handle_partials          | boolean | If the picking type is allowed to handle partially available pickings. If True, then pickings of this type will report their u_pending value. |
 | u_create_procurement_group | boolean | Indicate if a procurement group should be created on confirmation of the picking if one does not already exist. |

--- a/addons/udes_stock/models/stock_move_line.py
+++ b/addons/udes_stock/models/stock_move_line.py
@@ -656,3 +656,13 @@ class StockMoveLine(models.Model):
                 raise ValidationError(
                     _("The location '%s' is not a child of the picking destination "
                       "location '%s'" % (location.name, picking.location_dest_id.name)))
+
+    def any_destination_locations_default(self):
+        """Checks if all location_dest_id's are default_location_dest_id of
+           the picking_type_id.
+        """
+        default_dest = self.mapped(
+            'picking_id.picking_type_id.default_location_dest_id'
+        )
+        default_dest.ensure_one()
+        return any(ml.location_dest_id == default_dest for ml in self)

--- a/addons/udes_stock/models/stock_picking.py
+++ b/addons/udes_stock/models/stock_picking.py
@@ -1352,12 +1352,12 @@ class StockPicking(models.Model):
             raise ValidationError(
                 _('Products missing to suggest location for.'))
 
-        quants = Quant.search(
-            [('product_id', 'in', products.ids),
-             ('location_id', 'child_of', self.location_dest_id.ids)])
-
-        suggested_locations = quants.mapped('location_id') \
-            .filtered(lambda loc: not loc.u_blocked and loc.barcode)
+        suggested_locations = Quant.search([
+            ('product_id', 'in', products.ids),
+            ('location_id', 'child_of', self.location_dest_id.ids),
+            ('location_id.u_blocked', '=', False),
+            ('location_id.barcode', '!=', False),
+        ]).mapped('location_id')
 
         if not suggested_locations:
             # No drop locations currently used for this product;

--- a/addons/udes_stock/models/stock_picking.py
+++ b/addons/udes_stock/models/stock_picking.py
@@ -1292,9 +1292,18 @@ class StockPicking(models.Model):
 
         for picking in self:
             policy = picking.picking_type_id.u_drop_location_policy
-
             if policy:
-                func = getattr(self, '_get_suggested_location_' + policy, None)
+                if move_line_ids and \
+                        picking.picking_type_id.u_drop_location_preprocess and \
+                        not move_line_ids.any_destination_locations_default():
+                    # The policy has been preprocessed this assumes the
+                    # the polciy is able to provide a sensible value (this is
+                    # not the case for every policy)
+                    # Use the preselected value
+                    func = self._get_suggested_location_exactly_match_move_line
+                else:
+                    func = getattr(self, '_get_suggested_location_' + policy,
+                                   None)
 
                 if func:
                     result = func(move_line_ids)

--- a/addons/udes_stock/models/stock_picking.py
+++ b/addons/udes_stock/models/stock_picking.py
@@ -1005,6 +1005,13 @@ class StockPicking(models.Model):
         """
             Override action_assign to reserve full packages if applicable
         """
+
+        # stock.picking.action_assign is usually only called when manually
+        # clicking "check availability" in Odoo UI or when explicitly called.
+        # When the next step in a route is being reserved
+        # stock.move._action_assign is called directly
+        #
+
         res = super(StockPicking, self).action_assign()
         if res is not True:
             raise ValidationError(

--- a/addons/udes_stock/models/stock_picking_type.py
+++ b/addons/udes_stock/models/stock_picking_type.py
@@ -105,6 +105,7 @@ class StockPickingType(models.Model):
         ('exactly_match_move_line', 'Exactly Match The Move Line Destination Location'),
         ('by_products', 'By Products'),
         ('by_packages', 'By Products in Packages'),
+        ('by_height_speed', 'By Height and Speed Catagory'),
     ],
         string='Suggest Locations Policy',
         default='exactly_match_move_line',

--- a/addons/udes_stock/models/stock_picking_type.py
+++ b/addons/udes_stock/models/stock_picking_type.py
@@ -111,6 +111,13 @@ class StockPickingType(models.Model):
         help='Indicate the policy for suggesting drop locations.'
     )
 
+    u_drop_location_preprocess = fields.Boolean(
+        string='Add destination location on pick assignement',
+        default=False,
+        help='Flag to indicate if picking assignment should select '
+             'destination locations'
+    )
+
     u_auto_batch_pallet = fields.Boolean(
         string='Auto batch pallet',
         default=False,

--- a/addons/udes_stock/tests/common.py
+++ b/addons/udes_stock/tests/common.py
@@ -463,3 +463,8 @@ class BaseUDES(common.SavepointCase):
         vals = {}
         vals.update(kwargs)
         return Package.create(vals)
+
+    @classmethod
+    def create_category(cls, **kwargs):
+        ProductCategory = cls.env['product.category']
+        return ProductCategory.create(kwargs)

--- a/addons/udes_stock/tests/test_picking_type.py
+++ b/addons/udes_stock/tests/test_picking_type.py
@@ -191,7 +191,7 @@ class TestPickingType(common.BaseUDES):
 
     def test08_get_suggested_locations_by_products_missing_parameter(self):
         """ Validation error raised when trying to suggest locations of a
-            picking by products and passing an empty list of move lines.
+            picking by products and passing an empty set of move lines.
         """
         self.picking_type_putaway.u_drop_location_policy = 'by_products'
 
@@ -199,12 +199,13 @@ class TestPickingType(common.BaseUDES):
                           self.picking_type_putaway.default_location_src_id.id,
                           4, package_id=self.package_one.id)
         picking = self.create_picking(self.picking_type_putaway,
-                                       products_info=self.pack_4apples_info,
-                                       confirm=True,
-                                       assign=True)
+                                      products_info=self.pack_4apples_info,
+                                      confirm=True,
+                                      assign=True)
 
+        MoveLine = self.env['stock.move.line']
         with self.assertRaises(ValidationError) as err:
-            locations = picking.get_suggested_locations([])
+            locations = picking.get_suggested_locations(MoveLine)
 
         msg = 'Cannot determine the suggested location: missing move lines'
         self.assertEqual(err.exception.name, msg)

--- a/addons/udes_stock/views/stock_location.xml
+++ b/addons/udes_stock/views/stock_location.xml
@@ -30,6 +30,11 @@
                     </div>
                 </xpath>
 
+                <!-- Hide the Put Away strategy button (not removed as other modules may depend on it being here) -->
+                <xpath expr="//field[@name='putaway_strategy_id']" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </xpath>
+
                 <xpath expr="//field[@name='putaway_strategy_id']" position="after">
                     <field name="u_height_category_id" />
                     <field name="u_speed_category_id" />

--- a/addons/udes_stock/views/stock_picking_type.xml
+++ b/addons/udes_stock/views/stock_picking_type.xml
@@ -31,6 +31,7 @@
                     <field name="u_create_procurement_group"/>
                     <field name="u_drop_location_constraint" />
                     <field name="u_drop_location_policy" />
+                    <field name="u_drop_location_preprocess"/>
                     <field name="u_confirm_serial_numbers" />
                     <field name="u_auto_batch_pallet" />
                     <field name="u_check_work_available" />


### PR DESCRIPTION
Add the ability to preprocess suggested locations and add them to a move line
this allows the location to effectively reserved (for policies which check for this).

Also implements a policy to suggest locations based on height/speed category and also doing the aforementioned check