### PR TITLE
support for using diff-cover

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN unzip -q -d /opt /opt/odoo-blocked-locations.zip ; \
 
 # Add modules
 #
-ADD addons /opt/odoo-addons
+ADD . /opt/odoo-addons
 
 # Module installation (without tests)
 #


### PR DESCRIPTION
Related story: https://taiga.unipart.digital/project/udescore/us/4613

This PR is connected to a PR for odoo-tester https://github.com/unipartdigital/odoo-tester/pull/1. Please see the description in that PR for more details

Changes in this PR:
*   Copy the parent folder changes the location of modules. There is some code to identify modules which are now wrong - solution: update the code to look for modules.


Below is an example of the results of calling "diff-cover coverage.xml":

```
-------------
Diff Coverage
Diff: origin/master...HEAD, staged and unstaged changes
-------------
addons/service_job/models/sale_order.py (0.0%): Missing lines 26,31
addons/service_job/models/servicejob.py (66.7%): Missing lines 982
-------------
Total:   5 lines
Missing: 3 lines
Coverage: 40%
-------------

```
Each file with changes in the diff is listed along with:

* the percentage of the changed lines of code that are executed tests
* a list of the lines of code that are not hit (if the percentage is <100%)

Also there is a summary of changed lines and the number of lines that are executed across all the files in the diff. 