### PR TITLE
[ADD] udes_security: Add dependency on auth_session_timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN unzip -q -d /opt /opt/odoo-blocked-locations.zip ; \
           /opt/odoo-edi-HEAD/addons/* \
           /opt/server-auth-11.0/password_security \
           /opt/server-auth-11.0/auth_brute_force \
+          /opt/server-auth-11.0/auth_session_timeout \
           /opt/odoo/addons/
 
 # Add modules

--- a/addons/udes_security/__manifest__.py
+++ b/addons/udes_security/__manifest__.py
@@ -11,6 +11,7 @@ Security enhancements used by UDES
         'web',
         'password_security',
         'auth_brute_force',
+        'auth_session_timeout',
     ],
     'category': "Authentication",
     'data': [


### PR DESCRIPTION
The auth_session_timeout module times out user sessions after a
configurable duration, which is 2 hours by default.

Task: 4787
User-story: 98

Signed-off-by: Sean Quah <sean.quah@unipart.io>