### PR TITLE
User-story: 10074 - Confirm orders in batches and committing

### DIFF
--- a/addons/udes_sale_stock/__manifest__.py
+++ b/addons/udes_sale_stock/__manifest__.py
@@ -21,6 +21,7 @@
         'security/ir.model.access.csv',
         'security/udes_sale_stock_security.xml',
         'data/stock_config.xml',
+        'data/ir_cron.xml',
         'views/sale_order_views.xml',
         'views/stock_warehouse.xml',
         'views/res_users_views.xml',

--- a/addons/udes_sale_stock/data/ir_cron.xml
+++ b/addons/udes_sale_stock/data/ir_cron.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<odoo>
+    <data noupdate="1">
+
+        <!-- Confirm Sale Orders -->
+        <record id="confirm_sale_orders" model="ir.cron">
+          <field name="name">Confirm Orders</field>
+            <field name="active" eval="False" />
+            <field name="user_id" ref="base.user_root" />
+            <field name="interval_number">15</field>
+            <field name="interval_type">minutes</field>
+            <field name="numbercall">-1</field>
+            <field name="doall">0</field>
+            <field name="model_id" ref="udes_sale_stock.model_sale_order" />
+            <field name="state">code</field>
+            <field name="code">model.confirm_orders()</field>
+        </record>
+
+	</data>
+</odoo>


### PR DESCRIPTION
* Add confirm_orders() method to sale order so that they are confirmed in batches and committing after each batch to give visibility.

* Add cron job to execute confirm orders but disabled.
