### PR TITLE
[ADD] udes_stock: flag to enable exception handling

### DIFF
--- a/addons/udes_stock/README.md
+++ b/addons/udes_stock/README.md
@@ -121,6 +121,7 @@ A lot of custom UDES functionality is specfied at the picking type level. This i
 | u_handle_partials          | boolean | If the picking type is allowed to handle partially available pickings. If True, then pickings of this type will report their u_pending value. If False, prevents the state of a picking to be ready until the previous pickings are resolved.|
 | u_create_procurement_group | boolean | Indicate if a procurement group should be created on confirmation of the picking if one does not already exist. |
 | u_enable_unpickable_items  | boolean | When not enabled only an error is shown to the user instead of the usual unpickable items behaviour. |
+| u_enable_exception_handling| boolean | Flag to indicate if exception handling options (exceptions that raise a stock investigation) will be shown. |
 | u_confirm_batch            | boolean | Flag to indicate if user has to confirm the batch to work with |
 | u_enable_confirmations     | boolean | Flag to indicate if user has to perform any confirmation after picking a product.|
 | u_use_part_pallets         | boolean | Flag to indicate if each pallet is validated and processed at goods in as oppose scanning the whole ASN.|

--- a/addons/udes_stock/data/picking_types.xml
+++ b/addons/udes_stock/data/picking_types.xml
@@ -178,6 +178,7 @@
       <field name="u_create_procurement_group" eval="True"/>
       <field name="show_operations" eval="1"/>
       <field name="active">False</field>
+      <field name="u_enable_exception_handling" eval="True"/>
     </record>
 
     <record id="picking_type_check" model="stock.picking.type">

--- a/addons/udes_stock/models/stock_picking_type.py
+++ b/addons/udes_stock/models/stock_picking_type.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
 
@@ -176,6 +175,12 @@ class StockPickingType(models.Model):
         default=False,
         help='Flag to indicate if the current picking type has unpickable '
              'items enabled.',
+    )
+
+    u_enable_exception_handling = fields.Boolean(
+        string='Allow exception handling',
+        default=False,
+        help='Flag to indicate whether the user is shown exception handling options.'
     )
 
     u_confirm_batch = fields.Boolean(
@@ -366,6 +371,7 @@ class StockPickingType(models.Model):
             - u_create_batch_for_user: boolean
             - u_check_picking_priorities: boolean
             - u_use_location_categories: boolean
+            - u_enable_exception_handling: boolean
             - u_confirm_batch: boolean
             - u_enable_confirmations: boolean
             - u_use_part_pallets: boolean
@@ -419,6 +425,7 @@ class StockPickingType(models.Model):
                 'u_create_batch_for_user': self.u_create_batch_for_user,
                 'u_check_picking_priorities': self.u_check_picking_priorities,
                 'u_use_location_categories': self.u_use_location_categories,
+                'u_enable_exception_handling': self.u_enable_exception_handling,
                 'u_confirm_batch': self.u_confirm_batch,
                 'u_enable_confirmations': self.u_enable_confirmations,
                 'u_use_part_pallets': self.u_use_part_pallets,

--- a/addons/udes_stock/views/stock_picking_type.xml
+++ b/addons/udes_stock/views/stock_picking_type.xml
@@ -47,6 +47,7 @@
                     <field name="u_check_picking_priorities" />
                     <field name="u_use_location_categories" />
                     <field name="u_enable_unpickable_items" />
+                    <field name="u_enable_exception_handling" />
                     <field name="u_confirm_batch" />
                     <field name="u_enable_confirmations" />
                     <field name="u_use_part_pallets" />


### PR DESCRIPTION
Add a flag to PickingType to enable exception handling.
This flag is disabled by default and enabled explicitely for Pick
picking type.

User-story: 4743

Signed-off-by: Samuel Searles-Bryant <samuel.searles-bryant@unipart.io>