### PR TITLE
[IMP] udes_stock: Prevent locations having more than one orderpoint.

### DIFF
--- a/addons/udes_stock/README.md
+++ b/addons/udes_stock/README.md
@@ -44,6 +44,7 @@ The warehouse is made up of various locations for storing stock. There are two m
 | u_blocked        | boolean | Whether the location has been blocked. If it has been blocked, stock should not be moved to/from this location. |
 | u_blocked_reason | string  | A descriptive reason why the location has been blocked. |
 | quant_ids | [{stock.quants}]  | A list of all the quants at the given location. |
+| u_limit_order_points | boolean | When True, permit only one orderpoint per location for this location and its descendants. |
 
 ## Quants (model: stock.quant)
 

--- a/addons/udes_stock/tests/__init__.py
+++ b/addons/udes_stock/tests/__init__.py
@@ -23,3 +23,4 @@ from . import test_splitting
 from . import test_target_storage_types
 from . import test_update_picking
 from . import test_picking_print_strategy
+from . import test_limit_orderpoints

--- a/addons/udes_stock/tests/common.py
+++ b/addons/udes_stock/tests/common.py
@@ -101,9 +101,11 @@ class BaseUDES(common.SavepointCase):
             })
         cls.test_locations = cls.test_location_01 + cls.test_location_02
 
+        cls.warehouse_location = Location.create({'name': 'UPL'})
         cls.out_location = cls.picking_type_pick.default_location_dest_id.copy({
             'name': 'TEST_OUT',
             'active': True,
+            'location_id': cls.warehouse_location.id,
         })
         cls.test_output_location_01 = Location.create({
             'name': "Test output location 01",

--- a/addons/udes_stock/tests/test_limit_orderpoints.py
+++ b/addons/udes_stock/tests/test_limit_orderpoints.py
@@ -1,0 +1,58 @@
+"""Tests for the limit orderpoints flag."""
+
+from odoo.exceptions import ValidationError
+from . import common
+
+
+class LimitOrderpointsTestCase(common.BaseUDES):
+
+    @classmethod
+    def setUpClass(cls):
+        super(LimitOrderpointsTestCase, cls).setUpClass()
+        # Create an orderpoint with values
+        cls.create_orderpoint(cls.apple, cls.test_output_location_01, 5, 10)
+
+    def test01_cannot_add_orderpoint_if_one_exists(self):
+        """ Tests cannot add an orderpoint if one already exists and the limit
+        orderpoints flag is set on the location.
+        """
+        self.test_output_location_01.u_limit_orderpoints = True
+        with self.assertRaises(ValidationError) as cm:
+            self.create_orderpoint(self.banana,
+                                   self.test_output_location_01,
+                                   5, 10)
+        ex = cm.exception
+        self.assertEqual('An order point for location {} already exists on '
+                         '{}.'.format(self.test_output_location_01.name,
+                                      self.apple.name),
+                         ex.name)
+
+    def test02_cannot_add_orderpoint_if_limit_on_parent(self):
+        """ Tests cannot add an orderpoint if one already exists and the limit
+        orderpoints flag is set on the location's parent location.
+        """
+        self.out_location.u_limit_orderpoints = True
+        with self.assertRaises(ValidationError) as cm:
+            self.create_orderpoint(self.banana,
+                                   self.test_output_location_01,
+                                   5, 10)
+        ex = cm.exception
+        self.assertEqual('An order point for location {} already exists on '
+                         '{}.'.format(self.test_output_location_01.name,
+                                      self.apple.name),
+                         ex.name)
+
+    def test03_cannot_add_orderpoint_if_limit_on_grandparent(self):
+        """ Tests cannot add an orderpoint if one already exists and the limit
+        orderpoints flag is set on the location's grandparent location.
+        """
+        self.warehouse_location.u_limit_orderpoints = True
+        with self.assertRaises(ValidationError) as cm:
+            self.create_orderpoint(self.banana,
+                                   self.test_output_location_01,
+                                   5, 10)
+        ex = cm.exception
+        self.assertEqual('An order point for location {} already exists on '
+                         '{}.'.format(self.test_output_location_01.name,
+                                      self.apple.name),
+                         ex.name)

--- a/addons/udes_stock/views/stock_location.xml
+++ b/addons/udes_stock/views/stock_location.xml
@@ -25,6 +25,7 @@
                     <field name="u_date_last_checked_correct"
                            attrs="{'readonly': [('u_date_last_checked_correct', '!=', False)]}"/>
                     <field name="u_quant_policy" readonly="1"/>
+                    <field name="u_limit_orderpoints" groups="udes_stock.group_stock_user"/>
                 </xpath>
 
                 <!-- Add a confirmation to the "Archive" button. -->


### PR DESCRIPTION
Story/3885

Signed-off-by: Kevin Dwyer <kevin.dwyer@unipart.io>

This patch adds a boolean flag to the location model.  If set, the flag
prevents having more than one orderpoint on a location.