### PR TITLE
[FIX] udes_stock: Don't allow writes to inventory adjustments after v…

### DIFF
--- a/addons/udes_stock/models/stock_inventory.py
+++ b/addons/udes_stock/models/stock_inventory.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from odoo import api, models, fields, _
-from odoo.exceptions import ValidationError
+from odoo.exceptions import ValidationError, UserError
 
 
 class StockInventory(models.Model):
@@ -32,3 +32,10 @@ class StockInventory(models.Model):
                     _('There are undone preceding inventories.'))
 
         return super(StockInventory, self).action_done()
+
+    def write(self, values):
+        if self.state == 'done':
+            raise UserError(
+                _('Cannot write to an adjustment which has already been '
+                  'validated'))
+        return super(StockInventory, self).write(values)


### PR DESCRIPTION
…alidation

Do not allow writes to stock.inventory records after validation as this means
they can not be a suitable for an audit

User-story: 1329
Signed-off-by: Michele Costa <michele.costa@unipart.io>