### PR TITLE
[FIX] Dockerfile: correct version of server-auth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ADD https://codeload.github.com/unipartdigital/odoo-print/zip/HEAD \
     /opt/odoo-print.zip
 ADD https://codeload.github.com/unipartdigital/odoo-edi/zip/HEAD \
     /opt/odoo-edi.zip
-ADD https://codeload.github.com/OCA/server-auth/zip/HEAD \
+ADD https://codeload.github.com/OCA/server-auth/zip/11.0 \
     /opt/server-auth.zip
 USER root
 RUN unzip -q -d /opt /opt/odoo-blocked-locations.zip ; \
@@ -22,8 +22,8 @@ RUN unzip -q -d /opt /opt/odoo-blocked-locations.zip ; \
           /opt/odoo-package-hierarchy-HEAD/addons/* \
           /opt/odoo-print-HEAD/addons/* \
           /opt/odoo-edi-HEAD/addons/* \
-          /opt/server-auth-HEAD/password_security \
-          /opt/server-auth-HEAD/auth_brute_force \
+          /opt/server-auth-11.0/password_security \
+          /opt/server-auth-11.0/auth_brute_force \
           /opt/odoo/addons/
 
 # Add modules


### PR DESCRIPTION
We're currently downloading server-auth from Odoo 12.0. This fixes that
so we explicitly download version 11.0 to avoid getting pulled up a
version by whatever the OCA set as their default branch.

Task: 4208

Signed-off-by: Samuel Searles-Bryant <samuel.searles-bryant@unipart.io>