### PR TITLE
[IMP] udes_stock: Fix stock.location.is_compatible_package

### DIFF
--- a/addons/udes_stock/models/stock_location.py
+++ b/addons/udes_stock/models/stock_location.py
@@ -560,7 +560,7 @@ class StockLocation(models.Model):
         Package = self.env['stock.quant.package']
         self.ensure_one()
         package = Package.get_package(package_name, no_results=True)
-        if package:
+        if package and package.location_id:
             return package.location_id  == self
         return True
 


### PR DESCRIPTION
When the package is created but still without content the location
in self is different than the pallet location. This happens
when mulitple products of the same picking go into the same pallet,
because the location of the pallet is undefined.

User-story: 4604

Signed-off-by: Miquel PS <miquel.palahi.sitges@unipart.io>