### PR TITLE
[FIX] udes_stock: Do not attempt to cancel empty pickings

### DIFF
--- a/addons/udes_stock/models/stock_move.py
+++ b/addons/udes_stock/models/stock_move.py
@@ -424,14 +424,10 @@ class StockMove(models.Model):
 
             Picking._new_picking_for_group(key, move_group, **values)
 
+        # Deactivate any empty picks
         empty_picks = pickings.filtered(lambda p: len(p.move_lines) == 0)
         if empty_picks:
-            _logger.info(_("Cancelling empty picks after splitting."))
-            # action_cancel does not cancel a picking with no moves.
-            empty_picks.write({
-                'state': 'cancel',
-                'is_locked': True
-            })
+            empty_picks.write({'active': False})
 
         return self
 
@@ -489,13 +485,9 @@ class StockMove(models.Model):
             Picking._new_picking_for_group(key, group_moves, **values)
             result_moves |= group_moves
 
+        # Deactivate any empty picks
         empty_picks = pickings.filtered(lambda p: len(p.move_lines) == 0)
         if empty_picks:
-            _logger.info(_("Cancelling empty picks after splitting."))
-            # action_cancel does not cancel a picking with no moves.
-            empty_picks.write({
-                'state': 'cancel',
-                'is_locked': True
-            })
+            empty_picks.write({'active': False})
 
         return result_moves

--- a/addons/udes_stock/tests/test_splitting.py
+++ b/addons/udes_stock/tests/test_splitting.py
@@ -64,7 +64,7 @@ class TestAssignSplitting(common.BaseUDES):
         self.assertEqual(banana_ml.result_package_id, banana_pallet)
         self.assertEqual(banana_ml.product_id, self.banana)
 
-        self.assertFalse(self.picking.exists())
+        self.assertFalse(self.picking.active)
 
     def test02_split_move(self):
         """Reserve self.picking with two pallet of the same product and check it
@@ -108,7 +108,7 @@ class TestAssignSplitting(common.BaseUDES):
         self.assertEqual(p2_ml.result_package_id, cherry_pallet2)
         self.assertEqual(p2_ml.product_id, self.cherry)
 
-        self.assertFalse(self.picking.exists())
+        self.assertFalse(self.picking.active)
 
     def test03_two_products_in_pallet(self):
         """Reserve self.picking with a pallet containing two different products
@@ -146,7 +146,7 @@ class TestAssignSplitting(common.BaseUDES):
         self.assertEqual(grape_ml.package_id, mixed_pallet)
         self.assertEqual(grape_ml.result_package_id, mixed_pallet)
 
-        self.assertFalse(self.picking.exists())
+        self.assertFalse(self.picking.active)
 
     def test04_combine_two_pickings_at_reserve(self):
         """Create two pickings for two items on the same pallet. Reserve them
@@ -183,7 +183,7 @@ class TestAssignSplitting(common.BaseUDES):
         self.assertEqual(ml2.package_id, pallet)
         self.assertEqual(ml2.product_id, self.elderberry)
 
-        self.assertFalse(self.picking.exists())
+        self.assertFalse(self.picking.active)
 
     def test05_add_to_existing_picking(self):
         """Create two pickings for two items on the same pallet. Reserve them
@@ -221,7 +221,7 @@ class TestAssignSplitting(common.BaseUDES):
         self.assertEqual(ml2.package_id, pallet)
         self.assertEqual(ml2.product_id, self.elderberry)
 
-        self.assertFalse(self.picking.exists())
+        self.assertFalse(self.picking.active)
 
     def test06_persist_locations(self):
         """Reserve when the locations of the picking are not the defaults of

--- a/addons/udes_stock/wizard/refactor_views.py
+++ b/addons/udes_stock/wizard/refactor_views.py
@@ -20,7 +20,6 @@ class RefactorStockPicking(models.TransientModel):
 
         pickings = Picking.browse(picking_ids)
         res = pickings.mapped('move_lines')._action_refactor()
-        pickings.unlink_empty()
         return res
 
 
@@ -40,7 +39,6 @@ class RefactorStockMove(models.TransientModel):
 
         moves = Move.browse(move_ids)
         res = moves._action_refactor()
-        self.mapped('picking_id').unlink_empty()
         return res
 
 class RefactorStockPickingBatch(models.TransientModel):
@@ -59,5 +57,4 @@ class RefactorStockPickingBatch(models.TransientModel):
 
         batches = Batch.browse(batch_ids)
         res = batches.mapped('picking_ids.move_lines')._action_refactor()
-        batches.mapped('picking_ids').unlink_empty()
         return res        


### PR DESCRIPTION
Pick factorisation may result in some empty pickings.  The current
code attempts to cancel these by directly writing the "state" field to
the value "cancel", with a comment noting that action_cancel() does
not work on a picking with no associated stock moves.

The reason that action_cancel() does not work on a picking with no
associated stock moves is that the "state" field is a readonly field
computed from the associated stock move lines.  A picking with no
associated stock move lines is, by definition, in state "draft".

The current code seems to succeed in setting the state to "cancel" due
only to the permissiveness of the ORM, which (for performance reasons)
generally trusts code not to attempt undefined operations such as
writing to a non-invertible but stored computed field.

Fix by deleting any empty pickings, since there is no valid way for a
picking with no moves to exist in a cancelled state.

Deletions are performed via sudo() since most users will not have
permission to delete pickings.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>