### PR TITLE
[FIX] udes_stock: reservation popup shows in-stock products.

### DIFF
--- a/addons/udes_stock/models/stock_picking.py
+++ b/addons/udes_stock/models/stock_picking.py
@@ -1775,8 +1775,12 @@ class StockPicking(models.Model):
                     if unsatisfied:
                         if self:
                             # we need to construct our error message before the
-                            # changes are rolled back.
-                            moves = unsatisfied.mapped('move_lines')
+                            # changes are rolled back, and report only products
+                            # that are unreservable.
+                            not_done = lambda x: x.state not in (
+                                'done', 'assigned', 'cancelled')
+                            moves = (unsatisfied.mapped('move_lines')
+                                                .filtered(not_done))
                             products = moves.mapped('product_id.default_code')
                             picks = moves.mapped('picking_id.name')
                             fmt = ("Unable to reserve stock for products {} "


### PR DESCRIPTION
Story/3838
Task/3841

Signed-off-by: Kevin Dwyer <kevin.dwyer@unipart.io>

If an attempt to reserve stock for an individual picking fails, the
error message displayed to the user reports all products for the
picking, regardless of whether or not there is sufficient stock to
reserve each product.

This patch ensures only unreservable products are reported.