### PR TITLE
[IMP] udes_stock: Revise automatic reservation

### DIFF
--- a/addons/udes_stock/models/stock_picking.py
+++ b/addons/udes_stock/models/stock_picking.py
@@ -1758,7 +1758,7 @@ class StockPicking(models.Model):
                 processed |= pickings
 
                 unsatisfied = pickings.filtered(
-                    lambda x: x.state != 'assigned')
+                    lambda x: x.state not in ['assigned', 'cancel', 'done'])
                 mls = pickings.mapped('move_line_ids')
                 if unsatisfied:
                     # Rollback if the picking type cannot handle partials or it


### PR DESCRIPTION
Do no count pickings in state done or cancel as unsatisfied,
this can happen when reserving batches.

User-story:

Signed-off-by: Miquel PS <miquel.palahi.sitges@unipart.io>