### PR TITLE
[FIX] udes_stock: Check entire packages after refactoring moves

### DIFF
--- a/addons/udes_stock/models/stock_picking.py
+++ b/addons/udes_stock/models/stock_picking.py
@@ -1324,6 +1324,10 @@ class StockPicking(models.Model):
         mls = moves.mapped('move_line_ids')
         if mls:
             mls.write({'picking_id': picking.id})
+            # After moving move lines check entire packages again just in case
+            # some of the move lines are completing packages
+            if picking.state != 'done':
+                picking._check_entire_pack()
 
         return picking
 


### PR DESCRIPTION
This solves the issue where some move lines were losing the result
parent package when they were coming from different pickings and
refactored into one.

Issue: 2606
Signed-off-by: Miquel PS <miquel.palahi.sitges@unipart.io>