### PR TITLE
[FIX] udes_sale_stock: Bypass PII view logging for the superuser

### DIFF
--- a/addons/udes_sale_stock/models/partner_pii.py
+++ b/addons/udes_sale_stock/models/partner_pii.py
@@ -19,7 +19,10 @@ PII_RELATIONS = [
 @api.model
 def _read(self, result):
     """Redact fields based on res.user.u_view_customers"""
-    if self.env.uid == SUPERUSER_ID or self.env.user.u_view_customers:
+    if self._uid == SUPERUSER_ID:
+        return result
+
+    if self.env.user.u_view_customers:
         for record in result:
             for field in record:
                 if (field in PII_RELATIONS
@@ -55,8 +58,10 @@ class ResPartner(models.Model):
            still need to redact data retrieved via joined queries
         """
         result = super(ResPartner, self).name_get()
+        if self._uid == SUPERUSER_ID:
+            return result
 
-        if self.env.uid == SUPERUSER_ID or self.env.user.u_view_customers:
+        if self.env.user.u_view_customers:
             for record in result:
                 if (isinstance(record, tuple)
                         and self.sudo().search_count([('id', '=', record[0]),


### PR DESCRIPTION
Logging PII accesses for the superuser adds substantial amounts of log
noise and increase the time (and therefore cost) required to diagnose
almost any problem.

The superuser may be assumed to have full access to the system,
including the ability to tamper with the log files.  In addition,
security policy dictates that administrators log in as individual
accounts with administrative permissions, rather than logging in as
the superuser account.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>