### PR TITLE
[ADD] udes_security: Add inactive_session_time_out_enabled system parameter

### DIFF
--- a/addons/udes_security/__manifest__.py
+++ b/addons/udes_security/__manifest__.py
@@ -17,6 +17,7 @@ Security enhancements used by UDES
     'data': [
         'views/res_users_views.xml',
         'data/auth_brute_force.xml',
+        'data/ir_config_parameter_data.xml',
         'data/res_groups.xml',
         'data/res_users.xml',
     ]

--- a/addons/udes_security/data/ir_config_parameter_data.xml
+++ b/addons/udes_security/data/ir_config_parameter_data.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+
+<odoo noupdate="1">
+  <record id="inactive_session_time_out_enabled" model="ir.config_parameter">
+    <field name="key">inactive_session_time_out_enabled</field>
+    <field name="value">True</field>
+  </record>
+</odoo>

--- a/addons/udes_security/models/res_users.py
+++ b/addons/udes_security/models/res_users.py
@@ -99,3 +99,23 @@ class Users(models.Model):
                     )
                     % group.name
                 )
+
+    @api.model_cr_context
+    def _auth_timeout_enabled(self):
+        """ Pluggable method to check if session timeout is enabled """
+        IrConfigParameter = self.env["ir.config_parameter"]
+        
+        auth_timeout_enabled_parameter = IrConfigParameter.get_param(
+            "inactive_session_time_out_enabled"
+        )
+        return auth_timeout_enabled_parameter == "True"
+
+    @api.model
+    def _auth_timeout_check(self):
+        """ Override to not carry out timeout check if system parameter is disabled """
+        auth_timeout_enabled = self._auth_timeout_enabled()
+
+        if not auth_timeout_enabled:
+            return
+        else:
+            return super(Users, self)._auth_timeout_check()


### PR DESCRIPTION
Added system parameter "inactive_session_time_out_enabled" to allow the timeout check in auth_session_timeout to be disabled.

Story/9964

Signed-off-by: Peter Clark <peter.clark@unipart.io>