### PR TITLE
[FIX] udes_stock, udes_sale_stock: Correct dependency and config

### DIFF
--- a/addons/udes_sale_stock/__manifest__.py
+++ b/addons/udes_sale_stock/__manifest__.py
@@ -18,6 +18,7 @@
     'data': [
         'security/ir.model.access.csv',
         'security/udes_sale_stock_security.xml',
+        'data/stock_config.xml',
         'views/sale_order_views.xml',
         'views/res_users_views.xml',
         'views/res_groups_views.xml',

--- a/addons/udes_sale_stock/data/stock_config.xml
+++ b/addons/udes_sale_stock/data/stock_config.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<odoo>
+  <data>
+
+    <!-- Apply default configuration settings -->
+    <record id="settings_stock_config" model="res.config.settings">
+      <!-- Enable order-specific routes -->
+      <field name="group_route_so_lines" eval="1"/>
+    </record>
+
+    <function model="res.config.settings" name="execute">
+      <value eval="[ref('settings_stock_config')]"/>
+    </function>
+
+  </data>
+</odoo>

--- a/addons/udes_stock/__manifest__.py
+++ b/addons/udes_stock/__manifest__.py
@@ -7,7 +7,6 @@
     'summary': 'Inventory, Logistics, Warehousing',
     'description': "Holds core functionality for UDES Modules",
     'depends': [
-        'sale_stock',
         'stock',
         'stock_picking_batch',
         'blocked_locations',

--- a/addons/udes_stock/data/stock_config.xml
+++ b/addons/udes_stock/data/stock_config.xml
@@ -11,8 +11,6 @@
     <record id="settings_stock_config" model="res.config.settings">
       <!-- Enable using packages -->
       <field name="group_stock_tracking_lot" eval="1"/>
-      <!-- Enable order-specific routes -->
-      <field name="group_route_so_lines" eval="1"/>
       <!-- Enable picking batches -->
       <field name="module_stock_picking_batch" eval="1"/>
 


### PR DESCRIPTION
udes_stock had an incorrect dependency on sale_stock, in order
to set a config option. This was incorrect and causes 15 extra
modules to be installed on the mvp system, significantly increasing
risk and cost of maintainance.

This change moves the dependency and config into the udes_sale_stock
module, which houses our other work that depends on sale_stock.

Story: 3390

Signed-off-by: Charlie Wheeler-Robinson <crwr@pigotts.org.uk>