### PR TITLE
[IMP] mrp: make waiting Manufacturing Orders not show as todo

### DIFF
--- a/addons/udes_mrp/__init__.py
+++ b/addons/udes_mrp/__init__.py
@@ -1,2 +1,4 @@
 # -*- coding: utf-8 -*-
-#from . import models
+
+from . import models
+from . import tests

--- a/addons/udes_mrp/__manifest__.py
+++ b/addons/udes_mrp/__manifest__.py
@@ -25,7 +25,7 @@
     # always loaded
     'data': [
         'report/mrp_production_templates.xml',
-
+        'views/mrp_production_views.xml'
     ],
 
     # only loaded in demonstration mode

--- a/addons/udes_mrp/models/__init__.py
+++ b/addons/udes_mrp/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_picking

--- a/addons/udes_mrp/models/stock_picking.py
+++ b/addons/udes_mrp/models/stock_picking.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2019, Unipart Digital
+# Derived from Odoo.
+
+from odoo import fields, models
+
+
+class StockPickingType(models.Model):
+    _inherit = 'stock.picking.type'
+
+    def _get_mo_count(self):
+        """Override _get_mo_count so waiting orders don't show also as todo."""
+        mrp_picking_types = self.filtered(lambda picking: picking.code == 'mrp_operation')
+        if not mrp_picking_types:
+            return
+        domains = {
+            'count_mo_waiting': [('availability', '=', 'waiting')],
+            'count_mo_todo': [('state', 'in', ('confirmed', 'planned', 'progress')),
+                              ('availability', '<>', 'waiting')],
+            'count_mo_late': [('date_planned_start', '<', fields.Date.today()), ('state', '=', 'confirmed')],
+        }
+        for field in domains:
+            data = self.env['mrp.production'].read_group(domains[field] +
+                                                         [('state', 'not in', ('done', 'cancel')), ('picking_type_id', 'in', self.ids)],
+                                                         ['picking_type_id'], ['picking_type_id'])
+            count = {x['picking_type_id'] and x['picking_type_id'][0]: x['picking_type_id_count'] for x in data}
+            for record in mrp_picking_types:
+                record[field] = count.get(record.id, 0)
+

--- a/addons/udes_mrp/tests/__init__.py
+++ b/addons/udes_mrp/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_mrp_production

--- a/addons/udes_mrp/tests/test_mrp_production.py
+++ b/addons/udes_mrp/tests/test_mrp_production.py
@@ -1,0 +1,102 @@
+from odoo.tests import common
+from odoo.addons.mrp.tests.common import TestMrpCommon
+
+from datetime import datetime, timedelta
+
+
+@common.at_install(False)
+@common.post_install(True)
+class TestManufacturingOrder(TestMrpCommon):
+    def test01_filters(self):
+        """Tests that BOMs in different states are filtered and counted properly."""
+        MrpProduction = self.env['mrp.production'].sudo()
+
+        # Cancel and remove all the testing orders so changes there don't break the count
+        test_orders = MrpProduction.search([])
+        test_orders.action_cancel()
+        test_orders.unlink()
+
+        # Set up the picking type
+        picking_type = self.env['stock.picking.type'].create({
+            'name': 'Manufacturing',
+            'code': 'mrp_operation',
+            'sequence_id': self.env['ir.sequence'].search([('code', '=', 'mrp.production')], limit=1).id,
+        })
+
+        # Order 1: waiting, not todo, late
+        test_date_planned = datetime.now() - timedelta(days=1)
+        test_quantity = 2.0
+        order_1 = MrpProduction.create({
+            'name': 'Stick-0',
+            'product_id': self.product_4.id,
+            'product_uom_id': self.product_4.uom_id.id,
+            'product_qty': test_quantity,
+            'bom_id': self.bom_1.id,
+            'date_planned_start': test_date_planned,
+            'location_src_id': self.location_1.id,
+            'location_dest_id': self.warehouse_1.wh_output_stock_loc_id.id,
+            'picking_type_id': picking_type.id
+        })
+
+        self.assertEqual(order_1.availability, 'waiting', 'Order should be waiting since there are no source'
+                                                        ' products.')
+        self.assertEqual(order_1.picking_type_id.count_mo_waiting, 1, 'The count of waiting orders should '
+                                                                    'now equal one.')
+        self.assertEqual(order_1.picking_type_id.count_mo_todo, 0, 'The count of todo orders should '
+                                                                 'now equal zero.')
+        self.assertEqual(order_1.picking_type_id.count_mo_late, 1, 'The count of late orders should '
+                                                                 'now equal one.')
+
+        # Order 2: waiting, todo, not late
+        order_2 = MrpProduction.create({
+            'name': 'Stick-1',
+            'product_id': self.product_5.id,
+            'product_uom_id': self.product_5.uom_id.id,
+            'product_qty': test_quantity,
+            'bom_id': self.bom_2.id,
+            'date_planned_start': datetime.now(),
+            'location_src_id': self.location_1.id,
+            'location_dest_id': self.warehouse_1.wh_output_stock_loc_id.id,
+            'picking_type_id': picking_type.id
+        })
+
+        order_2.picking_type_id.invalidate_cache()
+        self.assertEqual(order_2.availability, 'waiting', 'Order should be waiting since there are no source'
+                                                          ' products.')
+        self.assertEqual(order_2.picking_type_id.count_mo_waiting, 2, 'The count of waiting orders should '
+                                                                      'now equal two.')
+        self.assertEqual(order_2.picking_type_id.count_mo_todo, 0, 'The count of todo orders should '
+                                                                   'now equal zero.')
+        self.assertEqual(order_2.picking_type_id.count_mo_late, 1, 'The count of late orders should '
+                                                                   'now equal one.')
+
+        # Stock products for Order 2
+        inventory = self.env['stock.inventory'].create({
+            'name': 'Test Inventory',
+            'filter': 'partial',
+            'line_ids': [(0, 0, {
+                'product_id': self.product_3.id,
+                'product_uom_id': self.product_3.uom_id.id,
+                'product_qty': 60,
+                'location_id': self.location_1.id
+            }), (0, 0, {
+                'product_id': self.product_4.id,
+                'product_uom_id': self.product_4.uom_id.id,
+                'product_qty': 60,
+                'location_id': self.location_1.id
+            })]
+        })
+        inventory.action_start()
+        inventory.action_done()
+        order_2.action_assign()
+        order_2.picking_type_id.invalidate_cache()
+
+        self.assertEqual(order_2.availability, 'assigned', 'The order should have assigned source products.')
+        self.assertEqual(order_2.state, 'confirmed', 'The order should be confirmed.')
+
+        self.assertEqual(order_2.picking_type_id.count_mo_waiting, 1, 'The count of waiting orders should '
+                                                                      'now equal one.')
+        self.assertEqual(order_2.picking_type_id.count_mo_todo, 1, 'The count of todo orders should '
+                                                                   'now equal one.')
+        self.assertEqual(order_2.picking_type_id.count_mo_late, 1, 'The count of late orders should '
+                                                                   'now equal one.')

--- a/addons/udes_mrp/views/mrp_production_views.xml
+++ b/addons/udes_mrp/views/mrp_production_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="view_mrp_production_filter_udes" model="ir.ui.view">
+            <field name="name">mrp.production.select</field>
+            <field name="model">mrp.production</field>
+            <field name="inherit_id" ref="mrp.view_mrp_production_filter" />
+            <field name="arch" type="xml">
+                <xpath expr="//filter[@name='todo']" position="replace">
+                    <!-- Don't show waiting orders as both waiting and todo -->
+                    <filter string="To Do" name="todo" domain="[('state','in',('confirmed', 'planned','progress')),
+                                                                ('availability','&lt;&gt;','waiting')]"
+                            help="Manufacturing Orders which are in confirmed state."/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Since they already show as waiting, it was requested that they do not show as todo.

Story: 4344
Task: 4716
Signed-off-by: Przemysław Buczkowski <pbuczkowski@unipart.io>