### PR TITLE
[IMP] udes_stock: Allow refactoring methods to return None

### DIFF
--- a/addons/udes_stock/models/stock_move.py
+++ b/addons/udes_stock/models/stock_move.py
@@ -221,8 +221,10 @@ class StockMove(models.Model):
                     _logger.info("Refactoring %s at %s using %s: %s",
                                  picking_type.name, stage, action, st_moves.ids)
                     func = getattr(st_moves, 'refactor_action_' + action)
-                    moves -= st_moves
-                    moves |= func()
+                    new_moves = func()
+                    if new_moves is not None:
+                        moves -= st_moves
+                        moves |= new_moves
 
         return moves
 


### PR DESCRIPTION
Allow a refactoring method to return None to indicate that the set of
move lines has remained unaltered.  This allow for simpler code when
the move lines are not themselves being modified, and eliminates some
unnecessary recordset manipulation.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>