### PR TITLE
[FIX] udes_stock: Package hierarchy depth and constaint on the fly

### DIFF
--- a/addons/udes_stock/models/stock_quant_package.py
+++ b/addons/udes_stock/models/stock_quant_package.py
@@ -14,24 +14,37 @@ class StockQuantPackage(models.Model):
     # presented externally, e.g. when a package's (external) barcode format is
     # different to the internal one.
     u_external_name = fields.Char(string="External Name")
-
+    u_top_parent = fields.Many2one(
+        'stock.quant.package', string='Top parent Package', readonly=True,
+        help="Highest level package in this stack", compute='_compute_top_parent')
     u_package_depth = fields.Integer(string="Package Depth",
         help="The maximum number of package levels within a package hierarchy. I.e. 2 would denote a single level of packages (each with no subpackage) within a parent package",
         compute="_compute_package_depth",
-        store=True,
+        store=False,
     )
 
-    @api.constrains('u_package_depth')
-    @api.depends('children_ids.u_package_depth')
-    def _compute_package_depth(self):
+    @api.depends('package_id')
+    def _compute_top_parent(self):
+        """ Finds the top level parent package """
+        for package in self:
+            if package.package_id:
+                package.u_top_parent = package.parent_ids.filtered(lambda p: not p.package_id)
+            else:
+                package.u_top_parent = package
+
+    @api.constrains('package_id')
+    def _check_package_depth(self):
         wh = self.env.user.get_user_warehouse()
         max_package_depth = wh.u_max_package_depth
         for package in self:
-            new_package_depth = max(package.children_ids.mapped('u_package_depth')) + 1 if package.children_ids else 1
-            if new_package_depth != package.u_package_depth:
-                package.u_package_depth = new_package_depth
-            if package.u_package_depth > max_package_depth:
+            patriarch = package.u_top_parent
+            if patriarch.u_package_depth > max_package_depth:
                 raise ValidationError(_("Maximum package depth exceeded."))
+
+    @api.depends('children_ids.u_package_depth')
+    def _compute_package_depth(self):
+        for package in self:
+            package.u_package_depth = max(package.children_ids.mapped('u_package_depth')) + 1 if package.children_ids else 1
 
     def new_package_name(self):
         Sequence = self.env['ir.sequence']

--- a/addons/udes_stock/tests/test_package_hierarchy.py
+++ b/addons/udes_stock/tests/test_package_hierarchy.py
@@ -12,7 +12,7 @@ class TestPackageHierarchy(common.BaseUDES):
         pack_child.package_id = pack_parent.id
         with self.assertRaises(ValidationError) as e:
             pack_parent.package_id = pack_grandparent.id
-            self.assertEqual(e.exception.name, 'Maximum package depth exceeded.')
+        self.assertEqual(e.exception.name, 'Maximum package depth exceeded.')
 
     def test2_max_package_depth_violation_tail(self):
         """Test Non-Branching Maximum Package Depth Tail Insertion"""
@@ -22,7 +22,7 @@ class TestPackageHierarchy(common.BaseUDES):
         pack_child.package_id = pack_parent.id
         with self.assertRaises(ValidationError) as e:
             pack_grandparent.package_id = pack_child.id
-            self.assertEqual(e.exception.name, 'Maximum package depth exceeded.')
+        self.assertEqual(e.exception.name, 'Maximum package depth exceeded.')
 
     def test3_max_package_depth_violation_middle(self):
         """Test Non-Branching Maximum Package Depth Middle Insertion"""
@@ -43,7 +43,7 @@ class TestPackageHierarchy(common.BaseUDES):
         # Increase length of middle child to create 4 level package
         with self.assertRaises(ValidationError) as e:
             pack_middle_child.package_id = pack_child_b.id
-            self.assertEqual(e.exception.name, 'Maximum package depth exceeded.')
+        self.assertEqual(e.exception.name, 'Maximum package depth exceeded.')
 
     def test4_max_package_depth_violation_branch_top(self):
         """Test Branching Maximum Package Depth Top Insertion"""
@@ -68,7 +68,7 @@ class TestPackageHierarchy(common.BaseUDES):
         # Add a 4 level package to grandparent
         with self.assertRaises(ValidationError) as e:
             pack_parent_1.package_id = pack_grandparent.id
-            self.assertEqual(e.exception.name, 'Maximum package depth exceeded.')
+        self.assertEqual(e.exception.name, 'Maximum package depth exceeded.')
 
     def test5_max_package_depth_violation_branch_tail(self):
         """Test Branching Maximum Package Depth Tail Insertion"""
@@ -100,7 +100,7 @@ class TestPackageHierarchy(common.BaseUDES):
         # Add a 5th level to grandparent as inner child
         with self.assertRaises(ValidationError) as e:
             pack_child_1_c.package_id = pack_child_1_a.id
-            self.assertEqual(e.exception.name, 'Maximum package depth exceeded.')
+        self.assertEqual(e.exception.name, 'Maximum package depth exceeded.')
 
     def test6_max_package_depth_violation_branch_middle(self):
         """Test Branching Maximum Package Depth Middle Insertion"""
@@ -135,7 +135,7 @@ class TestPackageHierarchy(common.BaseUDES):
         # Increase length of shorter chain middle child to create 5 level package
         with self.assertRaises(ValidationError) as e:
             pack_middle_child_b.package_id = pack_child_2.id
-            self.assertEqual(e.exception.name, 'Maximum package depth exceeded.')
+        self.assertEqual(e.exception.name, 'Maximum package depth exceeded.')
 
     def test7_max_package_depth_violation_branch_middle(self):
         """Test Adding Child Package To Parent Already Possessing Multiple Children"""
@@ -173,4 +173,4 @@ class TestPackageHierarchy(common.BaseUDES):
         # Add 4 level package to grandparent - 5 level grandparent
         with self.assertRaises(ValidationError) as e:
             pack_parent_2.package_id = pack_grandparent.id
-            self.assertEqual(e.exception.name, 'Maximum package depth exceeded.')
+        self.assertEqual(e.exception.name, 'Maximum package depth exceeded.')


### PR DESCRIPTION
Calculate depth and validate against max package depth on the fly,
instead of storing depth value against packages. (task/9748)