### PR TITLE
[ADD] used_stock (3598) more control over printing

### DIFF
--- a/addons/udes_stock/models/stock_move_line.py
+++ b/addons/udes_stock/models/stock_move_line.py
@@ -216,7 +216,8 @@ class StockMoveLine(models.Model):
             self.env.ref('udes_stock.picking_update_package').with_context(
                 active_model=picking._name,
                 active_ids=picking.ids,
-                print_records=result_package
+                print_records=result_package,
+                action_filter='move_lines.mark_as_done',
             ).run()
 
         if mls_done and picking is not None:
@@ -227,7 +228,8 @@ class StockMoveLine(models.Model):
             self.env.ref('udes_stock.picking_update_move_done').with_context(
                 active_model=picking._name,
                 active_ids=picking.ids,
-                print_records=print_mls
+                print_records=print_mls,
+                action_filter='move_lines.mark_as_done',
             ).run()
 
         return mls_done

--- a/addons/udes_stock/models/stock_picking.py
+++ b/addons/udes_stock/models/stock_picking.py
@@ -253,10 +253,16 @@ class StockPicking(models.Model):
         picks |= mls.mapped('picking_id.u_next_picking_ids')
         batches |= picks.mapped('batch_id')
         self._trigger_batch_state_recompute(batches=batches)
+        extra_context = {}
+
+        if hasattr(self, 'get_extra_printing_context'):
+            extra_context = picks.get_extra_printing_context()
 
         self.env.ref('udes_stock.picking_done').with_context(
             active_model=picks._name,
             active_ids=picks.ids,
+            action_filter='picking.action_done',
+            **extra_context
         ).run()
         self.unlink_empty()
         return res

--- a/addons/udes_stock/models/stock_picking_print_strategy.py
+++ b/addons/udes_stock/models/stock_picking_print_strategy.py
@@ -15,14 +15,23 @@ class PrintStrategy(models.Model):
         'stock.picking.type', string='Picking Type',
         required=True,
     )
+    action_filter = fields.Char(
+        'Action Filter',
+        readonly=True,
+        index=True
+    )
 
     @api.model
     def strategies(self, picking):
         '''Return print strategies for the picking type of `picking`.'''
         picking.ensure_one()
-        return self.search([
-            ('picking_type_id', '=', picking.picking_type_id.id),
-        ])
+        action_filter = self.env.context.get('action_filter')
+        domain = [('picking_type_id', '=', picking.picking_type_id.id)]
+
+        if action_filter is not None:
+            domain.append(('action_filter', '=', action_filter))
+
+        return self.search(domain)
 
     @api.multi
     def records(self, picking, context):

--- a/addons/udes_stock/views/stock_picking_print_strategy_views.xml
+++ b/addons/udes_stock/views/stock_picking_print_strategy_views.xml
@@ -11,6 +11,7 @@
       <field name="arch" type="xml">
         <xpath expr="//group[@name='basic']" position="inside">
           <field name="picking_type_id"/>
+          <field name="action_filter"/>
         </xpath>
       </field>
     </record>
@@ -24,6 +25,7 @@
       <field name="arch" type="xml">
         <xpath expr="//tree" position="inside">
           <field name="picking_type_id"/>
+          <field name="action_filter"/>
         </xpath>
       </field>
     </record>
@@ -37,6 +39,7 @@
       <field name="arch" type="xml">
         <xpath expr="//search" position="inside">
           <field name="picking_type_id"/>
+          <field name="action_filter"/>
         </xpath>
       </field>
     </record>


### PR DESCRIPTION
Here we send information about where the invocation
of the printing run method (that checks strategies)
is performed. We also gather more context info by
invoking a subclass method if defined.

The reason for that is to enable more control around
what strategies should be used for different picking
types.

User-story: 3598
Epic: 3584