### PR TITLE
udes_stock: Remove auto-batching from GET controller and add new policy by order point

### DIFF
--- a/addons/udes_stock/README.md
+++ b/addons/udes_stock/README.md
@@ -363,6 +363,20 @@ Check that a package is not in use and hence is compatible with the stock pickin
 * @param id - the id of the stock.picking to check.
 * @param package_name - string with the name of the package.
 
+### Auto-batch a stock picking
+```
+URI: /api/stock-picking/:id/batch-it/
+HTTP Method: POST
+```
+
+Create a batch assigned to the current user for the picking if the auto batch flag is set at the picking type.. Raise an error if the picking type does not support auto batching or if the picking is already in a batch for a different user or without a user.
+
+Request:
+
+The request shall not contain any payload; the batch id must be given in the URI.
+
+Response (same as /api/stock-picking-batch GET) or None when flag is not true.
+
 ## Stock Location
 
 ### Stock Location (GET)

--- a/addons/udes_stock/models/stock_picking_type.py
+++ b/addons/udes_stock/models/stock_picking_type.py
@@ -226,6 +226,7 @@ class StockPickingType(models.Model):
         ('by_products', 'By Products'),
         ('by_packages', 'By Products in Packages'),
         ('by_height_speed', 'By Height and Speed Catagory'),
+        ('by_orderpoint', 'By Order Point'),
     ],
         string='Suggest Locations Policy',
         default='exactly_match_move_line',


### PR DESCRIPTION
Do not update pickings when doing a GET call. This can cause several
problems, for instance when trying to get info of a picking in state
done.

User-story: 3753

Signed-off-by: Miquel PS <miquel.palahi.sitges@unipart.io>