### PR TITLE
[IMP] udes_sale_stock: Add ability to cancel unfulfillable sale orders

### DIFF
--- a/addons/udes_sale_stock/models/sale_order.py
+++ b/addons/udes_sale_stock/models/sale_order.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 
+from collections import defaultdict
 from odoo import api, fields, models
 from odoo.addons.udes_stock.models import common
+import logging
+
+_logger = logging.getLogger(__name__)
+
 
 class SaleOrder(models.Model):
     _inherit = "sale.order"
@@ -40,6 +45,94 @@ class SaleOrder(models.Model):
                 'priority': order.priority
             })
 
+    @api.model
+    def get_available_stock_locations(self):
+        """ Method returns stock locations that are considered (along with
+         their children) stock available for fulfilling orders. Should be
+        overridden where necessary """
+        return self.env.ref('stock.stock_location_stock')
+
+    @api.model
+    def get_available_quantity(self, product, locations):
+        """ Get available quantity of product_id within locations """
+        Stock = self.env['stock.quant']
+        domain = [('product_id', '=', product.id),
+                  ('location_id', 'child_of', locations.ids)]
+        quants = Stock.search(domain)
+        available_quantity = sum(quants.mapped('quantity')) - \
+                             sum(quants.mapped('reserved_quantity'))
+        return available_quantity
+
+    @api.model
+    def cancel_orders_without_availability(self):
+        """ From the current list of unconfirmed SO lines, cancel lines that
+        cannot be fulfilled with current stock holding """
+        OrderLine = self.env['sale.order.line']
+        Order = self.env['sale.order']
+
+        # Get order lines
+        orders = Order.search([('state', 'in', ['sale', 'draft'])])
+
+        # Get unreserved stock for each product in locations
+        locations = self.get_available_stock_locations()
+        stock = defaultdict(int)
+        for product in orders.mapped('order_line.product_id'):
+                stock[product] = stock[product] + \
+                             self.get_available_quantity(product, locations)
+
+        # Create empty record sets for SO lines
+        can_fulfill = OrderLine.browse()
+        cant_fulfill = OrderLine.browse()
+
+        for r, batch in orders.batched(100):
+            # Cache stuff
+            batch.mapped('order_line')
+            batch.mapped('order_line.move_ids')
+
+            for order in batch:
+                # Loop SO lines and deduct from stock dict, add order lines to
+                # can or cant fulfill record sets
+                for line in order.order_line.filtered(lambda x:
+                                                      not x.is_cancelled):
+
+                    # If any of the mls are done or assigned then skip this line
+                    line_states = line.mapped('move_ids.state')
+                    skip_states = ('assigned', 'done', 'cancel')
+                    if any(x in line_states for x in skip_states):
+                        continue
+
+                    product = line.product_id
+                    qty_ordered = line.product_uom_qty
+                    if stock[product] >= qty_ordered:
+                        can_fulfill |= line
+                        stock[product] = stock[product]-qty_ordered
+                    else:
+                        cant_fulfill |= line
+
+        if cant_fulfill:
+            # Cancel these lines
+            with self.statistics() as stats:
+                cant_fulfill.action_cancel()
+                cant_fulfill.write({'is_cancelled_due_shortage': True})
+
+            _logger.info(
+                "Sale lines on orders %s cancelled in %.2fs, %d queries, due to"
+                " stock shortage,",
+                ', '.join(cant_fulfill.mapped('order_id.name')),
+                stats.elapsed,
+                stats.count
+            )
+
+            cancelled_sales = cant_fulfill.mapped('order_id') \
+                .filtered(lambda x: x.state == 'cancel')
+            if cancelled_sales:
+                _logger.info(
+                    "Sales %s cancelling due to missing stock",
+                    ', '.join(cancelled_sales.mapped('name'))
+                )
+
+        return cant_fulfill
+
     def check_delivered(self):
         """ Update sale orders state based on the states of their related
             pickings.
@@ -58,13 +151,46 @@ class SaleOrder(models.Model):
 
     def action_cancel(self):
         """Override to cancel by moves instead of by pickings"""
-        self.mapped('order_line.move_ids')._action_cancel()
+        self.mapped('order_line').action_cancel()
         return self.write({'state': 'cancel'})
 
     def check_state_cancelled(self):
+        to_cancel = self.browse()
         for order in self.filtered(
-                lambda o: o.state not in ['done', 'cancel', 'draft']):
+                lambda o: o.state not in ['done', 'cancel']):
             non_cancelled = order.order_line.filtered(
                 lambda l: not l.is_cancelled)
             if len(non_cancelled) == 0:
-                order.state = 'cancel'
+                to_cancel |= order
+        to_cancel.write({'state': 'cancel'})
+
+
+class SaleOrderCancelWizard(models.TransientModel):
+    """ This only exists to allow a confirm dialogue from a menu item """
+    _name = "sale.order.cancel.wizard"
+    result = fields.Char('Result')
+
+    def cancel_unfulfillable_sales(self):
+        with self.statistics() as stats:
+            lines = self.env['sale.order'].cancel_orders_without_availability()
+
+        if lines:
+            message = "%s sale lines on %s orders cancelled in %.2fs" %\
+                      (len(lines),
+                       len(lines.mapped('order_id')),
+                       stats.elapsed)
+        else:
+            message = "No orders cancelled"
+
+        self.result = message
+        template = self.env.ref('udes_sale_stock.view_cancellation_result')
+        return {
+            'name': 'Cancellation Result',
+            'res_model': 'sale.order.cancel.wizard',
+            'type': 'ir.actions.act_window',
+            'view_type': 'form',
+            'view_mode': 'form',
+            'target': 'new',
+            'res_id': self.id,
+            'view_id': template.id
+        }

--- a/addons/udes_sale_stock/models/stock_move.py
+++ b/addons/udes_sale_stock/models/stock_move.py
@@ -17,10 +17,7 @@ class StockMove(models.Model):
         return result
 
     def _action_cancel(self):
-
         location_customers = self.env.ref('stock.stock_location_customers')
-        now_date = datetime.now()
-
         from_sale = self.env.context.get('from_sale', False)
         result = True
         if not from_sale:
@@ -35,8 +32,7 @@ class StockMove(models.Model):
             lambda m: m.location_dest_id == location_customers) \
             .mapped('sale_line_id').filtered(
             lambda s: len(s.move_ids.filtered(not_cancelled_filter)) == 0)
-        lines_to_cancel.write({'is_cancelled': True,
-                               'cancel_date': fields.Datetime.to_string(now_date)})
-        lines_to_cancel.mapped('order_id').check_state_cancelled()
+        if lines_to_cancel:
+            lines_to_cancel.action_cancel()
 
         return result

--- a/addons/udes_sale_stock/views/sale_order_views.xml
+++ b/addons/udes_sale_stock/views/sale_order_views.xml
@@ -57,5 +57,59 @@
       </field>
     </record>
 
+    <!-- cancel orders without stock -->
+    <record id="cancel_orders_without_availability" model="ir.actions.server">
+      <field name="name">cancel_orders_without_availability</field>
+      <field name="type">ir.actions.server</field>
+      <field name="model_id" ref="model_sale_order" />
+      <field name="state">code</field>
+        <field name="code">
+          model.cancel_orders_without_availability()
+        </field>
+    </record>
+
+    <record id="view_cancel_orders_without_availability" model="ir.ui.view">
+      <field name="name">view_cancel_orders_without_availability</field>
+      <field name="model">sale.order</field>
+      <field name="arch" type="xml">
+        <form string="Cancel Lines">
+          <separator string="Cancel order lines without available stock?"/>
+          <footer>
+            <button type="object"
+                    name="cancel_unfulfillable_sales"
+                    string="Yes" class="btn-primary"/>
+            <button string="No" class="btn-default" special="cancel"/>
+          </footer>
+        </form>
+      </field>
+    </record>
+
+    <record id="confirm_cancel_orders_without_availability" model="ir.actions.act_window">
+      <field name="name">Cancel Unfulfillable Lines</field>
+      <field name="type">ir.actions.act_window</field>
+      <field name="res_model">sale.order.cancel.wizard</field>
+      <field name="view_mode">form</field>
+      <field name="view_id" ref="view_cancel_orders_without_availability" />
+      <field name="target">new</field>
+    </record>
+
+    <menuitem id="menu_cancel_orders_without_availability"
+      action="confirm_cancel_orders_without_availability"
+      parent="sale.sale_order_menu"
+      sequence="99" groups="sales_team.group_sale_salesman"/>
+
+    <record id="view_cancellation_result" model="ir.ui.view">
+      <field name="name">view_cancellation_result</field>
+      <field name="model">sale.order.cancel.wizard</field>
+      <field name="arch" type="xml">
+        <form string="Cancel Lines">
+          <field name="result" readonly="1" />
+          <footer>
+            <button string="Close" class="btn-primary" special="cancel"/>
+          </footer>
+        </form>
+      </field>
+    </record>
+
   </data>
 </odoo>


### PR DESCRIPTION
Added a method to cancel unfulfillable sale orders, logic will search
sale orders that need fulfilling and compare with stock availability,
cancelling orders that current stock holding is not enough for.