### PR TITLE
[REM] udes_stock: Unneeded call to Picking.unlink_empty() at procurement.group

### DIFF
--- a/addons/udes_stock/models/procurement.py
+++ b/addons/udes_stock/models/procurement.py
@@ -39,17 +39,3 @@ class ProcurementGroup(models.Model):
                 _('Too many groups found for '
                   'identifier %s') % str(group_identifier))
         return results
-
-    @api.model
-    def run(self, product_id, product_qty, product_uom, location_id, name,
-            origin, values):
-        """ Override run to clean up empty pickings in case any refactoring has
-            occurred.
-        """
-        Picking = self.env['stock.picking']
-
-        super().run(product_id, product_qty, product_uom, location_id, name,
-                    origin, values)
-        Picking.unlink_empty()
-
-        return True


### PR DESCRIPTION
Calling unlink_empty() at procurement.group.run() causes to unexpectedly
being called when calling _procure_orderpoint_confirm().
This can cause serialisation errors if run() is triggered by more than
one reason at the same time, for example check reorder points and
procurement route creation.
There is a cron job to tidy up empty pickings which can be used instead.
