### PR TITLE
[FIX] udes_stock: Do not attempt to cancel empty pickings

### DIFF
--- a/addons/udes_stock/models/stock_move.py
+++ b/addons/udes_stock/models/stock_move.py
@@ -429,7 +429,7 @@ class StockMove(models.Model):
             _logger.info(_("Cancelling empty picks after splitting."))
             # action_cancel does not cancel a picking with no moves.
             empty_picks.write({
-                'state': 'cancel',
+                'active': False,
                 'is_locked': True
             })
 
@@ -494,7 +494,7 @@ class StockMove(models.Model):
             _logger.info(_("Cancelling empty picks after splitting."))
             # action_cancel does not cancel a picking with no moves.
             empty_picks.write({
-                'state': 'cancel',
+                'active': False,
                 'is_locked': True
             })
 

--- a/addons/udes_stock/models/stock_picking.py
+++ b/addons/udes_stock/models/stock_picking.py
@@ -40,6 +40,7 @@ class StockPicking(models.Model):
 
     priority = fields.Selection(selection=common.PRIORITIES)
     sequence = fields.Integer("Sequence", default=0)
+    active = fields.Boolean("Active", default=True)
 
     # compute previous and next pickings
     u_prev_picking_ids = fields.One2many(
@@ -1107,7 +1108,7 @@ class StockPicking(models.Model):
         """
         self.filtered(lambda p:
                       (len(p.move_lines) == 0
-                       and p.state == 'cancel'
+                       and not p.active
                        and p.is_locked)).unlink()
         return self.exists()
 


### PR DESCRIPTION
Pick factorisation may result in some empty pickings.  The current
code attempts to cancel these by directly writing the "state" field to
the value "cancel", with a comment noting that action_cancel() does
not work on a picking with no associated stock moves.

The reason that action_cancel() does not work on a picking with no
associated stock moves is that the "state" field is a readonly field
computed from the associated stock move lines.  A picking with no
associated stock move lines is, by definition, in state "draft".

The current code seems to succeed in setting the state to "cancel" due
only to the permissiveness of the ORM, which (for performance reasons)
generally trusts code not to attempt undefined operations such as
writing to a non-invertible but stored computed field.

Fix by adding an "active" field to stock.picking and deactivating
empty pickings instead of cancelling them, since there is no valid way
for a picking with no moves to exist in a cancelled state.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>