### PR TITLE
[FIX] udes_stock: Store u_top_parent

### DIFF
--- a/addons/udes_stock/models/stock_quant_package.py
+++ b/addons/udes_stock/models/stock_quant_package.py
@@ -15,7 +15,7 @@ class StockQuantPackage(models.Model):
     # different to the internal one.
     u_external_name = fields.Char(string="External Name")
     u_top_parent = fields.Many2one(
-        'stock.quant.package', string='Top parent Package', readonly=True,
+        'stock.quant.package', string='Top parent Package', readonly=True, store=True,
         help="Highest level package in this stack", compute='_compute_top_parent')
     u_package_depth = fields.Integer(string="Package Depth",
         help="The maximum number of package levels within a package hierarchy. I.e. 2 would denote a single level of packages (each with no subpackage) within a parent package",


### PR DESCRIPTION
When not stored can cause issues on action_done() when removing a
package from its parent package since it is recomputing the packages
depths which ends up calling _check_not_multi_location().
Having it stored prevents the check to happen when recomputing the
packages depths.
