### PR TITLE
[FIX] udes_stock: Auto created batches in pick should be ephemeral

### DIFF
--- a/addons/udes_stock/models/stock_picking_batch.py
+++ b/addons/udes_stock/models/stock_picking_batch.py
@@ -212,7 +212,8 @@ class StockPickingBatch(models.Model):
 
         batch = PickingBatch.create({'user_id': user_id})
         picking.batch_id = batch.id
-        batch.write({'state': 'in_progress'})
+        batch.write({'state': 'in_progress',
+                     'u_ephemeral': True})
 
         return batch
 


### PR DESCRIPTION
Batches created automatically in pick should be ephemeral so that pickings are unassigned when the user logs out or goes on break. 