### PR TITLE
[FIX] udes_stock: Dont write to name if updating to current value

### DIFF
--- a/addons/udes_stock/models/stock_location.py
+++ b/addons/udes_stock/models/stock_location.py
@@ -551,6 +551,15 @@ class StockLocation(models.Model):
         return bool(self.search_count([('id', 'child_of', limited.ids),
                                        ('id', '=', self.id)]))
 
+    def write(self, values):
+        """ Removing 'name' from values if it equals all names in self  """
+        if 'name' in values:
+            if all(name == values['name'] for name in self.mapped('name')):
+                del values['name']
+                if not values:
+                    return True
+        return super(StockLocation, self).write(values)
+
 
 class Orderpoint(models.Model):
 


### PR DESCRIPTION
When writing to stock.locations we should not update name to the
value it is currently as this causes recomputes of complete name
for all children. This is especially troublesome in the case of
having many locations sitting under 'Physical Locations' as this
is updated many times every restart.