### PR TITLE
[IMP] udes_stock: Improve evaluation speed of move/move_line access rules

### DIFF
--- a/addons/udes_stock/security/udes_stock_security.xml
+++ b/addons/udes_stock/security/udes_stock_security.xml
@@ -28,8 +28,7 @@
                    search="[('model','=','stock.move')]"
                    model="ir.model"/>
             <field name="global" eval="True"/>
-            <field name="domain_force">['|', ('picking_type_id','in',user.u_picking_type_ids.ids),
-                                             ('picking_type_id', '=', False)]</field>
+            <field name="domain_force">[('picking_type_id', 'in', user.u_picking_type_ids.ids + [False])]</field>
         </record>
         <record model="ir.rule" id="users_stock_move_line_rule">
             <field name="name">users_stock_move_line_rule</field>
@@ -37,8 +36,7 @@
                    search="[('model','=','stock.move.line')]"
                    model="ir.model"/>
             <field name="global" eval="True"/>
-            <field name="domain_force">['|', ('move_id.picking_type_id','in',user.u_picking_type_ids.ids),
-                                             ('move_id.picking_type_id', '=', False)]</field>
+            <field name="domain_force">[('u_picking_type_id', 'in', user.u_picking_type_ids.ids + [False])]</field>
         </record>
 
         <!-- Define default security groups -->


### PR DESCRIPTION

The improvements come because of two changes:
The first is removing the or branch in the domain a db query is removed.
The second is done by storing the picking type directly on the move_line
which removes an unbound query on the moves.
Credit goes Miquel who came up with the fix.

Signed-off-by: Michele Costa <michele.costa@unipart.io>