### PR TITLE
[IMP] stock_mobile: Allow stock check for locations with bad tracking

### DIFF
--- a/addons/udes_stock/models/product_template.py
+++ b/addons/udes_stock/models/product_template.py
@@ -3,6 +3,7 @@
 from odoo import api, fields, models
 from odoo.addons import decimal_precision as dp
 from odoo.exceptions import ValidationError
+from odoo.tools.translate import _
 
 
 class ProductTemplate(models.Model):
@@ -61,3 +62,13 @@ class ProductTemplate(models.Model):
         if self.u_pallet_qty < 0:
             raise ValidationError(
                 "Value for pallet quantity cannot be below 0.")
+
+    @api.onchange('tracking')
+    def _confirm_lot_trackng_change(self):
+        """ Prevent accidental changes to lot tracking number.
+        """
+        if self.qty_available > 0:
+            return  {'warning': {
+                        'title': _('Change Tracking Type'),
+                        'message': _('Products already existing in locations will need to be stock checked.')
+                    }}

--- a/addons/udes_stock/tests/test_location_pi.py
+++ b/addons/udes_stock/tests/test_location_pi.py
@@ -728,3 +728,42 @@ class TestLocationPI(common.BaseUDES):
         self.assertEquals(prec_inv.u_next_inventory_id.id, inv_id,
                           "The preceding adjustments inventory is not linked "
                           "correctly to the next inventory adjustments")
+
+    def test26_validate_pi_request_lot_with_untracked_product_zero_quantity(self):
+        """
+        No error raised if the request contains an inventory adjustment entry
+        for an untracked product with a lot name specified if quantity == 0
+        """
+        req = {
+            'location_id': self.test_location_01.id,
+            'inventory_adjustments': [
+                {
+                    'product_id': self.apple.id,
+                    'package_name': self.package_one.name,
+                    'quantity': 0,
+                    'lot_name': 'awesome_lot'
+                }
+            ]
+        }
+
+        self.test_location_01._validate_perpetual_inventory_request(req)
+        self.assertTrue(True)
+
+    def test27_validate_pi_request_tracked_product_without_lot_zero_quantity(self):
+        """
+        No error raised if the request contains an inventory adjustment entry
+        for a tracked product without a lot name specified if quantity == 0
+        """
+        req = {
+            'location_id': self.test_location_01.id,
+            'inventory_adjustments': [
+                {
+                    'product_id': self.strawberry.id,
+                    'package_name': self.package_one.name,
+                    'quantity': 0
+                }
+            ]
+        }
+
+        self.test_location_01._validate_perpetual_inventory_request(req)
+        self.assertTrue(True)


### PR DESCRIPTION
Allow stock check for locations containing products with the wrong lot number tracking type. Will still complain if a user attempts to stock new check items that are badly formed.

 User-story: 9247