### PR TITLE
[IMP] udes_sale_stock,udes_stock: Adding auto-confirm for sale orders

### DIFF
--- a/addons/udes_sale_stock/__manifest__.py
+++ b/addons/udes_sale_stock/__manifest__.py
@@ -22,6 +22,7 @@
         'security/udes_sale_stock_security.xml',
         'data/stock_config.xml',
         'views/sale_order_views.xml',
+        'views/stock_warehouse.xml',
         'views/res_users_views.xml',
         'views/res_groups_views.xml',
     ],

--- a/addons/udes_sale_stock/models/__init__.py
+++ b/addons/udes_sale_stock/models/__init__.py
@@ -8,3 +8,4 @@ from . import res_users
 from . import res_groups
 from . import partner_pii
 from . import edi_sale_request_document
+from . import stock_warehouse

--- a/addons/udes_sale_stock/models/stock_warehouse.py
+++ b/addons/udes_sale_stock/models/stock_warehouse.py
@@ -1,0 +1,12 @@
+from odoo import fields, models, _
+
+
+class StockWarehouse(models.Model):
+    _inherit = 'stock.warehouse'
+
+    u_so_auto_confirm_ahead_days = fields.Integer(
+        "Auto Confirm sale order within (days)",
+        default=-1,
+        help="Days ahead to auto confirm sales orders for. "
+             "0 = Today, 1 = Tomorrow, -1 = All"
+    )

--- a/addons/udes_sale_stock/views/stock_warehouse.xml
+++ b/addons/udes_sale_stock/views/stock_warehouse.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_warehouse_inherited" model="ir.ui.view">
+        <field name="name">Stock Warehouse Inherited</field>
+        <field name="model">stock.warehouse</field>
+        <field name="inherit_id" ref="udes_stock.view_warehouse_inherited"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='print_picking_type']" position="after">
+                <group name="udes_sale_stock_config" string="Sale Stock Config">
+                    <field name="u_so_auto_confirm_ahead_days" />
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/udes_stock/views/stock_warehouse.xml
+++ b/addons/udes_stock/views/stock_warehouse.xml
@@ -28,7 +28,7 @@
                                    nolabel="1"
                             />
                         </group>
-                        <group>
+                        <group name="udes_stock_config" string="Stock Config">
                             <field name="u_missing_stock_location_id" />
                             <field name="u_damaged_location_id" />
                             <field name="u_pi_count_move_picking_type" />


### PR DESCRIPTION
Adding config and functionality to automatically confirm sale orders
based on an x days in the  future value. Triggers so.action_confirm()
on all orders within x days (0 being today only)

Also adding a string to the UDES stock warehouse configs for clarity.