### PR TITLE
[IMP] udes_security: Enabling auth_brute_force module with settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN unzip -q -d /opt /opt/odoo-blocked-locations.zip ; \
           /opt/odoo-print-HEAD/addons/* \
           /opt/odoo-edi-HEAD/addons/* \
           /opt/server-auth-HEAD/password_security \
+          /opt/server-auth-HEAD/auth_brute_force \
           /opt/odoo/addons/
 
 # Add modules

--- a/addons/udes_security/__init__.py
+++ b/addons/udes_security/__init__.py
@@ -1,3 +1,4 @@
 """UDES security enhancements"""
 
 from . import controllers
+from . import models

--- a/addons/udes_security/__manifest__.py
+++ b/addons/udes_security/__manifest__.py
@@ -10,6 +10,10 @@ Security enhancements used by UDES
     'depends': [
         'web',
         'password_security',
+        'auth_brute_force',
     ],
     'category': "Authentication",
+    'data': [
+        'data/auth_brute_force.xml',
+    ]
 }

--- a/addons/udes_security/data/auth_brute_force.xml
+++ b/addons/udes_security/data/auth_brute_force.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+
+<odoo>
+
+  <!-- Auth brute force config -->
+  <record id="per_ip_attempts" model="ir.config_parameter">
+    <field name="key">auth_brute_force.max_by_ip</field>
+    <field name="value" eval="1000"/>
+  </record>
+
+  <record id="per_user_attempts" model="ir.config_parameter">
+    <field name="key">auth_brute_force.max_by_ip_user</field>
+    <field name="value" eval="15"/>
+  </record>
+
+  <!-- Disable remote api checks -->
+  <record id="remote_ip_api" model="ir.config_parameter">
+    <field name="key">auth_brute_force.check_remote</field>
+    <field name="value" eval="0" />
+  </record>
+
+  <!-- Disable per IP checks -->
+  <record id="check_by_ip" model="ir.config_parameter">
+    <field name="key">auth_brute_force.check_by_ip</field>
+    <field name="value" eval="0"/>
+  </record>
+
+</odoo>

--- a/addons/udes_security/models/__init__.py
+++ b/addons/udes_security/models/__init__.py
@@ -1,0 +1,1 @@
+from . import res_authentication_attempt

--- a/addons/udes_security/models/res_authentication_attempt.py
+++ b/addons/udes_security/models/res_authentication_attempt.py
@@ -1,0 +1,16 @@
+from odoo import api, models
+
+
+class ResAuthenticationAttempt(models.Model):
+    _inherit = 'res.authentication.attempt'
+    _name = 'res.authentication.attempt'
+
+    @api.model
+    def _hits_limit(self, limit, remote, login=None, *args, **kwargs):
+        """ Override _hits_limit method to ignore non-user specific IP bans
+         if configured to """
+        check_by_ip = int(self.env["ir.config_parameter"].sudo()
+                          .get_param("auth_brute_force.check_by_ip", 0))
+        if not login and check_by_ip == 0:
+            return False
+        return super()._hits_limit(limit, remote, login, *args, **kwargs)


### PR DESCRIPTION
Adding auth_brute_force (from server_auth) module as a udes_security
dependency. Adding default configs for the modules inbuilt settings
and adding an additional setting to allow us to disable the global
IP ban for all users - allowing this to be used with Odoo when
x_forwarded_for headers are not available when behind a proxy.