### PR TITLE
[ADD] udes_stock: Add reserve_pallet functionality for batches

### DIFF
--- a/addons/udes_stock/README.md
+++ b/addons/udes_stock/README.md
@@ -603,6 +603,24 @@ Returns true on success otherwise an error indicating the failure (e.g. the
 batch was not in the `in_progress` state; the batch was not assigned to the
 current user).
 
+### Reserve pallet for batch
+```
+URI: /api/stock-picking-batch/:id/reserve-pallet
+HTTP Method: POST
+```
+Reserves a pallet for use in a batch.
+Fails if the pallet is already reserved for a different batch.
+
+Request:
+
+A JSON object containing:
+
+* @param pallet_name - Barcode of the pallet to be reserved.
+
+Response:
+
+Returns true on success and an error otherwise.
+
 ### Update picking batch
 ```
 URI: /api/stock-picking-batch/:id

--- a/addons/udes_stock/views/stock_picking_batch.xml
+++ b/addons/udes_stock/views/stock_picking_batch.xml
@@ -15,6 +15,7 @@
           <field name="u_ephemeral"/>
           <field name="priority"/>
           <field name="u_location_category_id"/>
+          <field name="u_last_reserved_pallet_name" groups="udes_security.group_trusted_user"/>
         </xpath>
         <xpath expr="//button[@name='action_cancel']" position="replace" />
         <xpath expr="//button[@name='cancel_picking']" position="replace">
@@ -57,6 +58,7 @@
           <field name="picking_type_ids"/>
           <field name="priority"/>
           <field name="u_location_category_id"/>
+          <field name="u_last_reserved_pallet_name" groups="udes_security.group_trusted_user"/>
         </xpath>
         <xpath expr="//group" position="inside">
           <filter name="by_scheduled_date" string="Scheduled Date"


### PR DESCRIPTION
[ADD] udes_stock: Add reserve_pallet functionality for batches

reserve_pallet reserves a single pallet for use in a batch and raises
an error if another batch has already reserved the pallet. Pallets are
automatically considered unreserved once the batch is done or a different
pallet is reserved for the batch.

User-story: 9391

Signed-off-by: Sean Quah <sean.quah@unipart.io>
