### PR TITLE
[ADD] Handle confirmed not ready picks

### DIFF
--- a/addons/udes_stock/models/stock_picking.py
+++ b/addons/udes_stock/models/stock_picking.py
@@ -1844,3 +1844,32 @@ class StockPicking(models.Model):
             _logger.info('Reserving stock for picking type %r completed.',
                          picking_type)
         return
+
+    def handle_confirmed_not_ready(self):
+        """Method to return the 'confirmed' pickings that need to be retained in
+        a batch. Default behaviour is to remove all of these from the batch. Return
+        any pickings from self if the desired behaviour is to keep them in the batch.
+        E.G. Some clients may want to check for stock and only remove pickings for
+        which there is insufficient stock.
+        """
+        Picking = self.env['stock.picking']
+        picks_to_retain = Picking.browse()
+        return picks_to_retain
+
+    def handle_waiting_not_ready(self):
+        """Method to return the 'waiting' pickings that need to be retained in
+        a batch. Default behaviour is to remove all of these from the batch. Return
+        any pickings from self if the desired behaviour is to keep them in the batch.
+        """
+        Picking = self.env['stock.picking']
+        picks_to_retain = Picking.browse()
+        return picks_to_retain
+
+    def handle_draft_not_ready(self):
+        """Method to return the 'draft' pickings that need to be retained in
+        a batch. Default behaviour is to remove all of these from the batch. Return
+        any pickings from self if the desired behaviour is to keep them in the batch.
+        """
+        Picking = self.env['stock.picking']
+        picks_to_retain = Picking.browse()
+        return picks_to_retain

--- a/addons/udes_stock/tests/test_picking_batch.py
+++ b/addons/udes_stock/tests/test_picking_batch.py
@@ -1272,17 +1272,8 @@ class TestBatchState(common.BaseUDES):
         self.draft_to_ready()
         self.assign_user()
 
-        # Cancel the pick and confirm we reach state done, compute state
-        with self.compute_patch as mocked_compute:
-            self.picking01.action_cancel()
-
-        mocked_compute.assert_called_with(self.batch01)
-        self.assertEqual(
-            mocked_compute.call_count, 2,
-            "The function that computes state wasn't invoked"
-        )
-
-        self.batch01._compute_state()
+        # Cancel the pick and confirm we reach state done,
+        self.picking01.action_cancel()
         self.assertEqual(self.batch01.state, 'done')
 
     def test10_check_computing_cancel(self):
@@ -1401,7 +1392,7 @@ class TestBatchState(common.BaseUDES):
         # Unreserve the pick and confirm we reach state done
         self.picking01.do_unreserve()
         self.assert_number_of_reserved_apples_is(0)
-        self.assertEqual(self.batch01.state, 'in_progress', 'Batch 1 should be inprogress')
+        self.assertEqual(self.batch01.state, 'done', 'Batch 1 should be done')
         self.assertEqual(self.picking01.state, 'confirmed', 'Picking 1 should be confirmed')
 
 


### PR DESCRIPTION
added failing tests in class TestBatchState:
* test13_unreserves_stock_after_cancel_pick
* test14_unreserves_stock_after_unreserve_pick
Checking that when unreserving/cancelling a pick in a batch the stock gets unreserved

Task: 4072
Story: 4059