### PR TITLE
[FIX] udes_sale_stock: Explicitly clear sale.order.picking_ids invers…

### DIFF
--- a/addons/udes_sale_stock/models/sale_order.py
+++ b/addons/udes_sale_stock/models/sale_order.py
@@ -12,7 +12,7 @@ class SaleOrder(models.Model):
         ('done', 'Done'),
     ])
 
-    picking_ids = fields.One2many('stock.picking',
+    picking_ids = fields.One2many('stock.picking', inverse_name=None,
                                   compute="_compute_picking_ids_by_line")
 
     @api.depends('order_line.move_ids.picking_id')


### PR DESCRIPTION
…e_name

The existing code in udes_sale_stock redefines sale.order.picking_ids
as a non-stored computed field, rendering the inverse field
stock.picking.sale_id meaningless.  Explicitly clear the inverse field
for sale.order.picking_ids to avoid confusing the ORM and generating
multiple "Non-stored field sale.order.picking_ids cannot be searched"
error messages.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>