### PR TITLE
Story/9246 scan lots

### DIFF
--- a/addons/udes_stock/models/stock_move_line.py
+++ b/addons/udes_stock/models/stock_move_line.py
@@ -411,10 +411,14 @@ class StockMoveLine(models.Model):
 
     def generate_lot_name(self, lot_names, product):
         """ If required, create a lot and return it's name in a list """
-        confirm_tracking = self.mapped('picking_id.picking_type_id').u_confirm_tracking
+        picking_type = self.mapped('picking_id.picking_type_id')
+        picking_type.ensure_one()
+        confirm_tracking = picking_type.u_scan_tracking
         if confirm_tracking == 'no':
             if len(lot_names) == 0:
                 return [self._generate_lot_name(product)]
+            else:
+                return lot_names
         elif confirm_tracking == 'first_last':
             raise ValidationError(_('Not implemented'))
         else:

--- a/addons/udes_stock/models/stock_picking.py
+++ b/addons/udes_stock/models/stock_picking.py
@@ -335,7 +335,7 @@ class StockPicking(models.Model):
     def update_lot_names(self):
         """ Create lot names for move lines where user is not required to provide them """
         picking_type = self.picking_type_id
-        if (picking_type.use_create_lots or picking_type.use_existing_lots) and picking_type.u_confirm_tracking == 'no':
+        if (picking_type.use_create_lots or picking_type.use_existing_lots) and picking_type.u_scan_tracking == 'no':
             lines_to_check = self.move_line_ids.filtered(lambda ml: ml.product_id.tracking != 'none')
             for line in lines_to_check:
                 product = line.product_id

--- a/addons/udes_stock/models/stock_picking_type.py
+++ b/addons/udes_stock/models/stock_picking_type.py
@@ -92,16 +92,16 @@ class StockPickingType(models.Model):
         help="Flag to indicate reservations should be rounded up to entire packages."
     )
 
-    # u_scan_tracking maybe better?
-    u_confirm_tracking = fields.Selection([
+    u_scan_tracking = fields.Selection([
         ('no', 'No'),
         ('yes', 'Yes'),
         ('first_last', 'First/Last'),
     ],
         required=True,
         default='yes',
-        string='Confirm Tracked Products',
-        help='Confirm tracked products: yes; no; first and last serial number.',
+        string='Scan Tracked Products',
+        help='Scan tracked products: yes; no; first and last serial number.',
+        oldname='u_confirm_tracking',
     )
 
     u_confirm_expiry_date = fields.Boolean(
@@ -412,7 +412,7 @@ class StockPickingType(models.Model):
                 'u_reserve_as_packages': self.u_reserve_as_packages,
                 'u_handle_partials': self.u_handle_partials,
                 'u_create_procurement_group': self.u_create_procurement_group,
-                'u_confirm_tracking': self.u_confirm_tracking,
+                'u_scan_tracking': self.u_scan_tracking,
                 'u_confirm_expiry_date': self.u_confirm_expiry_date,
                 'u_drop_criterion': self.u_drop_criterion,
                 'drop_criterion_instructions': drop_off_instructions,

--- a/addons/udes_stock/tests/test_generate_lot.py
+++ b/addons/udes_stock/tests/test_generate_lot.py
@@ -10,9 +10,9 @@ class TestGenerateLot(common.BaseUDES):
 
     def test01_update_picking_missing_lot(self):
         """ Update picking of a tracked product without lot_name should raise
-            a ValidationError when u_confirm_tracking is yes.
+            a ValidationError when u_scan_tracking is yes.
         """
-        self.picking_type_in.u_confirm_tracking = 'yes'
+        self.picking_type_in.u_scan_tracking = 'yes'
         create_info = [{'product': self.tangerine, 'qty': 4}]
         picking = self.create_picking(self.picking_type_in,
                                       products_info=create_info,
@@ -29,10 +29,10 @@ class TestGenerateLot(common.BaseUDES):
 
     def test02_update_picking_generate_lot(self):
         """ Update picking of a tracked product without lot_name shouldn't raise
-            any error when u_confirm_tracking is no, and a lot name should be
+            any error when u_scan_tracking is no, and a lot name should be
             automatically generated.
         """
-        self.picking_type_in.u_confirm_tracking = 'no'
+        self.picking_type_in.u_scan_tracking = 'no'
 
         create_info = [{'product': self.tangerine, 'qty': 4}]
         picking = self.create_picking(self.picking_type_in,
@@ -50,9 +50,9 @@ class TestGenerateLot(common.BaseUDES):
 
     def test03_button_validate_generate_lot(self):
         """ Calling button_validate on a picking generates lot names if they
-            are not set and u_confirm_tracking is no.
+            are not set and u_scan_tracking is no.
         """
-        self.picking_type_in.u_confirm_tracking = 'no'
+        self.picking_type_in.u_scan_tracking = 'no'
 
         create_info = [{'product': self.tangerine, 'qty': 4}]
         picking = self.create_picking(self.picking_type_in,

--- a/addons/udes_stock/views/stock_picking_type.xml
+++ b/addons/udes_stock/views/stock_picking_type.xml
@@ -36,7 +36,7 @@
                     <field name="u_drop_location_policy" />
                     <field name="u_new_package_policy" />
                     <field name="u_drop_location_preprocess"/>
-                    <field name="u_confirm_tracking" />
+                    <field name="u_scan_tracking" />
                     <field name="u_confirm_expiry_date" />
                     <field name="u_auto_batch_pallet" />
                     <field name="u_continue_picking" />


### PR DESCRIPTION
Changed behaviour for lot based tracking to allow multiple movelines to pick the same lot number. This is allowed behaviour for lot based tracking (but disallowed for serial based tracking). 

Additionally, a configuration option for scanning the lot number during the pick process was added.
The default behaviour is to scan tracking numbers, as it was before.