### PR TITLE
[IMP] udes_stock: remove dotted name in domain

### DIFF
--- a/addons/udes_stock/models/stock_move_line.py
+++ b/addons/udes_stock/models/stock_move_line.py
@@ -1060,6 +1060,8 @@ class StockMoveLine(models.Model):
     def _check_resultant_package_level(self):
         MoveLine = self.env["stock.move.line"]
         # Collect move lines with packages related to those being checked which are in progress
+        if not self.mapped("result_package_id"):
+            return
         package_ids = self.mapped("result_package_id") | self.mapped("u_result_parent_package_id")
         package_mls = MoveLine.search(
             [

--- a/addons/udes_stock/models/stock_picking.py
+++ b/addons/udes_stock/models/stock_picking.py
@@ -1941,7 +1941,7 @@ class StockPicking(models.Model):
             # remove locations which are already used in move lines
             valid_locations -= MoveLines.search(
                 [
-                    ("picking_id.state", "=", "assigned"),
+                    ("state", "=", "assigned"),
                     ("location_dest_id", "in", valid_locations.ids),
                 ]
             ).mapped("location_dest_id")


### PR DESCRIPTION
User-story/9977
Task/10018

Signed-off-by: Kevin Dwyer <kevin.dwyer@unipart.io>

MoveLines has its own state attribute, it doesn't need to get it via
picking_id.