### PR TITLE
{IMP] udes_load_testing: recommend running _report in tearDown

### DIFF
--- a/addons/udes_load_testing/README.md
+++ b/addons/udes_load_testing/README.md
@@ -50,6 +50,6 @@ This will then add the time it took too run your method into a file called `<cla
 N.B: files will be appended.
 The filename can be specified directly by setting the _filename attribute before calling `super().setUpClass()`
 
-If you wish to view your results in an ASCII plot, call the `_report` method - this should be done in another test
+If you wish to view your results in an ASCII plot, call the `_report` method - this should be done in the TestCase's `tearDown` method
 When using `parameterized`.
 


### PR DESCRIPTION
User-story/9878
Task/9985

Signed-off-by: Kevin Dwyer <kevin.dwyer@unipart.io>

Calling `_report()` in a test method means that it gets counted as a test,
and triggers the class's `setUp()` method.  Recommend that it be called
in the class's `tearDown` method instead.