### PR TITLE
[IMP] udes_stock: Override stock.picking._recompute_state()

### DIFF
--- a/addons/udes_stock/README.md
+++ b/addons/udes_stock/README.md
@@ -117,7 +117,7 @@ A lot of custom UDES functionality is specfied at the picking type level. This i
 | u_drop_location_policy     | string  | To indicate the policy for suggesting drop locations (enum: 'exactly_match_move_line', 'by_products', 'by_packages'); default: 'exactly_match_move_line'. |
 | u_drop_location_preprocess  | boolean | Selects if suggestions u_drop_location_policy should be added on assignment. If this is set will apply the u_drop_location_policy and the first location is set as location_dest_id for the set of move_lines. This can only be used with polcies decorated with allow_preprocess, usage on other polcies will result in an ValidationError.|
 | u_display_summary          | string  | How to display the Source Document and a summary of all Package Names associated with that Source Document number at Goods-Out (enum: 'none', 'list', 'list_contents'). |
-| u_handle_partials          | boolean | If the picking type is allowed to handle partially available pickings. If True, then pickings of this type will report their u_pending value. |
+| u_handle_partials          | boolean | If the picking type is allowed to handle partially available pickings. If True, then pickings of this type will report their u_pending value. If False, prevents the state of a picking to be ready until the previous pickings are resolved.|
 | u_create_procurement_group | boolean | Indicate if a procurement group should be created on confirmation of the picking if one does not already exist. |
 
 More on the enumeration fields below.


### PR DESCRIPTION
The state of a picking with partially available moves is going to
be 'waiting' or 'confirmed' instead of 'assigned' when the
value of u_handle_partials of its picking type is False, because
it means that the picking cannot be worked with until it is fully
assigned.

Issue: 2502
Signed-off-by: Miquel PS <miquel.palahi.sitges@unipart.io>