### PR TITLE
[IMP] udes_stock: Revise stock.picking.u_location_category_id dependency

### DIFF
--- a/addons/udes_stock/models/stock_picking.py
+++ b/addons/udes_stock/models/stock_picking.py
@@ -115,8 +115,7 @@ class StockPicking(models.Model):
     )
 
     @api.depends('move_line_ids',
-                 'move_line_ids.location_id',
-                 'move_line_ids.location_id.u_location_category_id')
+                 'move_line_ids.location_id')
     @api.one
     def _compute_location_category(self):
         """ Compute location category from move lines"""

--- a/addons/udes_stock/tests/test_location_category.py
+++ b/addons/udes_stock/tests/test_location_category.py
@@ -87,11 +87,18 @@ class TestLocationCategory(common.BaseUDES):
 
         batch.unlink()
 
-        # changing the category of the location is propagated to the pick
+        # changing the category of the location does not propagate to the pick
         self.test_location_01.u_location_category_id = self.location_category_super_high
-        # now ground_pick is super high pick
+        # now ground_pick is still ground pick
+        self.assertEqual(ground_pick.u_location_category_id,
+                         self.location_category_ground)
+        # unreserve and reserve again ground pick should update the category
+        # to super high pick
+        ground_pick.do_unreserve()
+        ground_pick.action_assign()
         self.assertEqual(ground_pick.u_location_category_id,
                          self.location_category_super_high)
+        # now ground_pick is super high pick
         super_high_pick = ground_pick
 
         # change user setting to high locations


### PR DESCRIPTION
Remove dependency to location.u_location_category_id from
stock.picking.u_location_category_id to avoid conflicts.
Once it is set, it only changes if the move_lines or their
locations change.
This prevents to update it when pickings are done or serialisation
erros because they are in use.
