### PR TITLE
[FIX] udes_stock: Fix package reservation for multiple pickings

### DIFF
--- a/addons/udes_stock/models/stock_picking.py
+++ b/addons/udes_stock/models/stock_picking.py
@@ -1143,9 +1143,9 @@ class StockPicking(models.Model):
                     remaining_qtys = defaultdict(int)
 
                     # get all packages
-                    packages = self.mapped('move_line_ids.package_id')
+                    packages = picking.mapped('move_line_ids.package_id')
                     for package in packages:
-                        move_lines = self.mapped('move_line_ids').filtered(lambda ml: ml.package_id == package)
+                        move_lines = picking.mapped('move_line_ids').filtered(lambda ml: ml.package_id == package)
                         # TODO: merge with assert_reserved_full_package
                         pack_products = frozenset(package._get_all_products_quantities().items())
                         mls_products = frozenset(move_lines._get_all_products_quantities().items())


### PR DESCRIPTION
Fix a bug when action_assign is called on more than one picking
at a time, with package reservation turned on.
The bug was caused by erroneous use of self while in a loop over
the records in self, causing all packages in all pickings in self
to have to be in the current item of the loop.

This fixes the issue and adds a unit test.

Story: 3453

Signed-off-by: Charlie Wheeler-Robinson <crwr@pigotts.org.uk>