### PR TITLE
[FIX] udes_report: fix typo in scheduled action title

### DIFF
--- a/addons/udes_report/data/stock_email.xml
+++ b/addons/udes_report/data/stock_email.xml
@@ -5,7 +5,7 @@
     <record id="outbound_main_server" model="ir.mail_server">
       <field name="name">Unipart Digital mail server</field>
       <field name="sequence" eval="1"/>
-      <field name="smtp_host">localhost</field> 
+      <field name="smtp_host">localhost</field>
       <field name="smtp_port" eval="25"/>
     </record>
 
@@ -28,14 +28,14 @@
 
     <!-- Cronjob for sending stock file-->
     <record id="send_stock_file_cron_action" model="ir.cron">
-      <field name="name">Send Sock File</field>
+      <field name="name">Send Stock File</field>
       <field name="active" eval="True"/>
       <field name="user_id" ref="base.user_root" />
       <field name="interval_number">1</field>
       <field name="interval_type">days</field>
       <field name="numbercall">-1</field>
       <field name="doall">0</field>
-      <field name="model_id" ref="model_udes_report_stock_export" /> 
+      <field name="model_id" ref="model_udes_report_stock_export" />
       <field name="state">code</field>
       <field name="code">model.send_automated_stock_file()</field>
     </record>


### PR DESCRIPTION
'stock' instead of 'sock'