### PR TITLE
[IMP] udes_stock: Add stock.picking sequence field

### DIFF
--- a/addons/udes_stock/controllers/main.py
+++ b/addons/udes_stock/controllers/main.py
@@ -1,6 +1,30 @@
 # -*- coding: utf-8 -*-
 
 from odoo import http
+from odoo.exceptions import ValidationError
+from odoo.tools.translate import _
+from odoo.addons.web import controllers
+
 
 class UdesApi(http.Controller):
     pass
+
+
+class DataSet(controllers.main.DataSet):
+    """Dataset controller"""
+
+    @http.route()
+    def resequence(self, model, ids, field='sequence', **kwargs):
+        """Check that resequencing has resulted in expected record order
+
+        The Odoo web UI does not correctly handle models for which the
+        ``sequence`` field is not the highest precedence within the
+        sort order.
+        """
+        result = super().resequence(model, ids, field=field, **kwargs)
+        recs = http.request.env[model].browse(ids)
+        if list(recs.sorted()) != list(recs.sorted(field)):
+            raise ValidationError(
+                _("Sequence is overridden by default sort ordering")
+            )
+        return result

--- a/addons/udes_stock/models/stock_picking.py
+++ b/addons/udes_stock/models/stock_picking.py
@@ -37,7 +37,10 @@ def allow_preprocess(func):
 class StockPicking(models.Model):
     _inherit = 'stock.picking'
 
+    _order = 'priority desc, scheduled_date asc, sequence asc, id asc'
+
     priority = fields.Selection(selection=common.PRIORITIES)
+    sequence = fields.Integer("Sequence", default=0)
 
     # compute previous and next pickings
     u_prev_picking_ids = fields.One2many(

--- a/addons/udes_stock/views/stock_picking.xml
+++ b/addons/udes_stock/views/stock_picking.xml
@@ -56,6 +56,11 @@
                 <attribute name="attrs">{'required': [('picking_type_code', '=', 'incoming')]}</attribute>
             </xpath>              
 
+            <!-- Add sequence -->
+            <xpath expr="//field[@name='priority']" position="after">
+                <field name="sequence"/>
+            </xpath>
+
             <!--Hide unlock/lock button-->
             <xpath expr="//button[@name='action_toggle_is_locked']" position="attributes">
                 <attribute name="invisible">1</attribute>
@@ -87,6 +92,21 @@
                 <attribute name="decoration-muted">scrapped == True or state == 'cancel'</attribute>
                 <attribute name="decoration-bf">(ordered_qty == quantity_done) or (ordered_qty &lt; quantity_done)</attribute>
             </xpath>
+        </field>
+    </record>
+
+    <!-- Change default stock.vpicktree -->
+    <record id="view_tree_stock_picking" model="ir.ui.view">
+        <field name="name">udes_picking_tree</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.vpicktree"/>
+        <field name="arch" type="xml">
+
+            <!-- Add sequence widget -->
+            <xpath expr="//tree/field[1]" position="before">
+                <field name="sequence" widget="handle"/>
+            </xpath>
+
         </field>
     </record>
 


### PR DESCRIPTION
Provide the ability to specify an arbitrary ordering amongst
stock.picking records with the same priority and scheduled date, by
adding a standard "sequence" integer field and redefining the default
sort order.

A standard handle widget is provided in the stock.picking tree view.
Note that the sequence is (deliberately) not the highest precedence
field within the sort order, and so using the widget to attempt to
reorder stock.picking records that do not already have the same
priority and scheduled date will not work as expected.

There seems to be no sensible way to modify the behaviour of sequence
handle widgets to e.g. limit the positions in which the dragged row
can be dropped.

On the server side, we can intercept the /web/dataset/resequence
endpoint and verify that the resequencing operation has left the
records in an order that reflects the user's intention.  The
resequencing transaction can be aborted and an error message
propagated to the user, but there seems to be no way to prevent the
BasicModel.resequence() method in the UI from updating the displayed
sort order as though the operation had succeeded.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>