### PR TITLE
[ADD] udes_stock: add button to bulk unreserve pickings

### DIFF
--- a/addons/udes_security/__manifest__.py
+++ b/addons/udes_security/__manifest__.py
@@ -15,5 +15,6 @@ Security enhancements used by UDES
     'category': "Authentication",
     'data': [
         'data/auth_brute_force.xml',
+        'data/res_groups.xml',
     ]
 }

--- a/addons/udes_security/data/res_groups.xml
+++ b/addons/udes_security/data/res_groups.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="group_trusted_user" model="res.groups">
+        <field name="name">Trusted User</field>
+        <field name="category_id" ref="base.module_category_extra"/>
+    </record>
+
+</odoo>

--- a/addons/udes_security/models/__init__.py
+++ b/addons/udes_security/models/__init__.py
@@ -1,1 +1,3 @@
 from . import res_authentication_attempt
+from . import res_groups
+from . import res_users

--- a/addons/udes_security/models/res_groups.py
+++ b/addons/udes_security/models/res_groups.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+import logging
+
+from odoo import api, models, SUPERUSER_ID
+from odoo.exceptions import AccessError
+from odoo.tools.translate import _
+
+_logger = logging.getLogger(__name__)
+
+class Groups(models.Model):
+    _inherit = 'res.groups'
+
+    @api.multi
+    def write(self, values):
+        group_trusted_user = self.env.ref('udes_security.group_trusted_user')
+
+        # Only the root user can add or remove the Trusted User group
+        if (group_trusted_user in self and
+            self.env.uid != SUPERUSER_ID and
+            len(values.get('users', [])) > 0):
+            raise AccessError(_('Trusted Users cannot be added or removed due to security restrictions. Please contact your system administrator.'))
+
+        res = super(Groups, self).write(values)
+        return res

--- a/addons/udes_security/models/res_users.py
+++ b/addons/udes_security/models/res_users.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+import logging
+
+from odoo import api, models, SUPERUSER_ID
+from odoo.exceptions import AccessError
+from odoo.tools.translate import _
+
+_logger = logging.getLogger(__name__)
+
+class Users(models.Model):
+    _inherit = 'res.users'
+
+    @api.model
+    def create(self, values):
+        self._check_trusted_user_grant(values)
+
+        user = super(Users, self).create(values)
+        return user
+
+    @api.multi
+    def write(self, values):
+        self._check_trusted_user_grant(values)
+
+        res = super(Users, self).write(values)
+        return res
+
+    def _check_trusted_user_grant(self, values):
+        group_trusted_user = self.env.ref('udes_security.group_trusted_user')
+
+        values = self._remove_reified_groups(values)
+
+        # Only the root user can add or remove the Trusted User group
+        for op, group_id in values.get('groups_id', []):
+            if (group_id == group_trusted_user.id and
+                self.env.uid != SUPERUSER_ID):
+                raise AccessError(_('Trusted Users cannot be added or removed due to security restrictions. Please contact your system administrator.'))

--- a/addons/udes_stock/wizard/reservation_views.xml
+++ b/addons/udes_stock/wizard/reservation_views.xml
@@ -9,7 +9,7 @@
             <form string="Reserve Stock">
                 <separator string="Are you sure?"/>
                 <footer>
-                    <button name="do_reservation" type="object" string="Do Reservation" class="btn-primary"/>
+                    <button name="do_reserve" type="object" string="Reserve" class="btn-primary"/>
                     <button string="Cancel" class="btn-default" special="cancel"/>
                 </footer>
             </form>
@@ -30,6 +30,30 @@
         multi="True"
         key2="client_action_multi" name="Reserve Stock"
         res_model="stock.reserve.stock.wizard" src_model="stock.picking"
-        view_mode="form" target="new" view_type="form"/>
+        view_mode="form" target="new" view_type="form"
+        view_id="stock_reserve_stock_form"/>
+
+    <!-- Trigger unreservation on pickings -->
+    <record id="stock_unreserve_stock_form" model="ir.ui.view">
+        <field name="name">stock.reserve.stock.form</field>
+        <field name="model">stock.reserve.stock.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Unreserve Stock">
+                <separator string="Are you sure?"/>
+                <footer>
+                    <button name="do_unreserve" type="object" string="Unreserve" class="btn-primary"/>
+                    <button string="Cancel" class="btn-default" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <act_window id="stock_unreserve_stock_action_stock_picking"
+        multi="True"
+        key2="client_action_multi" name="Unreserve Stock"
+        res_model="stock.reserve.stock.wizard" src_model="stock.picking"
+        view_mode="form" target="new" view_type="form"
+        view_id="stock_unreserve_stock_form"
+        groups="udes_security.group_trusted_user"/>
 
 </odoo>


### PR DESCRIPTION
To match the behaviour of the existing Reserve Stock button, the new
Unreserve Stock button only affects pickings in the assigned state and
does nothing for all other pickings.

The button is only visible to users who have the Bulk Unreserve User
permission, which can only be granted in developer mode.

Task: 4086
User-story: 3917

Signed-off-by: Sean Quah <sean.quah@unipart.io>