### PR TITLE
[IMP] udes_stock: Delete empty picks instead of cancelling

### DIFF
--- a/addons/udes_stock/models/stock_move.py
+++ b/addons/udes_stock/models/stock_move.py
@@ -402,12 +402,8 @@ class StockMove(models.Model):
 
         empty_picks = pickings.filtered(lambda p: len(p.move_lines) == 0)
         if empty_picks:
-            _logger.info(_("Cancelling empty picks after splitting."))
-            # action_cancel does not cancel a picking with no moves.
-            empty_picks.write({
-                'state': 'cancel',
-                'is_locked': True
-            })
+            _logger.info(_("Deleting empty picks after splitting."))
+            empty_picks.unlink()
 
         return self
 
@@ -469,11 +465,7 @@ class StockMove(models.Model):
 
         empty_picks = pickings.filtered(lambda p: len(p.move_lines) == 0)
         if empty_picks:
-            _logger.info(_("Cancelling empty picks after splitting."))
-            # action_cancel does not cancel a picking with no moves.
-            empty_picks.write({
-                'state': 'cancel',
-                'is_locked': True
-            })
+            _logger.info(_("Deleting empty picks after splitting."))
+            empty_picks.unlink()
 
         return result_moves


### PR DESCRIPTION
The current approach of cancelling empty picks results in large
numbers of cancelled picks left polluting the database.  Fix by
deleting empty picks instead.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>