### PR TITLE
[FIX] udes_stock: remove forced recompute of u_grouping_key

### DIFF
--- a/addons/udes_stock/models/stock_move.py
+++ b/addons/udes_stock/models/stock_move.py
@@ -69,10 +69,6 @@ class StockMove(models.Model):
         # this with the equivalent for move_line_key
         # we need to think of how we want to do it
 
-        # The environment must include {'compute_key': True}
-        # to allow the keys to be computed.
-        if not self.env.context.get('compute_key', False):
-            return
         for move in self:
             move_vals = {
                 fname: getattr(move, fname)
@@ -368,8 +364,7 @@ class StockMove(models.Model):
             raise UserError(_("Cannot group moves when their picking type"
                               "has no grouping key set."))
 
-        # force recompute on u_grouping_key so we have an up-to-date key:
-        return self.with_context(compute_key=True).groupby(lambda ml: ml.u_grouping_key)
+        return self.groupby(lambda ml: ml.u_grouping_key)
 
     def _prepare_extra_info_for_new_picking_for_group(self, pickings, moves):
         """ Given the group of moves to refactor and its related pickings,

--- a/addons/udes_stock/models/stock_move_line.py
+++ b/addons/udes_stock/models/stock_move_line.py
@@ -764,10 +764,6 @@ class StockMoveLine(models.Model):
         return task
 
     def compute_grouping_key(self):
-        # The environment must include {'compute_key': True}
-        # to allow the keys to be computed.
-        if not self.env.context.get('compute_key', False):
-            return
         for ml in self:
             ml_vals = {
                 fname: getattr(ml, fname)
@@ -791,7 +787,7 @@ class StockMoveLine(models.Model):
         by_key = lambda ml: ml.u_grouping_key
         return {k: self.browse([ml.id for ml in g])
                 for k, g in
-                groupby(sorted(self.with_context(compute_key=True), key=by_key),
+                groupby(sorted(self, key=by_key),
                         key=by_key)}
 
     def write(self, values):


### PR DESCRIPTION
We shouldn't need to recompute the grouping key every time.

Task: 3541
User-story: 3539

Signed-off-by: Samuel Searles-Bryant <samuel.searles-bryant@unipart.io>

Taiga: https://taiga.udes.io/project/udescore/task/3541