### PR TITLE
[ADD] udes_security: Added 'debug user' group

### DIFF
--- a/addons/udes_security/controllers/redirect.py
+++ b/addons/udes_security/controllers/redirect.py
@@ -1,11 +1,13 @@
 """Open redirect filter"""
 
 import logging
+import werkzeug
 from werkzeug import urls
 from werkzeug.exceptions import BadRequest
 from odoo import http
 from odoo.tools.translate import _
 from odoo.addons.web.controllers import main
+from odoo.http import request
 
 _logger = logging.getLogger(__name__)
 
@@ -50,7 +52,12 @@ class Home(main.Home):
     @http.route()
     @no_absolute_redirect
     def web_client(self, *args, **kwargs):
-        """Prevent absolute redirects on /web"""
+        """Prevent absolute redirects on /web/login,
+           also redirects requests from users without debug rights
+           to non-debug session"""
+        if request.debug and not request.env.user.browse(request.session.uid)\
+            .has_group('udes_security.group_debug_user'):
+                return werkzeug.utils.redirect('/web')
         return super().web_client(*args, **kwargs)
 
     @http.route()

--- a/addons/udes_security/data/res_groups.xml
+++ b/addons/udes_security/data/res_groups.xml
@@ -6,4 +6,9 @@
         <field name="category_id" ref="base.module_category_extra"/>
     </record>
 
+    <record id="group_debug_user" model="res.groups">
+        <field name="name">Debug User</field>
+        <field name="category_id" ref="base.module_category_extra"/>
+    </record>
+
 </odoo>

--- a/addons/udes_security/data/res_users.xml
+++ b/addons/udes_security/data/res_users.xml
@@ -1,7 +1,7 @@
 <odoo>
   <data noupdate="1">
     <record id="base.user_root" model="res.users">
-      <field name="groups_id" eval="[(4, ref('udes_security.group_trusted_user'))]"/>
+      <field name="groups_id" eval="[(4, ref('udes_security.group_trusted_user')), (4, ref('udes_security.group_debug_user'))]"/>
     </record>
   </data>
 </odoo>

--- a/addons/udes_security/models/res_groups.py
+++ b/addons/udes_security/models/res_groups.py
@@ -7,15 +7,22 @@ from odoo.tools.translate import _
 
 _logger = logging.getLogger(__name__)
 
+
+security_groups = [
+    'udes_security.group_trusted_user',
+    'udes_security.group_debug_user',
+]
+
 class Groups(models.Model):
     _inherit = 'res.groups'
 
     @api.multi
     def write(self, values):
-        group_trusted_user = self.env.ref('udes_security.group_trusted_user')
+        for group in security_groups:
+            group_user = self.env.ref(group)
 
-        # Only the root user can add or remove the Trusted User group
-        self._check_is_admin(values, group_trusted_user)
+            # Only the root user can add or remove the Trusted User group
+            self._check_is_admin(values, group_user)
 
         res = super(Groups, self).write(values)
         return res

--- a/addons/udes_security/models/res_users.py
+++ b/addons/udes_security/models/res_users.py
@@ -6,6 +6,8 @@ from odoo.exceptions import AccessError
 from odoo.tools.translate import _
 from odoo.http import root, request
 
+from . import res_groups
+
 _store = root.session_store
 _logger = logging.getLogger(__name__)
 
@@ -41,21 +43,22 @@ class Users(models.Model):
 
     @api.model
     def create(self, values):
-        self._check_trusted_user_grant(values)
+        self._check_user_group_grant(values)
 
         user = super(Users, self).create(values)
         return user
 
     @api.multi
     def write(self, values):
-        self._check_trusted_user_grant(values)
+        self._check_user_group_grant(values)
 
         res = super(Users, self).write(values)
         return res
 
-    def _check_trusted_user_grant(self, values):
-        group_trusted_user = self.env.ref("udes_security.group_trusted_user")
-        self._check_is_admin(values, group_trusted_user)
+    def _check_user_group_grant(self, values):
+        for group in res_groups.security_groups:
+            group_user = self.env.ref(group)
+            self._check_is_admin(values, group_user)
 
     def _check_is_admin(self, values, group):
 

--- a/addons/udes_security/tests/test_trusted_user.py
+++ b/addons/udes_security/tests/test_trusted_user.py
@@ -21,6 +21,8 @@ class TestTrustedUser(common.SavepointCase):
         self.group_access_rights = self.env.ref('base.group_erp_manager')
         self.group_trusted_user = self.env.ref(
                                       'udes_security.group_trusted_user')
+        self.group_debug_user = self.env.ref(
+                                      'udes_security.group_debug_user')
 
         self.user_1 = User.create({
             'name': 'Test User 1',
@@ -32,93 +34,128 @@ class TestTrustedUser(common.SavepointCase):
             'login': 'test_user_2',
         })
 
-    def test01_user_group_add_remove_root(self):
+    def test01_trusted_add_remove_root(self):
         """Test that the admin user can add and remove the Trusted User group"""
-        self.assertNotIn(self.group_trusted_user, self.user_2.groups_id)
+        self._user_group_add_remove_root(self.group_trusted_user)
+
+    def test02_debug_add_remove_root(self):
+        """Test that the admin user can add and remove the Debug User group"""
+        self._user_group_add_remove_root(self.group_debug_user)
+
+    def test03_trusted_add_non_root(self):
+        """Test that a non-admin user cannot add the Trusted User group"""
+        self._user_group_add_non_root(self.group_trusted_user)
+
+    def test04_debug_add_non_root(self):
+        """Test that a non-admin user cannot add the Debug User group"""
+        self._user_group_add_non_root(self.group_debug_user)
+
+    def test05_trusted_remove_non_root(self):
+        """Test that a non-admin user cannot remove the Trusted User group"""
+        self._user_group_remove_non_root(self.group_trusted_user)
+
+    def test06_debug_remove_non_root(self):
+        """Test that a non-admin user cannot remove the Debug User group"""
+        self._user_group_remove_non_root(self.group_debug_user)
+
+    def test07_trusted_add_remove_root(self):
+        """Test that the admin user can add and remove users"""
+        self._group_user_add_remove_root(self.group_trusted_user)
+
+    def test08_debug_add_remove_root(self):
+        """Test that the admin user can add and remove users"""
+        self._group_user_add_remove_root(self.group_debug_user)
+
+    def test09_trusted_add_remove_non_root(self):
+        """Test that a non-admin user cannot modify the Trusted User group's
+        users"""
+        self._group_user_add_remove_non_root(self.group_trusted_user)
+
+    def test10_debug_add_remove_non_root(self):
+        """Test that a non-admin user cannot modify the Debug User group's
+        users"""
+        self._group_user_add_remove_non_root(self.group_debug_user)
+
+    def _user_group_add_remove_root(self, user_group):
+        self.assertNotIn(user_group, self.user_2.groups_id)
 
         # Add group
-        self.user_2.write({ 'groups_id': [(4, self.group_trusted_user.id)] })
-        self.assertIn(self.group_trusted_user, self.user_2.groups_id)
+        self.user_2.write({ 'groups_id': [(4, user_group.id)] })
+        self.assertIn(user_group, self.user_2.groups_id)
 
         # Remove group
-        self.user_2.write({ 'groups_id': [(3, self.group_trusted_user.id)] })
-        self.assertNotIn(self.group_trusted_user, self.user_2.groups_id)
+        self.user_2.write({ 'groups_id': [(3, user_group.id)] })
+        self.assertNotIn(user_group, self.user_2.groups_id)
 
         # Add group via replacement
         self.user_2.write({ 'groups_id':
-                                [(6, 0, [self.group_trusted_user.id])] })
-        self.assertIn(self.group_trusted_user, self.user_2.groups_id)
+                                [(6, 0, [user_group.id])] })
+        self.assertIn(user_group, self.user_2.groups_id)
 
         # Remove group via replacement
         self.user_2.write({ 'groups_id': [(6, 0, [])] })
-        self.assertNotIn(self.group_trusted_user, self.user_2.groups_id)
+        self.assertNotIn(user_group, self.user_2.groups_id)
 
         # Remove all groups
-        self.user_2.write({ 'groups_id': [(4, self.group_trusted_user.id)] })
-        self.assertIn(self.group_trusted_user, self.user_2.groups_id)
+        self.user_2.write({ 'groups_id': [(4, user_group.id)] })
+        self.assertIn(user_group, self.user_2.groups_id)
         self.user_2.write({ 'groups_id': [(5,)] })
-        self.assertNotIn(self.group_trusted_user, self.user_2.groups_id)
+        self.assertNotIn(user_group, self.user_2.groups_id)
 
-    def test02_user_group_add_non_root(self):
-        """Test that a non-admin user cannot add the Trusted User group"""
+    def _user_group_add_non_root(self, user_group):
         user_2 = self.user_2.sudo(self.user_1.id)
-        self.assertNotIn(self.group_trusted_user, user_2.groups_id)
+        self.assertNotIn(user_group, user_2.groups_id)
 
         # Add group
         with self.assertRaises(AccessError):
-            user_2.write({ 'groups_id': [(4, self.group_trusted_user.id)] })
-        self.assertNotIn(self.group_trusted_user, user_2.groups_id)
+            user_2.write({ 'groups_id': [(4, user_group.id)] })
+        self.assertNotIn(user_group, user_2.groups_id)
 
         # Add group via replacement
         with self.assertRaises(AccessError):
             user_2.write({ 'groups_id':
-                               [(6, 0, [self.group_trusted_user.id])] })
-        self.assertNotIn(self.group_trusted_user, user_2.groups_id)
+                               [(6, 0, [user_group.id])] })
+        self.assertNotIn(user_group, user_2.groups_id)
 
-    def test03_user_group_remove_non_root(self):
-        """Test that a non-admin user cannot remove the Trusted User group"""
-        self.user_2.write({ 'groups_id': [(4, self.group_trusted_user.id)] })
+    def _user_group_remove_non_root(self, user_group):
+        self.user_2.write({ 'groups_id': [(4, user_group.id)] })
 
         user_2 = self.user_2.sudo(self.user_1.id)
-        self.assertIn(self.group_trusted_user, user_2.groups_id)
+        self.assertIn(user_group, user_2.groups_id)
 
         # Remove group
         with self.assertRaises(AccessError):
-            user_2.write({ 'groups_id': [(3, self.group_trusted_user.id)] })
-        self.assertIn(self.group_trusted_user, user_2.groups_id)
+            user_2.write({ 'groups_id': [(3, user_group.id)] })
+        self.assertIn(user_group, user_2.groups_id)
 
         # Replacement no-op
         user_2.write({ 'groups_id': [(6, 0, user_2.groups_id.ids)] })
-        self.assertIn(self.group_trusted_user, user_2.groups_id)
+        self.assertIn(user_group, user_2.groups_id)
 
         # Remove group via replacement
         with self.assertRaises(AccessError):
             user_2.write({ 'groups_id': [(6, 0, [])] })
-        self.assertIn(self.group_trusted_user, user_2.groups_id)
+        self.assertIn(user_group, user_2.groups_id)
 
         # Remove all groups
         with self.assertRaises(AccessError):
             user_2.write({ 'groups_id': [(5,)] })
-        self.assertIn(self.group_trusted_user, user_2.groups_id)
+        self.assertIn(user_group, user_2.groups_id)
 
-    def test04_group_user_add_remove_root(self):
-        """Test that the admin user can add and remove users"""
-        self._test_group_user_add_remove(self.env.user,
-                                         self.group_trusted_user, self.user_2)
+    def _group_user_add_remove_root(self, user_group):
+        self._test_group_user_add_remove(self.env.user, user_group, self.user_2)
 
-    def test05_group_user_add_remove_non_root(self):
-        """Test that a non-admin user cannot modify the Trusted User group's
-        users"""
+    def _group_user_add_remove_non_root(self, user_group):
         # Check that user_1 can modify the users of a different group
         self._test_group_user_add_remove(self.user_1,
                                          self.group_access_rights, self.user_2)
 
-        # Check that user_1 cannot modify the users of the Trusted User group
-        group_trusted_user = self.group_trusted_user.sudo(self.user_1.id)
+        # Check that user_1 cannot modify the users of the User group
+        group_user = user_group.sudo(self.user_1.id)
         for act in [(4, self.user_2.id), (3, self.user_2.id), (5,), (6, 0, [])]:
             with self.assertRaises(AccessError):
-                group_trusted_user.sudo(self.user_1.id).write({ 'users': [act] })
-            self.assertNotIn(self.user_2, group_trusted_user.users)
+                group_user.sudo(self.user_1.id).write({ 'users': [act] })
+            self.assertNotIn(self.user_2, group_user.users)
 
     def _test_group_user_add_remove(self, user, test_group, test_user):
         """Test that user can modify test_group's users"""


### PR DESCRIPTION
Added a 'debug user' group that can only be added to by the main admin user, similarly to the 'trusted user' group. Only users in the 'debug user' group can user debug mode. If a user outside of this group tries to use any form of debug mode they will be redirected to a version of the page without debug mode enabled.

Story/9774

Signed-off-by: Adam Patrick <adam.patrick@unipart.io>