### PR TITLE
[FIX] udes_stock: Fix new_picking_for_group()

### DIFF
--- a/addons/udes_stock/models/stock_picking.py
+++ b/addons/udes_stock/models/stock_picking.py
@@ -1313,6 +1313,8 @@ class StockPicking(models.Model):
             # origin with value 'ASN002', picking.origin is set to False.
             for field, value in kwargs.items():
                 current_value = getattr(picking, field, None)
+                if isinstance(current_value, models.BaseModel):
+                    current_value = current_value.id
                 if current_value and current_value != value:
                     setattr(picking, field, False)
 

--- a/addons/udes_stock/tests/common.py
+++ b/addons/udes_stock/tests/common.py
@@ -511,3 +511,10 @@ class BaseUDES(common.SavepointCase):
     def create_category(cls, **kwargs):
         ProductCategory = cls.env['product.category']
         return ProductCategory.create(kwargs)
+
+    @classmethod
+    def create_partner(cls, name, **kwargs):
+        Partner = cls.env['res.partner']
+        vals = {'name': name}
+        vals.update(kwargs)
+        return Partner.create(vals)


### PR DESCRIPTION
In some cases the function was returning a log error like:
Comparing oranges and apples.
The issue was that when there is already an existing picking that
matches for the given group, some fields are checked to see if
their current value is consistent with the new one to update.
If it is not then the value of the picking is set to False to avoid
misleading information. When this happens the values sometimes are
the id of the res.partner, or another recordset. In that case we
were ending up comparing a recordset with an integer.
Fixed to get the id of the recordset instead.

Signed-off-by: Miquel PS <miquel.palahi.sitges@unipart.io>