### PR TITLE
[FIX] udes_stock: Handle newID at stock.picking.batch computed fields

### DIFF
--- a/addons/udes_stock/models/stock_picking_batch.py
+++ b/addons/udes_stock/models/stock_picking_batch.py
@@ -112,7 +112,7 @@ class StockPickingBatch(models.Model):
         for batch in self:
             if batch.picking_ids:
                 batch.picking_type_ids = batch.picking_ids.mapped('picking_type_id')
-            else:
+            elif not isinstance(batch.id, models.NewId):
                 # If the picking ids are empty use the stored picking type ids
                 batch.picking_type_ids = batch.read(['picking_type_ids'])[0]['picking_type_ids']
 
@@ -130,7 +130,9 @@ class StockPickingBatch(models.Model):
     def _compute_priority(self):
         for batch in self:
             # Get the old priority of the batch
-            old_priority = batch.read(['priority'])[0]['priority']
+            old_priority = False
+            if not isinstance(batch.id, models.NewId):
+                old_priority = batch.read(['priority'])[0]['priority']
             if batch.mapped('picking_ids'):
                 priorities = batch.mapped('picking_ids.priority')
                 new_priority = max(priorities)


### PR DESCRIPTION
Priority and picking_type_ids are computed from the pickings inside
the batch. A change was made in a previous commit to preserve their
value in case all the pickings of the batch were removed from it.
When the id of the batch is newID it shouldn't try to preserve it.
