### PR TITLE
[FIX] udes_sale_stock: depend on sale_order_dates

### DIFF
--- a/addons/udes_sale_stock/__manifest__.py
+++ b/addons/udes_sale_stock/__manifest__.py
@@ -8,6 +8,7 @@
     'description': "Extension of sale_stock model for UDES",
     'depends': [
         'edi_sale',
+        'sale_order_dates',
         'sale_stock',
         'udes_stock',
     ],


### PR DESCRIPTION
`udes_sale_stock` defines a `SaleOrder._order` attribute that references a
field defined in `sale_order_dates`, so `udes_sale_stock` needs to depend on
this module.

User-story: 3621
Task: 3622

Signed-off-by: Samuel Searles-Bryant <samuel.searles-bryant@unipart.io>