### PR TITLE
[FIX] udes_sale_stock: Set sale_line is_cancelled on picking.action_cancel

### DIFF
--- a/addons/udes_sale_stock/models/sale_order_line.py
+++ b/addons/udes_sale_stock/models/sale_order_line.py
@@ -8,40 +8,11 @@ from odoo import api, models, fields
 class SaleOrderLine(models.Model):
     _inherit = 'sale.order.line'
 
-    is_cancelled = fields.Boolean(string='Cancelled', readonly=True, store=True,
-                                  default=False, index=True,
-                                  compute='_compute_is_cancelled')
+    is_cancelled = fields.Boolean(string='Cancelled', readonly=True,
+                                  default=False, index=True)
     cancel_date = fields.Datetime(string='Cancel Date',
                                   help='Time of cancellation',
                                   readonly=True, index=True)
-
-    @api.depends('move_ids.state')
-    def _compute_is_cancelled(self):
-        location_customers = self.env.ref('stock.stock_location_customers')
-        now_date = datetime.now()
-
-        def not_cancelled_filter(m):
-            return m.state not in ['cancel'] \
-                   and m.location_dest_id == location_customers
-
-        for line in self.filtered(lambda l: not l.is_cancelled):
-            if not line.move_ids:
-                line.is_cancelled = False
-                continue
-
-            # The sale order line will be flagged as cancelled based
-            # on whether it has finalized moves that were not cancelled
-            not_cancelled_moves = line.move_ids.filtered(not_cancelled_filter)
-            line.is_cancelled = len(not_cancelled_moves) == 0
-
-            if line.is_cancelled:
-                line.write({'cancel_date': fields.Datetime.to_string(now_date)})
-
-    @api.onchange('is_cancelled')
-    @api.constrains('is_cancelled')
-    def compute_order_state(self):
-        for order, lines in self.groupby('order_id'):
-            order.check_state_cancelled()
 
     def _prepare_procurement_values(self, group_id=False):
         values = super()._prepare_procurement_values(group_id)

--- a/addons/udes_sale_stock/models/stock_move.py
+++ b/addons/udes_sale_stock/models/stock_move.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from odoo import api, fields, models
+from datetime import datetime
 
 import logging
 _logger = logging.getLogger(__name__)
@@ -16,10 +17,26 @@ class StockMove(models.Model):
         return result
 
     def _action_cancel(self):
+
+        location_customers = self.env.ref('stock.stock_location_customers')
+        now_date = datetime.now()
+
         from_sale = self.env.context.get('from_sale', False)
         result = True
         if not from_sale:
             result = super(StockMove, self)._action_cancel()
             self.mapped('sale_line_id.order_id').check_delivered()
+
+        def not_cancelled_filter(m):
+            return m.state not in ['cancel'] \
+                   and m.location_dest_id == location_customers
+
+        lines_to_cancel = self.filtered(
+            lambda m: m.location_dest_id == location_customers) \
+            .mapped('sale_line_id').filtered(
+            lambda s: len(s.move_ids.filtered(not_cancelled_filter)) == 0)
+        lines_to_cancel.write({'is_cancelled': True,
+                               'cancel_date': fields.Datetime.to_string(now_date)})
+        lines_to_cancel.mapped('order_id').check_state_cancelled()
 
         return result


### PR DESCRIPTION
Using api onchange is inefficient, it will calcualte for every state
change. Set this only when cancelling the final picking.