### PR TITLE
[ADD] Result package information to batch::get

### DIFF
--- a/addons/udes_stock/models/stock_picking.py
+++ b/addons/udes_stock/models/stock_picking.py
@@ -894,6 +894,11 @@ class StockPicking(models.Model):
 
         return res
 
+    def get_result_packages_names(self):
+        """ Return a list of the names of the parent packages
+        """
+        return list(set(self.mapped('move_line_ids.result_package_id.name')))
+
     @api.model
     def get_priorities(self):
         """ Return a list of dicts containing the priorities of the

--- a/addons/udes_stock/models/stock_picking_batch.py
+++ b/addons/udes_stock/models/stock_picking_batch.py
@@ -157,7 +157,8 @@ class StockPickingBatch(models.Model):
                 lambda x: x.state in allowed_picking_states)
 
         return {'id': self.id,
-                'picking_ids': pickings.get_info()}
+                'picking_ids': pickings.get_info(),
+                'result_package_names': pickings.get_result_packages_names()}
 
     def get_info(self, allowed_picking_states):
         """


### PR DESCRIPTION
Adding the move lines result package barcodes to the
batch metadata returned in the batch::get response.

This can be then used by the requester to easily
determine whether a scanned pallet barcode is expected
by the batch.

Task: 2165