### PR TITLE
[FIX] udes_security: Fix Trusted User write check and add tests

### DIFF
--- a/addons/udes_security/__init__.py
+++ b/addons/udes_security/__init__.py
@@ -2,3 +2,4 @@
 
 from . import controllers
 from . import models
+from . import tests

--- a/addons/udes_security/models/res_users.py
+++ b/addons/udes_security/models/res_users.py
@@ -30,7 +30,30 @@ class Users(models.Model):
         values = self._remove_reified_groups(values)
 
         # Only the root user can add or remove the Trusted User group
-        for op, group_id in values.get('groups_id', []):
-            if (group_id == group_trusted_user.id and
-                self.env.uid != SUPERUSER_ID):
+        if (self.env.uid != SUPERUSER_ID and
+           'groups_id' in values):
+            # Validate the many2many write to check that the
+            # Trusted User group is not being added or removed.
+            disallowed = False
+            for act in values['groups_id']:
+                if act[0] in (0, 1, 2):
+                    pass
+                elif act[0] in (3, 4):
+                    # Remove and add group
+                    disallowed |= act[1] == group_trusted_user.id
+                elif act[0] == 5:
+                    # Remove all groups
+                    disallowed |= group_trusted_user in self.mapped('groups_id')
+                elif act[0] == 6:
+                    # Replace all groups
+                    for user in self:
+                        disallowed |= ((group_trusted_user in user.groups_id) !=
+                                       (group_trusted_user.id in act[2]))
+                else:
+                    raise ValueError('Unknown operation in many2many write for groups_id')
+
+                if disallowed:
+                    break
+
+            if disallowed:
                 raise AccessError(_('Trusted Users cannot be added or removed due to security restrictions. Please contact your system administrator.'))

--- a/addons/udes_security/tests/__init__.py
+++ b/addons/udes_security/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_trusted_user

--- a/addons/udes_security/tests/test_trusted_user.py
+++ b/addons/udes_security/tests/test_trusted_user.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+
+from odoo.exceptions import AccessError
+from odoo.tests import common
+
+@common.at_install(False)
+@common.post_install(True)
+class TestTrustedUser(common.SavepointCase):
+    """
+    Check that only the admin user can add and remove the Trusted User group
+    """
+
+    def setUp(self):
+        """
+        Create two users for testing
+        """
+        super(TestTrustedUser, self).setUp()
+
+        User = self.env['res.users']
+
+        self.group_access_rights = self.env.ref('base.group_erp_manager')
+        self.group_trusted_user = self.env.ref(
+                                      'udes_security.group_trusted_user')
+
+        self.user_1 = User.create({
+            'name': 'Test User 1',
+            'login': 'test_user_1',
+            'groups_id': [(6, 0, [self.group_access_rights.id])],
+        })
+        self.user_2 = User.create({
+            'name': 'Test User 2',
+            'login': 'test_user_2',
+        })
+
+    def test01_user_group_add_remove_root(self):
+        """Test that the admin user can add and remove the Trusted User group"""
+        self.assertNotIn(self.group_trusted_user, self.user_2.groups_id)
+
+        # Add group
+        self.user_2.write({ 'groups_id': [(4, self.group_trusted_user.id)] })
+        self.assertIn(self.group_trusted_user, self.user_2.groups_id)
+
+        # Remove group
+        self.user_2.write({ 'groups_id': [(3, self.group_trusted_user.id)] })
+        self.assertNotIn(self.group_trusted_user, self.user_2.groups_id)
+
+        # Add group via replacement
+        self.user_2.write({ 'groups_id':
+                                [(6, 0, [self.group_trusted_user.id])] })
+        self.assertIn(self.group_trusted_user, self.user_2.groups_id)
+
+        # Remove group via replacement
+        self.user_2.write({ 'groups_id': [(6, 0, [])] })
+        self.assertNotIn(self.group_trusted_user, self.user_2.groups_id)
+
+        # Remove all groups
+        self.user_2.write({ 'groups_id': [(4, self.group_trusted_user.id)] })
+        self.assertIn(self.group_trusted_user, self.user_2.groups_id)
+        self.user_2.write({ 'groups_id': [(5,)] })
+        self.assertNotIn(self.group_trusted_user, self.user_2.groups_id)
+
+    def test02_user_group_add_non_root(self):
+        """Test that a non-admin user cannot add the Trusted User group"""
+        user_2 = self.user_2.sudo(self.user_1.id)
+        self.assertNotIn(self.group_trusted_user, user_2.groups_id)
+
+        # Add group
+        with self.assertRaises(AccessError):
+            user_2.write({ 'groups_id': [(4, self.group_trusted_user.id)] })
+        self.assertNotIn(self.group_trusted_user, user_2.groups_id)
+
+        # Add group via replacement
+        with self.assertRaises(AccessError):
+            user_2.write({ 'groups_id':
+                               [(6, 0, [self.group_trusted_user.id])] })
+        self.assertNotIn(self.group_trusted_user, user_2.groups_id)
+
+    def test03_user_group_remove_non_root(self):
+        """Test that a non-admin user cannot remove the Trusted User group"""
+        self.user_2.write({ 'groups_id': [(4, self.group_trusted_user.id)] })
+
+        user_2 = self.user_2.sudo(self.user_1.id)
+        self.assertIn(self.group_trusted_user, user_2.groups_id)
+
+        # Remove group
+        with self.assertRaises(AccessError):
+            user_2.write({ 'groups_id': [(3, self.group_trusted_user.id)] })
+        self.assertIn(self.group_trusted_user, user_2.groups_id)
+
+        # Replacement no-op
+        user_2.write({ 'groups_id': [(6, 0, user_2.groups_id.ids)] })
+        self.assertIn(self.group_trusted_user, user_2.groups_id)
+
+        # Remove group via replacement
+        with self.assertRaises(AccessError):
+            user_2.write({ 'groups_id': [(6, 0, [])] })
+        self.assertIn(self.group_trusted_user, user_2.groups_id)
+
+        # Remove all groups
+        with self.assertRaises(AccessError):
+            user_2.write({ 'groups_id': [(5,)] })
+        self.assertIn(self.group_trusted_user, user_2.groups_id)
+
+    def test04_group_user_add_remove_root(self):
+        """Test that the admin user can add and remove users"""
+        self._test_group_user_add_remove(self.env.user,
+                                         self.group_trusted_user, self.user_2)
+
+    def test05_group_user_add_remove_non_root(self):
+        """Test that a non-admin user cannot modify the Trusted User group's
+        users"""
+        # Check that user_1 can modify the users of a different group
+        self._test_group_user_add_remove(self.user_1,
+                                         self.group_access_rights, self.user_2)
+
+        # Check that user_1 cannot modify the users of the Trusted User group
+        group_trusted_user = self.group_trusted_user.sudo(self.user_1.id)
+        for act in [(4, self.user_2.id), (3, self.user_2.id), (5,), (6, 0, [])]:
+            with self.assertRaises(AccessError):
+                group_trusted_user.sudo(self.user_1.id).write({ 'users': [act] })
+            self.assertNotIn(self.user_2, group_trusted_user.users)
+
+    def _test_group_user_add_remove(self, user, test_group, test_user):
+        """Test that user can modify test_group's users"""
+        test_group = test_group.sudo(user.id)
+
+        self.assertNotIn(test_user, test_group.users)
+
+        # Add user
+        test_group.write({ 'users': [(4, test_user.id)] })
+        self.assertIn(test_user, test_group.users)
+
+        # Remove user
+        test_group.write({ 'users': [(3, test_user.id)] })
+        self.assertNotIn(test_user, test_group.users)


### PR DESCRIPTION
[FIX] udes_security: Fix Trusted User write check

Fix the res.users write override to correctly handle all many2many write
operations. Also remove the assumption that many2many write operations have
the right number of elements and no more.

Task: 4209
User-story: 3917

Signed-off-by: Sean Quah <sean.quah@unipart.io>

[ADD] udes_security: Add tests for restrictions on granting Trusted User

Task: 4209
User-story: 3917

Signed-off-by: Sean Quah <sean.quah@unipart.io>
