### PR TITLE
[FIX] udes_stock: Do not propagate move qty change

### DIFF
--- a/addons/udes_stock/models/stock_move.py
+++ b/addons/udes_stock/models/stock_move.py
@@ -165,7 +165,8 @@ class StockMove(models.Model):
                 'picking_id': None,
             })
 
-            self.with_context(bypass_reservation_update=True).write({
+            self.with_context(bypass_reservation_update=True,
+                              do_not_propagate=True).write({
                 'ordered_qty': self.ordered_qty - total_ordered_qty,
                 'product_uom_qty': self.product_uom_qty - total_initial_qty,
             })


### PR DESCRIPTION
When a move is split, the qty of the original move is updated and
incorrectly propagates the qty update to the following move.
Use do_not_propagate context variable to avoid it.

Signed-off-by: Miquel PS <miquel.palahi.sitges@unipart.io>