### PR TITLE
[FIX] udes_stock: Don't recompute batch on picking cancel until done

### DIFF
--- a/addons/udes_stock/models/stock_picking.py
+++ b/addons/udes_stock/models/stock_picking.py
@@ -301,7 +301,10 @@ class StockPicking(models.Model):
         """
         Check if picking batch is now complete
         """
-        res = super(StockPicking, self).action_cancel()
+        batch = self.mapped('batch_id')
+        res = super(StockPicking, self.with_context(lock_batch_state=True))\
+            .action_cancel()
+        batch._compute_state()
         return res
 
     def write(self, vals):

--- a/addons/udes_stock/models/stock_picking_batch.py
+++ b/addons/udes_stock/models/stock_picking_batch.py
@@ -210,12 +210,6 @@ class StockPickingBatch(models.Model):
             if confirmed_not_ready:
                 # Attempt to make confirmed picks ready
                 confirmed_not_ready.action_assign()
-                # TODO This has the undesired effect of having a cancelled
-                # picking with stock still assigned to it. When a picking is
-                # cancelled, this is fired before the relevant picking and batch
-                # state changes have all been made, resulting in the newly unreserved
-                # stock for the cancelled picking being reserved again via action_assign.
-                # Needs design and a rethink.
 
             # Filter again as we are possibly calling action_assign which
             # could make some of the previous not ready picks to now be ready

--- a/addons/udes_stock/tests/test_picking_batch.py
+++ b/addons/udes_stock/tests/test_picking_batch.py
@@ -1271,7 +1271,7 @@ class TestBatchState(common.BaseUDES):
 
         mocked_compute.assert_called_with(self.batch01)
         self.assertEqual(
-            mocked_compute.call_count, 2,
+            mocked_compute.call_count, 3,
             "The function that computes state wasn't invoked"
         )
 


### PR DESCRIPTION
Recomputing the batch AFTER the picking cancel logic prevents quant
re-reservation being triggered on something that in in process of
being cancelled, and resolves the issue of batch-cancelled picks
still having reserved stock.