### PR TITLE
Story/9770 - Blocked file type filtering

### DIFF
--- a/addons/udes_security/__manifest__.py
+++ b/addons/udes_security/__manifest__.py
@@ -15,6 +15,7 @@ Security enhancements used by UDES
         "views/res_users_views.xml",
         "views/webclient_templates.xml",
         "data/auth_brute_force.xml",
+        "data/blocked_file_type_data.xml",
         "data/ir_config_parameter_data.xml",
         "data/res_groups.xml",
         "data/res_users.xml",

--- a/addons/udes_security/__manifest__.py
+++ b/addons/udes_security/__manifest__.py
@@ -1,27 +1,22 @@
 # pylint: disable=missing-docstring,pointless-statement
 {
-    'name': "UDES Security",
-    'summary': "UDES security enhancements",
-    'description': """
+    "name": "UDES Security",
+    "summary": "UDES security enhancements",
+    "description": """
 Security enhancements used by UDES
 ==================================
 """,
-    'version': '0.1',
-    'depends': [
-        'web',
-        'password_security',
-        'auth_brute_force',
-        'auth_session_timeout',
+    "version": "0.1",
+    "depends": ["web", "password_security", "auth_brute_force", "auth_session_timeout"],
+    "category": "Authentication",
+    "data": [
+        "security/ir.model.access.csv",
+        "views/blocked_file_type_views.xml",
+        "views/res_users_views.xml",
+        "views/webclient_templates.xml",
+        "data/auth_brute_force.xml",
+        "data/ir_config_parameter_data.xml",
+        "data/res_groups.xml",
+        "data/res_users.xml",
     ],
-    'category': "Authentication",
-    'data': [
-        'security/ir.model.access.csv',
-        'views/blocked_file_type_views.xml',
-        'views/res_users_views.xml',
-        'views/webclient_templates.xml',
-        'data/auth_brute_force.xml',
-        'data/ir_config_parameter_data.xml',
-        'data/res_groups.xml',
-        'data/res_users.xml',
-    ]
 }

--- a/addons/udes_security/__manifest__.py
+++ b/addons/udes_security/__manifest__.py
@@ -15,7 +15,10 @@ Security enhancements used by UDES
     ],
     'category': "Authentication",
     'data': [
+        'security/ir.model.access.csv',
+        'views/blocked_file_type_views.xml',
         'views/res_users_views.xml',
+        'views/webclient_templates.xml',
         'data/auth_brute_force.xml',
         'data/ir_config_parameter_data.xml',
         'data/res_groups.xml',

--- a/addons/udes_security/controllers/__init__.py
+++ b/addons/udes_security/controllers/__init__.py
@@ -1,3 +1,4 @@
 """UDES security enhancement controllers"""
 
+from . import main
 from . import redirect

--- a/addons/udes_security/controllers/main.py
+++ b/addons/udes_security/controllers/main.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+
+import json
+import logging
+
+from odoo import http, SUPERUSER_ID, _
+from odoo.http import request
+from odoo.exceptions import UserError
+
+from odoo.addons.web.controllers.main import Binary, serialize_exception
+
+_logger = logging.getLogger(__name__)
+
+
+class BinaryExtension(Binary):
+    def _get_file_type(self, filename):
+        """Extract the file type from the filename by returning value
+           after the last '.' character"""
+        return filename.split(".")[-1].lower()
+
+    def _get_file_type_blocked(self, file_type):
+        """Return true if the file type is blocked, otherwise false"""
+        BlockedFileType = request.env["udes.blocked_file_type"].sudo()
+
+        search_args = [("name", "=", file_type)]
+        blocked_file_type_count = BlockedFileType.search_count(search_args)
+
+        return bool(blocked_file_type_count)
+
+    def _get_file_type_blocked_error_message(self, file_type):
+        """Return an error message stating that the file type has been blocked"""
+        return _("File type '%s' has been blocked by system administrator." % (file_type))
+
+    def _log_user_file_action_blocked(self, action, filename, user_id):
+        """Log a message when a user is blocked trying to upload/download a file"""
+        ResUsers = request.env["res.users"].sudo()
+
+        user = ResUsers.browse(user_id)
+
+        message = "Blocked attempt to %s file '%s' by user '%s'" % (action, filename, user.login)
+        _logger.info(message)
+
+        return True
+
+    @http.route(
+        [
+            "/web/content",
+            "/web/content/<string:xmlid>",
+            "/web/content/<string:xmlid>/<string:filename>",
+            "/web/content/<int:id>",
+            "/web/content/<int:id>/<string:filename>",
+            "/web/content/<int:id>-<string:unique>",
+            "/web/content/<int:id>-<string:unique>/<string:filename>",
+            "/web/content/<string:model>/<int:id>/<string:field>",
+            "/web/content/<string:model>/<int:id>/<string:field>/<string:filename>",
+        ],
+        type="http",
+        auth="public",
+    )
+    def content_common(
+        self,
+        xmlid=None,
+        model="ir.attachment",
+        id=None,
+        field="datas",
+        filename=None,
+        filename_field="datas_fname",
+        unique=None,
+        mimetype=None,
+        download=None,
+        data=None,
+        token=None,
+        access_token=None,
+        **kw
+    ):
+        """Override to prevent non-admin users from downloading blocked file types"""
+        user_id = request.session.uid
+
+        if user_id != SUPERUSER_ID:
+            # Check if the file type is blocked
+            if download:
+                record_filename = ""
+
+                if filename:
+                    record_filename = filename
+                elif id and model and filename_field:
+                    RecordModel = request.env[model].sudo()
+                    record = RecordModel.browse(id)
+                    record_filename = record[filename_field]
+
+                file_type = self._get_file_type(record_filename)
+                file_type_blocked = self._get_file_type_blocked(file_type)
+
+                # If the user is trying to download a blocked file type then
+                # prevent download and return an error message
+                if file_type_blocked:
+                    self._log_user_file_action_blocked("download", record_filename, user_id)
+
+                    download_error = {
+                        "message": "Unable to download file: File type blocked",
+                        "data": {"debug": self._get_file_type_blocked_error_message(file_type),},
+                    }
+
+                    return request.make_response((json.dumps(download_error)))
+
+        return super(BinaryExtension, self).content_common(
+            xmlid,
+            model,
+            id,
+            field,
+            filename,
+            filename_field,
+            unique,
+            mimetype,
+            download,
+            data,
+            token,
+            access_token,
+            **kw
+        )
+
+    @http.route("/web/binary/upload_attachment", type="http", auth="user")
+    @serialize_exception
+    def upload_attachment(self, callback, model, id, ufile):
+        """Override to prevent non-admin users from uploading blocked file types"""
+        user_id = request.session.uid
+        files = request.httprequest.files.getlist("ufile")
+
+        if user_id != SUPERUSER_ID:
+            for upload_file in files:
+                filename = upload_file.filename
+
+                if upload_file and filename:
+                    file_type = self._get_file_type(filename)
+                    file_type_blocked = self._get_file_type_blocked(file_type)
+
+                    # If the user is trying to upload a blocked file type then
+                    # prevent upload and return an error message
+                    if file_type_blocked:
+                        self._log_user_file_action_blocked("upload", filename, user_id)
+
+                        out = """<script language="javascript" type="text/javascript">
+                                    var win = window.top.window;
+                                    win.jQuery(win).trigger(%s, %s);
+                                </script>"""
+
+                        args = [{"error": self._get_file_type_blocked_error_message(file_type)}]
+
+                        return out % (json.dumps(callback), json.dumps(args))
+
+        return super(BinaryExtension, self).upload_attachment(callback, model, id, ufile)

--- a/addons/udes_security/data/blocked_file_type_data.xml
+++ b/addons/udes_security/data/blocked_file_type_data.xml
@@ -1,0 +1,1037 @@
+<?xml version="1.0"?>
+
+<odoo noupdate="1">
+
+  <record id="udes_blocked_file_type_action" model="udes.blocked_file_type">
+    <field name="name">action</field>
+    <field name="description">Automator Action</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_apk" model="udes.blocked_file_type">
+    <field name="name">apk</field>
+    <field name="description">Application</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_app" model="udes.blocked_file_type">
+    <field name="name">app</field>
+    <field name="description">Executable</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_bat" model="udes.blocked_file_type">
+    <field name="name">bat</field>
+    <field name="description">Batch File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_bin" model="udes.blocked_file_type">
+    <field name="name">bin</field>
+    <field name="description">Binary Executable</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_cmd" model="udes.blocked_file_type">
+    <field name="name">cmd</field>
+    <field name="description">Command Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_com" model="udes.blocked_file_type">
+    <field name="name">com</field>
+    <field name="description">Command File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_command" model="udes.blocked_file_type">
+    <field name="name">command</field>
+    <field name="description">Terminal Command</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_cpl" model="udes.blocked_file_type">
+    <field name="name">cpl</field>
+    <field name="description">Control Panel Extension</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_csh" model="udes.blocked_file_type">
+    <field name="name">csh</field>
+    <field name="description">C Shell Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_exe" model="udes.blocked_file_type">
+    <field name="name">exe</field>
+    <field name="description">Executable</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_gadget" model="udes.blocked_file_type">
+    <field name="name">gadget</field>
+    <field name="description">Windows Gadget</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_inf1" model="udes.blocked_file_type">
+    <field name="name">inf1</field>
+    <field name="description">Setup Information File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_ins" model="udes.blocked_file_type">
+    <field name="name">ins</field>
+    <field name="description">Internet Communication Settings</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_inx" model="udes.blocked_file_type">
+    <field name="name">inx</field>
+    <field name="description">InstallShield Compiled Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_ipa" model="udes.blocked_file_type">
+    <field name="name">ipa</field>
+    <field name="description">Application</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_isu" model="udes.blocked_file_type">
+    <field name="name">isu</field>
+    <field name="description">InstallShield Uninstaller Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_job" model="udes.blocked_file_type">
+    <field name="name">job</field>
+    <field name="description">Windows Task Scheduler Job File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_jse" model="udes.blocked_file_type">
+    <field name="name">jse</field>
+    <field name="description">JScript Encoded File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_ksh" model="udes.blocked_file_type">
+    <field name="name">ksh</field>
+    <field name="description">Unix Korn Shell Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_lnk" model="udes.blocked_file_type">
+    <field name="name">lnk</field>
+    <field name="description">File Shortcut</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_msc" model="udes.blocked_file_type">
+    <field name="name">msc</field>
+    <field name="description">Microsoft Common Console Document</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_msi" model="udes.blocked_file_type">
+    <field name="name">msi</field>
+    <field name="description">Windows Installer Package</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_msp" model="udes.blocked_file_type">
+    <field name="name">msp</field>
+    <field name="description">Windows Installer Patch</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_mst" model="udes.blocked_file_type">
+    <field name="name">mst</field>
+    <field name="description">Windows Installer Setup Transform File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_osx" model="udes.blocked_file_type">
+    <field name="name">osx</field>
+    <field name="description">Executable</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_out" model="udes.blocked_file_type">
+    <field name="name">out</field>
+    <field name="description">Executable</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_paf" model="udes.blocked_file_type">
+    <field name="name">paf</field>
+    <field name="description">Portable Application Installer File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_pif" model="udes.blocked_file_type">
+    <field name="name">pif</field>
+    <field name="description">Program Information File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_prg" model="udes.blocked_file_type">
+    <field name="name">prg</field>
+    <field name="description">Executable</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_ps1" model="udes.blocked_file_type">
+    <field name="name">ps1</field>
+    <field name="description">Windows PowerShell Cmdlet</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_reg" model="udes.blocked_file_type">
+    <field name="name">reg</field>
+    <field name="description">Registry Data File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_rgs" model="udes.blocked_file_type">
+    <field name="name">rgs</field>
+    <field name="description">Registry Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_run" model="udes.blocked_file_type">
+    <field name="name">run</field>
+    <field name="description">Executable</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_scr" model="udes.blocked_file_type">
+    <field name="name">scr</field>
+    <field name="description">Screensaver Executable</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_sct" model="udes.blocked_file_type">
+    <field name="name">sct</field>
+    <field name="description">Windows Scriptlet</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_shb" model="udes.blocked_file_type">
+    <field name="name">shb</field>
+    <field name="description">Windows Document Shortcut</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_shs" model="udes.blocked_file_type">
+    <field name="name">shs</field>
+    <field name="description">Shell Scrap Object</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_u3p" model="udes.blocked_file_type">
+    <field name="name">u3p</field>
+    <field name="description">U3 Smart Application</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_vb" model="udes.blocked_file_type">
+    <field name="name">vb</field>
+    <field name="description">VBScript File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_vbe" model="udes.blocked_file_type">
+    <field name="name">vbe</field>
+    <field name="description">VBScript Encoded Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_vbs" model="udes.blocked_file_type">
+    <field name="name">vbs</field>
+    <field name="description">VBScript File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_vbscript" model="udes.blocked_file_type">
+    <field name="name">vbscript</field>
+    <field name="description">Visual Basic Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_workflow" model="udes.blocked_file_type">
+    <field name="name">workflow</field>
+    <field name="description">Automator Workflow</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_ws" model="udes.blocked_file_type">
+    <field name="name">ws</field>
+    <field name="description">Windows Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_wsf" model="udes.blocked_file_type">
+    <field name="name">wsf</field>
+    <field name="description">Windows Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_wsh" model="udes.blocked_file_type">
+    <field name="name">wsh</field>
+    <field name="description">Windows Script Preference</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_0xe" model="udes.blocked_file_type">
+    <field name="name">0xe</field>
+    <field name="description">Renamed Virus File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_73k" model="udes.blocked_file_type">
+    <field name="name">73k</field>
+    <field name="description">TI-73 Application</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_89k" model="udes.blocked_file_type">
+    <field name="name">89k</field>
+    <field name="description">TI-89 Application</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_a6p" model="udes.blocked_file_type">
+    <field name="name">a6p</field>
+    <field name="description">Authorware 6 Program File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_ac" model="udes.blocked_file_type">
+    <field name="name">ac</field>
+    <field name="description">GNU Autoconf Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_acc" model="udes.blocked_file_type">
+    <field name="name">acc</field>
+    <field name="description">GEM Accessory File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_acr" model="udes.blocked_file_type">
+    <field name="name">acr</field>
+    <field name="description">ACRobot Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_actm" model="udes.blocked_file_type">
+    <field name="name">actm</field>
+    <field name="description">AutoCAD Action Macro</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_ahk" model="udes.blocked_file_type">
+    <field name="name">ahk</field>
+    <field name="description">AutoHotkey Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_air" model="udes.blocked_file_type">
+    <field name="name">air</field>
+    <field name="description">Adobe AIR Installation Package</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_app" model="udes.blocked_file_type">
+    <field name="name">app</field>
+    <field name="description">FoxPro Application</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_arscript" model="udes.blocked_file_type">
+    <field name="name">arscript</field>
+    <field name="description">ArtRage Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_as" model="udes.blocked_file_type">
+    <field name="name">as</field>
+    <field name="description">Adobe Flash ActionScript File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_asb" model="udes.blocked_file_type">
+    <field name="name">asb</field>
+    <field name="description">Alphacam Stone VB Macro</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_awk" model="udes.blocked_file_type">
+    <field name="name">awk</field>
+    <field name="description">AWK Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_azw2" model="udes.blocked_file_type">
+    <field name="name">azw2</field>
+    <field name="description">Kindle Active Content App File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_beam" model="udes.blocked_file_type">
+    <field name="name">beam</field>
+    <field name="description">Compiled Erlang File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_btm" model="udes.blocked_file_type">
+    <field name="name">btm</field>
+    <field name="description">4DOS Batch File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_cel" model="udes.blocked_file_type">
+    <field name="name">cel</field>
+    <field name="description">Celestia Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_celx" model="udes.blocked_file_type">
+    <field name="name">celx</field>
+    <field name="description">Celestia Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_chm" model="udes.blocked_file_type">
+    <field name="name">chm</field>
+    <field name="description">Compiled HTML Help File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_cof" model="udes.blocked_file_type">
+    <field name="name">cof</field>
+    <field name="description">MPLAB COFF File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_crt" model="udes.blocked_file_type">
+    <field name="name">crt</field>
+    <field name="description">Security Certificate</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_dek" model="udes.blocked_file_type">
+    <field name="name">dek</field>
+    <field name="description">Eavesdropper Batch File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_dld" model="udes.blocked_file_type">
+    <field name="name">dld</field>
+    <field name="description">EdLog Compiled Program</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_dmc" model="udes.blocked_file_type">
+    <field name="name">dmc</field>
+    <field name="description">Medical Manager Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_docm" model="udes.blocked_file_type">
+    <field name="name">docm</field>
+    <field name="description">Word Macro-Enabled Document</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_dotm" model="udes.blocked_file_type">
+    <field name="name">dotm</field>
+    <field name="description">Word Macro-Enabled Template</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_dxl" model="udes.blocked_file_type">
+    <field name="name">dxl</field>
+    <field name="description">Rational DOORS Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_ear" model="udes.blocked_file_type">
+    <field name="name">ear</field>
+    <field name="description">Java Enterprise Archive File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_ebm" model="udes.blocked_file_type">
+    <field name="name">ebm</field>
+    <field name="description">EXTRA! Basic Macro</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_ebs" model="udes.blocked_file_type">
+    <field name="name">ebs</field>
+    <field name="description">E-Run 1.x Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_ebs2" model="udes.blocked_file_type">
+    <field name="name">ebs2</field>
+    <field name="description">E-Run 2.0 Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_ecf" model="udes.blocked_file_type">
+    <field name="name">ecf</field>
+    <field name="description">SageCRM Component File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_eham" model="udes.blocked_file_type">
+    <field name="name">eham</field>
+    <field name="description">ExtraHAM Executable</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_elf" model="udes.blocked_file_type">
+    <field name="name">elf</field>
+    <field name="description">Nintendo Wii Game File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_es" model="udes.blocked_file_type">
+    <field name="name">es</field>
+    <field name="description">SageCRM Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_ex4" model="udes.blocked_file_type">
+    <field name="name">ex4</field>
+    <field name="description">MetaTrader Program File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_exopc" model="udes.blocked_file_type">
+    <field name="name">exopc</field>
+    <field name="description">ExoPC Application</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_ezs" model="udes.blocked_file_type">
+    <field name="name">ezs</field>
+    <field name="description">EZ-R Stats Batch Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_fas" model="udes.blocked_file_type">
+    <field name="name">fas</field>
+    <field name="description">Compiled Fast-Load AutoLISP File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_fky" model="udes.blocked_file_type">
+    <field name="name">fky</field>
+    <field name="description">FoxPro Macro</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_fpi" model="udes.blocked_file_type">
+    <field name="name">fpi</field>
+    <field name="description">FPS Creator Intelligence Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_frs" model="udes.blocked_file_type">
+    <field name="name">frs</field>
+    <field name="description">Flash Renamer Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_fxp" model="udes.blocked_file_type">
+    <field name="name">fxp</field>
+    <field name="description">FoxPro Compiled Program</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_gs" model="udes.blocked_file_type">
+    <field name="name">gs</field>
+    <field name="description">Geosoft Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_ham" model="udes.blocked_file_type">
+    <field name="name">ham</field>
+    <field name="description">HAM Executable</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_hms" model="udes.blocked_file_type">
+    <field name="name">hms</field>
+    <field name="description">HostMonitor Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_hpf" model="udes.blocked_file_type">
+    <field name="name">hpf</field>
+    <field name="description">HP9100A Program File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_hta" model="udes.blocked_file_type">
+    <field name="name">hta</field>
+    <field name="description">HTML Application</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_iim" model="udes.blocked_file_type">
+    <field name="name">iim</field>
+    <field name="description">iMacro Macro</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_ipf" model="udes.blocked_file_type">
+    <field name="name">ipf</field>
+    <field name="description">SMS Installer Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_isp" model="udes.blocked_file_type">
+    <field name="name">isp</field>
+    <field name="description">Internet Communication Settings</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_jar" model="udes.blocked_file_type">
+    <field name="name">jar</field>
+    <field name="description">Java Archive</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_js" model="udes.blocked_file_type">
+    <field name="name">js</field>
+    <field name="description">JScript Executable Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_jsx" model="udes.blocked_file_type">
+    <field name="name">jsx</field>
+    <field name="description">ExtendScript Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_kix" model="udes.blocked_file_type">
+    <field name="name">kix</field>
+    <field name="description">KiXtart Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_lo" model="udes.blocked_file_type">
+    <field name="name">lo</field>
+    <field name="description">Interleaf Compiled Lisp File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_ls" model="udes.blocked_file_type">
+    <field name="name">ls</field>
+    <field name="description">LightWave LScript File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_mam" model="udes.blocked_file_type">
+    <field name="name">mam</field>
+    <field name="description">Access Macro-Enabled Workbook</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_mcr" model="udes.blocked_file_type">
+    <field name="name">mcr</field>
+    <field name="description">3ds Max Macroscript or Tecplot Macro</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_mel" model="udes.blocked_file_type">
+    <field name="name">mel</field>
+    <field name="description">Maya Embedded Language File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_mpx" model="udes.blocked_file_type">
+    <field name="name">mpx</field>
+    <field name="description">FoxPro Compiled Menu Program</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_mrc" model="udes.blocked_file_type">
+    <field name="name">mrc</field>
+    <field name="description">mIRC Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_ms" model="udes.blocked_file_type">
+    <field name="name">ms</field>
+    <field name="description">3ds Max Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_ms" model="udes.blocked_file_type">
+    <field name="name">ms</field>
+    <field name="description">Maxwell Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_mxe" model="udes.blocked_file_type">
+    <field name="name">mxe</field>
+    <field name="description">Macro Express Playable Macro</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_nexe" model="udes.blocked_file_type">
+    <field name="name">nexe</field>
+    <field name="description">Chrome Native Client Executable</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_obs" model="udes.blocked_file_type">
+    <field name="name">obs</field>
+    <field name="description">ObjectScript Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_ore" model="udes.blocked_file_type">
+    <field name="name">ore</field>
+    <field name="description">Ore Executable</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_otm" model="udes.blocked_file_type">
+    <field name="name">otm</field>
+    <field name="description">Outlook Macro</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_pex" model="udes.blocked_file_type">
+    <field name="name">pex</field>
+    <field name="description">ProBoard Executable</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_plx" model="udes.blocked_file_type">
+    <field name="name">plx</field>
+    <field name="description">Perl Executable</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_potm" model="udes.blocked_file_type">
+    <field name="name">potm</field>
+    <field name="description">PowerPoint Macro-Enabled Design Template</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_ppam" model="udes.blocked_file_type">
+    <field name="name">ppam</field>
+    <field name="description">PowerPoint Macro-Enabled Add-in</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_ppsm" model="udes.blocked_file_type">
+    <field name="name">ppsm</field>
+    <field name="description">PowerPoint Macro-Enabled Slide Show</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_pptm" model="udes.blocked_file_type">
+    <field name="name">pptm</field>
+    <field name="description">PowerPoint Macro-Enabled Presentation</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_prc" model="udes.blocked_file_type">
+    <field name="name">prc</field>
+    <field name="description">Palm Resource Code File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_pvd" model="udes.blocked_file_type">
+    <field name="name">pvd</field>
+    <field name="description">Instalit Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_pwc" model="udes.blocked_file_type">
+    <field name="name">pwc</field>
+    <field name="description">PictureTaker File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_pyc" model="udes.blocked_file_type">
+    <field name="name">pyc</field>
+    <field name="description">Python Compiled File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_pyo" model="udes.blocked_file_type">
+    <field name="name">pyo</field>
+    <field name="description">Python Optimized Code</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_qpx" model="udes.blocked_file_type">
+    <field name="name">qpx</field>
+    <field name="description">FoxPro Compiled Query Program</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_rbx" model="udes.blocked_file_type">
+    <field name="name">rbx</field>
+    <field name="description">Rembo-C Compiled Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_rox" model="udes.blocked_file_type">
+    <field name="name">rox</field>
+    <field name="description">Actuate Report Object Executable</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_rpj" model="udes.blocked_file_type">
+    <field name="name">rpj</field>
+    <field name="description">Real Pac Batch Job File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_s2a" model="udes.blocked_file_type">
+    <field name="name">s2a</field>
+    <field name="description">SEAL2 Application</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_sbs" model="udes.blocked_file_type">
+    <field name="name">sbs</field>
+    <field name="description">SPSS Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_sca" model="udes.blocked_file_type">
+    <field name="name">sca</field>
+    <field name="description">Scala Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_scar" model="udes.blocked_file_type">
+    <field name="name">scar</field>
+    <field name="description">SCAR Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_scb" model="udes.blocked_file_type">
+    <field name="name">scb</field>
+    <field name="description">Scala Published Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_script" model="udes.blocked_file_type">
+    <field name="name">script</field>
+    <field name="description">Generic Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_smm" model="udes.blocked_file_type">
+    <field name="name">smm</field>
+    <field name="description">Ami Pro Macro</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_spr" model="udes.blocked_file_type">
+    <field name="name">spr</field>
+    <field name="description">FoxPro Generated Screen File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_tcp" model="udes.blocked_file_type">
+    <field name="name">tcp</field>
+    <field name="description">Tally Compiled Program</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_thm" model="udes.blocked_file_type">
+    <field name="name">thm</field>
+    <field name="description">Thermwood Macro</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_tlb" model="udes.blocked_file_type">
+    <field name="name">tlb</field>
+    <field name="description">OLE Type Library</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_tms" model="udes.blocked_file_type">
+    <field name="name">tms</field>
+    <field name="description">Telemate Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_udf" model="udes.blocked_file_type">
+    <field name="name">udf</field>
+    <field name="description">Excel User Defined Function</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_upx" model="udes.blocked_file_type">
+    <field name="name">upx</field>
+    <field name="description">Ultimate Packer for eXecutables File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_url" model="udes.blocked_file_type">
+    <field name="name">url</field>
+    <field name="description">Internet Shortcut</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_vlx" model="udes.blocked_file_type">
+    <field name="name">vlx</field>
+    <field name="description">Compiled AutoLISP File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_vpm" model="udes.blocked_file_type">
+    <field name="name">vpm</field>
+    <field name="description">Vox Proxy Macro</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_wcm" model="udes.blocked_file_type">
+    <field name="name">wcm</field>
+    <field name="description">WordPerfect Macro</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_widget" model="udes.blocked_file_type">
+    <field name="name">widget</field>
+    <field name="description">Yahoo! Widget</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_wiz" model="udes.blocked_file_type">
+    <field name="name">wiz</field>
+    <field name="description">Microsoft Wizard File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_wpk" model="udes.blocked_file_type">
+    <field name="name">wpk</field>
+    <field name="description">WordPerfect Macro</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_wpm" model="udes.blocked_file_type">
+    <field name="name">wpm</field>
+    <field name="description">WordPerfect Macro</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_xap" model="udes.blocked_file_type">
+    <field name="name">xap</field>
+    <field name="description">Silverlight Application Package</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_xbap" model="udes.blocked_file_type">
+    <field name="name">xbap</field>
+    <field name="description">XAML Browser Application</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_xlam" model="udes.blocked_file_type">
+    <field name="name">xlam</field>
+    <field name="description">Excel Macro-Enabled Add-In</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_xlm" model="udes.blocked_file_type">
+    <field name="name">xlm</field>
+    <field name="description">Excel Macro-Enabled Workbook</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_xlsm" model="udes.blocked_file_type">
+    <field name="name">xlsm</field>
+    <field name="description">Excel Macro-Enabled Workbook</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_xltm" model="udes.blocked_file_type">
+    <field name="name">xltm</field>
+    <field name="description">Excel Macro-Enabled Template</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_xqt" model="udes.blocked_file_type">
+    <field name="name">xqt</field>
+    <field name="description">SuperCalc Macro</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_xys" model="udes.blocked_file_type">
+    <field name="name">xys</field>
+    <field name="description">XYplorer Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_zl9" model="udes.blocked_file_type">
+    <field name="name">zl9</field>
+    <field name="description">Renamed Virus File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_sh" model="udes.blocked_file_type">
+    <field name="name">sh</field>
+    <field name="description">Shell Script</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_php" model="udes.blocked_file_type">
+    <field name="name">php</field>
+    <field name="description">PHP File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_py" model="udes.blocked_file_type">
+    <field name="name">py</field>
+    <field name="description">Python File</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_htm" model="udes.blocked_file_type">
+    <field name="name">htm</field>
+    <field name="description">Web Page</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_html" model="udes.blocked_file_type">
+    <field name="name">html</field>
+    <field name="description">Web Page</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_asp" model="udes.blocked_file_type">
+    <field name="name">asp</field>
+    <field name="description">Active Server Page</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_deb" model="udes.blocked_file_type">
+    <field name="name">deb</field>
+    <field name="description">Debian Installer Package</field>
+    <field name="active" eval="True"/>
+  </record>
+
+  <record id="udes_blocked_file_type_rpm" model="udes.blocked_file_type">
+    <field name="name">rpm</field>
+    <field name="description">RedHat Installer Package</field>
+    <field name="active" eval="True"/>
+  </record>
+
+</odoo>

--- a/addons/udes_security/models/__init__.py
+++ b/addons/udes_security/models/__init__.py
@@ -1,3 +1,5 @@
+from . import blocked_file_type
+from . import ir_attachment
 from . import res_authentication_attempt
 from . import res_groups
 from . import res_users

--- a/addons/udes_security/models/blocked_file_type.py
+++ b/addons/udes_security/models/blocked_file_type.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
+
+
+class BlockedFileType(models.Model):
+    """
+    Blocked file type which the user is prevented from uploading or downloading
+    """
+
+    _name = "udes.blocked_file_type"
+    _description = "Blocked File Type"
+    _order = "name"
+
+    _sql_constraints = [("name_uniq", "unique (name)", "The File Type must be unique")]
+
+    name = fields.Char("File Type", required=True, index=True)
+    description = fields.Char("Description")
+    active = fields.Boolean("Active?", default=True)
+
+    def _format_name(self, name):
+        """Convert supplied name to lowercase if needed"""
+        formatted_name = name.lower().replace(".", "") if name else ""
+        return formatted_name
+
+    def _format_vals(self, vals):
+        """Format the required values in the supplied dictionary and 
+           return the updated values"""
+        formatted_vals = {}
+
+        name = vals.get("name", "")
+        if name:
+            name = self._format_name(name)
+            formatted_vals["name"] = name
+
+        return formatted_vals
+
+    def _update_attachments_active_status(self, deleted=False):
+        """Set active field on attachments that match the supplied blocked file types"""
+        IrAttachment = self.env["ir.attachment"]
+
+        attachments_to_set_active = IrAttachment.browse()
+        attachments_to_set_inactive = IrAttachment.browse()
+
+        for blocked_file_type in self:
+            is_blocked_file_type = blocked_file_type.active
+
+            # If a blocked file type record is being deleted then it should be treated as inactive
+            if deleted:
+                is_blocked_file_type = False
+
+            attachment_search_args = [("datas_file_type", "=", blocked_file_type.name)]
+
+            attachments = IrAttachment.with_context(active_test=False).search(
+                attachment_search_args
+            )
+
+            if not is_blocked_file_type:
+                attachments_to_set_active += attachments
+            else:
+                attachments_to_set_inactive += attachments
+
+        attachments_to_set_active.with_context(skip_active_check=True).write({"active": True})
+        attachments_to_set_inactive.with_context(skip_active_check=True).write({"active": False})
+
+        return True
+
+    def _set_inactive_attachments_active_from_file_types(self, file_types):
+        """Set active field to True for attachments that are in the file_types list"""
+        IrAttachment = self.env["ir.attachment"]
+
+        attachment_search_args = [
+            ("datas_file_type", "in", file_types),
+            ("active", "=", False),
+        ]
+        attachments = IrAttachment.search(attachment_search_args)
+        attachments.with_context(skip_active_check=True).write({"active": True})
+
+        return True
+
+    @api.model
+    def create(self, vals):
+        """Override to ensure name is formatted correctly
+           and relevant attachments are set to active/inactive"""
+        formatted_vals = self._format_vals(vals)
+        vals.update(formatted_vals)
+
+        blocked_file_type = super(BlockedFileType, self).create(vals)
+        blocked_file_type._update_attachments_active_status()
+
+        return blocked_file_type
+
+    @api.multi
+    def write(self, vals):
+        """Override to ensure name cannot be changed
+           and relevant attachments are set to active/inactive"""
+        if "name" in vals:
+            raise UserError(_("Cannot change File Type, please create a new record instead."))
+
+        res = super(BlockedFileType, self).write(vals)
+
+        if "active" in vals:
+            self._update_attachments_active_status()
+
+        return res
+
+    @api.multi
+    def unlink(self):
+        """Set attachments with same file type to active if needed"""
+        file_types = self.mapped("name")
+
+        res = super(BlockedFileType, self).unlink()
+
+        self._set_inactive_attachments_active_from_file_types(file_types)
+
+        return res

--- a/addons/udes_security/models/ir_attachment.py
+++ b/addons/udes_security/models/ir_attachment.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+
+from odoo import api, fields, models, SUPERUSER_ID, _
+from odoo.exceptions import UserError
+
+
+class IrAttachment(models.Model):
+    _inherit = "ir.attachment"
+
+    @api.depends("datas_fname")
+    def _compute_datas_file_type(self):
+        """Set file type from file name"""
+        for attachment in self:
+            filename = attachment.datas_fname or ""
+            attachment.datas_file_type = filename.split(".")[-1].lower()
+
+    datas_file_type = fields.Char("File Type", compute="_compute_datas_file_type", store=True)
+    active = fields.Boolean(string="Active?", default=True)
+
+    def _get_active_value(self, attachment_type, file_type):
+        """Return false if attachment file type is blocked, otherwise true"""
+        BlockedFileType = self.env["udes.blocked_file_type"]
+
+        active = True
+        if attachment_type == "binary":
+            blocked_file_type_domain = [("name", "=", file_type)]
+            blocked_file_type_count = BlockedFileType.search_count(blocked_file_type_domain)
+
+            if blocked_file_type_count:
+                active = False
+
+        return active
+
+    @api.model
+    def create(self, vals):
+        """Override to set active to False if file type is blocked"""
+        attachment = super(IrAttachment, self).create(vals)
+
+        # Check if the attachment file type is blocked
+        # Raise exception if not superuser otherwise set to inactive
+        active = self._get_active_value(attachment.type, attachment.datas_file_type)
+        if not active:
+            if self.env.uid != SUPERUSER_ID:
+                raise UserError(
+                    _("Unable to upload file: File type blocked by system administrator.")
+                )
+            else:
+                attachment.with_context(skip_active_check=True).write({"active": False})
+
+        return attachment
+
+    @api.multi
+    def write(self, vals):
+        """Override to update active if file type is blocked/unblocked"""
+        res = super(IrAttachment, self).write(vals)
+
+        if not self.env.context.get("skip_active_check", False):
+            for attachment in self:
+                active = self._get_active_value(attachment.type, attachment.datas_file_type)
+                if active != attachment.active:
+                    # If the attachment would not be active then the file type is blocked
+                    # Raise exception if not superuser
+                    if not active:
+                        if self.env.uid != SUPERUSER_ID:
+                            raise UserError(
+                                _(
+                                    """Unable to upload attachment:
+                                    File type blocked by system administrator."""
+                                )
+                            )
+
+                    attachment.with_context(skip_active_check=True).write({"active": active})
+
+        return res

--- a/addons/udes_security/security/ir.model.access.csv
+++ b/addons/udes_security/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+udes_blocked_file_type,udes_blocked_file_type,model_udes_blocked_file_type,base.group_user,1,0,0,0

--- a/addons/udes_security/static/src/js/binary_fields.js
+++ b/addons/udes_security/static/src/js/binary_fields.js
@@ -1,0 +1,100 @@
+odoo.define('udes_security.basic_fields', function (require) {
+    "use strict";
+
+    var core = require('web.core');
+    var _t = core._t;
+    var rpc = require('web.rpc');
+
+    var basicFields = require('web.basic_fields');
+    var FieldBinaryFile = basicFields.FieldBinaryFile;
+    var FieldBinaryImage = basicFields.FieldBinaryImage;
+
+    var warningFTBlockedTitle = _t("File upload");
+    var warningFTBlockedMessage = _t("The selected file type has been blocked by system administrator.");
+
+    function getFileType(filename) {
+        var fileTypeRegEx = /(?:\.([^.]+))?$/;
+        var fileType = fileTypeRegEx.exec(filename)[1];
+
+        return fileType;
+    }
+
+    function getBlockedFileTypeCount(fileType) {
+        return new Promise(function (resolve, reject) {
+            var checkFileType = fileType.toLowerCase();
+
+            rpc.query({
+                model: "udes.blocked_file_type",
+                method: "search_count",
+                args: [[["name", "=", checkFileType]]],
+            }).then(function (blockedCount) {
+                resolve(blockedCount);
+            });
+        });
+    }
+
+    FieldBinaryFile.include({
+        on_file_change: function (e) {
+            var self = this;
+            var _super = this._super;
+            var args = arguments;
+
+            if (this.useFileAPI) {
+                var file_node = e.target;
+                var file = file_node.files[0];
+
+                if (file.name) {
+                    var fileType = getFileType(file.name);
+
+                    if (fileType) {
+                        getBlockedFileTypeCount(fileType).then(function (blockedCount) {
+                            if (blockedCount > 0) {
+                                self.do_warn(warningFTBlockedTitle, warningFTBlockedMessage);
+                                return false;
+                            }
+                            else {
+                                _super.apply(self, args);
+                            }
+                        });
+                    }
+                }
+            }
+            else {
+                _super.apply(self, args);
+            }
+        },
+    })
+
+    FieldBinaryImage.include({
+        on_file_change: function (e) {
+            var self = this;
+            var _super = this._super;
+            var args = arguments;
+
+            if (this.useFileAPI) {
+                var file_node = e.target;
+                var file = file_node.files[0];
+
+                if (file.name) {
+                    var fileType = getFileType(file.name);
+
+                    if (fileType) {
+                        getBlockedFileTypeCount(fileType).then(function (blockedCount) {
+                            if (blockedCount > 0) {
+                                self.do_warn(warningFTBlockedTitle, warningFTBlockedMessage);
+                                return false;
+                            }
+                            else {
+                                _super.apply(self, args);
+                            }
+                        });
+                    }
+                }
+            }
+            else {
+                _super.apply(self, args);
+            }
+        },
+    })
+
+});

--- a/addons/udes_security/tests/__init__.py
+++ b/addons/udes_security/tests/__init__.py
@@ -1,2 +1,3 @@
+from . import test_blocked_file_type
 from . import test_trusted_user
 from . import test_single_session

--- a/addons/udes_security/tests/__init__.py
+++ b/addons/udes_security/tests/__init__.py
@@ -1,3 +1,4 @@
 from . import test_blocked_file_type
+from . import test_file_controllers
 from . import test_trusted_user
 from . import test_single_session

--- a/addons/udes_security/tests/files/json_file.json
+++ b/addons/udes_security/tests/files/json_file.json
@@ -1,0 +1,4 @@
+{
+   "type": "JSON",
+   "testing": 1
+}

--- a/addons/udes_security/tests/files/rtf_file.rtf
+++ b/addons/udes_security/tests/files/rtf_file.rtf
@@ -1,0 +1,1 @@
+Rich Text Format test file.

--- a/addons/udes_security/tests/files/spreadsheet_file.csv
+++ b/addons/udes_security/tests/files/spreadsheet_file.csv
@@ -1,0 +1,2 @@
+Type,Testing
+Spreadsheet,Y

--- a/addons/udes_security/tests/files/text_file.txt
+++ b/addons/udes_security/tests/files/text_file.txt
@@ -1,0 +1,1 @@
+Text file for testing.

--- a/addons/udes_security/tests/test_blocked_file_type.py
+++ b/addons/udes_security/tests/test_blocked_file_type.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+
+import base64
+import pathlib
+import sys
+
+from psycopg2 import IntegrityError
+
+from odoo.exceptions import UserError
+from odoo.modules.module import get_resource_from_path, get_resource_path
+from odoo.tests import common
+from odoo.tools import mute_logger
+
+
+@common.at_install(False)
+@common.post_install(True)
+class TestBlockedFileType(common.SavepointCase):
+    """
+    Check that only the admin user can manage blocked file types and that downloads are blocked
+    for non-admin users when trying to download files with a blocked file type
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Create blocked file type and attachments for blocked/unblocked files
+        """
+        super(TestBlockedFileType, cls).setUpClass()
+
+        cls.BlockedFileType = cls.env["udes.blocked_file_type"]
+
+        cls.atch_txt_file = cls.create_attachment("text_file.txt")
+        cls.atch_csv_file = cls.create_attachment("spreadsheet_file.csv")
+
+        cls.blocked_file_type_txt = cls.create_blocked_file_type("txt")
+
+    @classmethod
+    def _get_file_path(self, filename):
+        """Get file path from supplied filename"""
+        module_file = sys.modules[self.__module__].__file__
+        module = get_resource_from_path(module_file)[0]
+        files_path_str = get_resource_path(module, "tests", "files")
+        files_path = pathlib.Path(files_path_str)
+        file_path = files_path.joinpath(filename)
+
+        return file_path
+    
+    @classmethod
+    def create_attachment(self, filename):
+        """Create attachment from supplied filename"""
+        IrAttachment = self.env["ir.attachment"]
+
+        file_path = self._get_file_path(filename)
+
+        attachment = IrAttachment.create(
+            {
+                "name": file_path.name,
+                "datas_fname": file_path.name,
+                "datas": base64.b64encode(file_path.read_bytes()),
+            }
+        )
+        return attachment
+
+    @classmethod
+    def update_attachment(self, attachment, filename):
+        """Update attachment data from supplied filename"""
+        file_path = self._get_file_path(filename)
+
+        res = attachment.write({
+            "name": file_path.name,
+            "datas_fname": file_path.name,
+            "datas": base64.b64encode(file_path.read_bytes()),
+        })
+
+        return res
+
+    @classmethod
+    def create_blocked_file_type(self, file_type, **kwargs):
+        """Create blocked file type from supplied file type"""
+        blocked_file_type_vals = {"name": file_type}
+        blocked_file_type_vals.update(kwargs)
+
+        blocked_file_type = self.BlockedFileType.create(blocked_file_type_vals)
+
+        return blocked_file_type
+
+    def test_blocked_file_active_status(self):
+        """Test that attachment is inactive if it's file type is blocked or otherwise active"""
+        # Check txt file is inactive and csv file is active
+        self.assertFalse(self.atch_txt_file.active)
+        self.assertTrue(self.atch_csv_file.active)
+
+        # Set txt blocked file type to inactive and check txt attachment is now active
+        self.blocked_file_type_txt.active = False
+        self.assertTrue(self.atch_txt_file.active)
+
+        # Check that csv file is unaffected and still active
+        self.assertTrue(self.atch_csv_file.active)
+
+    def test_blocked_file_type_deleted(self):
+        """Test that deleting an active blocked file type sets blocked attachments to active"""
+        # Check txt file is active after txt blocked file type record is deleted
+        self.blocked_file_type_txt.unlink()
+        self.assertTrue(self.atch_txt_file.active)
+
+    def test_blocked_file_type_unique(self):
+        """Test that only one blocked file type record can exist for each file type"""
+        with mute_logger("odoo.sql_db"), self.assertRaises(IntegrityError):
+            self.create_blocked_file_type("txt")
+
+    def test_blocked_file_type_change_file_type_prevented(self):
+        """Test that the file type on a blocked file type record cannot be changed"""
+        with self.assertRaises(UserError):
+            self.blocked_file_type_txt.name = "other_txt"
+
+    def test_blocked_file_type_format_name(self):
+        """Test that file type name is properly formatted"""
+        json_file_type = "json"
+        json_unformatted_file_types = ("JSON", ".json", ".JSON")
+
+        # Ensure that _format_name properly formats each unformatted file type
+        [
+            self.assertEquals(self.BlockedFileType._format_name(file_type), json_file_type)
+            for file_type in json_unformatted_file_types
+        ]
+
+    def test_attachment_file_type(self):
+        """Test that the file type is properly set on attachment"""
+        self.assertEquals(self.atch_csv_file.datas_file_type, "csv")
+
+        # Replace csv file on csv attachment with a json file and check file type is updated
+        self.update_attachment(self.atch_csv_file, "json_file.json")
+        self.assertEquals(self.atch_csv_file.datas_file_type, "json")

--- a/addons/udes_security/tests/test_file_controllers.py
+++ b/addons/udes_security/tests/test_file_controllers.py
@@ -1,0 +1,149 @@
+import base64
+import json
+import pathlib
+import sys
+
+from contextlib import contextmanager
+
+from odoo.exceptions import UserError
+from odoo.modules.module import get_resource_from_path, get_resource_path
+from odoo.tests import common
+
+@common.at_install(False)
+@common.post_install(True)
+class TestFileControllers(common.HttpCase):
+    """Check that blocked file types cannont be uploaded or downloaded by non-admin users"""
+
+    def setUp(self):
+        """
+        Use test cursor for envorionment
+        Create blocked file types and blocked/unblocked attachments
+        Create user for testing controllers as non-admin
+        """
+        super().setUp()
+
+        # Use default test cursor for default environment
+        def restore(cr=self.cr, env=self.env):
+            """
+            Based on workaround from print module
+            Restore original cursor and environment once changes made with test cursor
+            """
+            self.env = env
+            self.cr = cr
+
+        self.cr = self.registry.cursor()
+        self.env = self.env(self.cr)
+        self.addCleanup(restore)
+
+        ResUsers = self.env["res.users"]
+
+        self.test_user_login = "test_user"
+        self.test_user_pwd = "7estUserPassword!"
+
+        self.test_user = ResUsers.create({"name": "Test User", "login": self.test_user_login})
+        self.test_user.password = self.test_user_pwd
+
+        self.atch_txt_file = self.create_attachment("text_file.txt")
+        self.atch_csv_file = self.create_attachment("spreadsheet_file.csv")
+
+        self.create_blocked_file_type("txt")
+        self.create_blocked_file_type("json")
+
+        # Run tests as the test user
+        self.authenticate(self.test_user_login, self.test_user_pwd)
+
+    @contextmanager
+    def release(self):
+        """
+        Workaround from print module to temporarily release test cursor
+        """
+
+        # Commit so that any changes are visible to external threads
+        self.cr.commit()
+
+        # Release thread's cursor lock
+        self.cr.release()
+
+        try:
+            # Allow external threads to use the cursor
+            yield
+
+        finally:
+            # Reacquire thread's cursor lock
+            self.cr.acquire()
+
+            # Flush cache so that external changes are picked up
+            self.env.clear()
+
+    def url_open(self, *args, **kwargs):
+        with self.release():
+            return super().url_open(*args, **kwargs)
+
+    def _get_file_path(self, filename):
+        """Get file path from supplied filename"""
+        module_file = sys.modules[self.__module__].__file__
+        module = get_resource_from_path(module_file)[0]
+        files_path_str = get_resource_path(module, "tests", "files")
+        files_path = pathlib.Path(files_path_str)
+        file_path = files_path.joinpath(filename)
+
+        return file_path
+
+    def _get_attachment_download_url(self, attachment):
+        return "/web/content/%s?download=true" % (attachment.id)
+
+    def create_attachment(self, filename, user=False):
+        """Create attachment from supplied filename"""
+        IrAttachment = self.env["ir.attachment"]
+
+        # Create attachment as specifc user, if specified
+        if user:
+            IrAttachment = IrAttachment.sudo(user)
+
+        file_path = self._get_file_path(filename)
+
+        attachment = IrAttachment.create(
+            {
+                "name": file_path.name,
+                "datas_fname": file_path.name,
+                "datas": base64.b64encode(file_path.read_bytes()),
+            }
+        )
+
+        return attachment
+
+    def create_blocked_file_type(self, file_type, **kwargs):
+        """Create blocked file type from supplied file type"""
+        BlockedFileType = self.env["udes.blocked_file_type"]
+
+        blocked_file_type_vals = {"name": file_type}
+        blocked_file_type_vals.update(kwargs)
+
+        blocked_file_type = BlockedFileType.create(blocked_file_type_vals)
+
+        return blocked_file_type
+
+    def test_blocked_file_type_download_restricted(self):
+        """Test blocked file type download prevented for test user"""
+        txt_file_url = self._get_attachment_download_url(self.atch_txt_file)
+        csv_file_url = self._get_attachment_download_url(self.atch_csv_file)
+
+        # Attempt to download blocked .txt attachment
+        # Should get a message back saying the file type is blocked
+        txt_response = self.url_open(txt_file_url)
+        txt_response_message = json.loads(txt_response.content)["message"]
+        self.assertEquals(txt_response_message, "Unable to download file: File type blocked")
+
+        # Attempt to download unblocked .csv attachment
+        # Should be able to download the file as CSV files are not blocked
+        csv_response = self.url_open(csv_file_url)
+        self.assertEquals(csv_response.text, "Type,Testing\nSpreadsheet,Y\n")
+
+    def test_blocked_file_type_upload_restricted(self):
+        """Test blocked file type upload prevented for test user"""
+        #Should be able to upload rtf file as it is not a blocked file type
+        self.create_attachment("rtf_file.rtf", user=self.test_user)
+
+        #Should not be able to upload json file as it is a blocked file type
+        with self.assertRaises(UserError):
+            self.create_attachment("json_file.json", user=self.test_user)

--- a/addons/udes_security/views/blocked_file_type_views.xml
+++ b/addons/udes_security/views/blocked_file_type_views.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<odoo>
+
+  <record id="action_udes_blocked_file_types" model="ir.actions.act_window">
+    <field name="name">Blocked File Types</field>
+    <field name="res_model">udes.blocked_file_type</field>
+    <field name="view_type">form</field>
+    <field name="view_mode">tree,form</field>
+    <field name="domain">['|', ('active', '=', True), ('active', '=', False)]</field>
+  </record>
+
+  <menuitem id="menu_udes_uploads_and_downloads"
+            name="Uploads &amp; Downloads"
+            parent="base.menu_administration"
+            sequence="130"/>
+
+  <menuitem id="menu_udes_blocked_file_types"
+            name="Blocked File Types"
+            parent="menu_udes_uploads_and_downloads"
+            action="action_udes_blocked_file_types"
+            groups="base.group_system"/>
+
+  <record id="view_udes_blocked_file_type_form" model="ir.ui.view">
+    <field name="name">udes.blocked_file_type.form</field>
+    <field name="model">udes.blocked_file_type</field>
+    <field name="arch" type="xml">
+      <form string="Blocked File Type">
+        <sheet>
+          <group string="Blocked File Type Details">
+            <group>
+              <field name="name"
+                     attrs="{'readonly': [('id', '!=', False)]}"/>
+              <field name="active"/>
+              <field name="id"
+                     invisible="1"/>
+            </group>
+            <group>
+              <field name="description"/>
+            </group>
+          </group>
+        </sheet>
+      </form>
+    </field>
+  </record>
+
+  <record id="view_udes_blocked_file_type_tree" model="ir.ui.view">
+    <field name="name">udes.blocked_file_type.tree</field>
+    <field name="model">udes.blocked_file_type</field>
+    <field name="arch" type="xml">
+      <tree string="Blocked File Type"
+            decoration-muted="not active">
+        <field name="name"/>
+        <field name="description"/>
+        <field name="active"/>
+      </tree>
+    </field>
+  </record>
+
+  <record id="view_udes_blocked_file_type_search" model="ir.ui.view">
+    <field name="name">udes.blocked_file_type.search</field>
+    <field name="model">udes.blocked_file_type</field>
+    <field name="arch" type="xml">
+      <search string="Search Blocked File Types">
+        <field name="name"/>
+        <field name="description"/>
+        <filter name="filter_active" string="Active" domain="[('active','=', True)]"/>
+        <filter name="filter_inactive" string="Inactive" domain="[('active','=', False)]"/>
+      </search>
+    </field>
+  </record>
+
+</odoo>

--- a/addons/udes_security/views/webclient_templates.xml
+++ b/addons/udes_security/views/webclient_templates.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <template id="udes_security.web" name="udes_security.web" inherit_id="web.assets_backend">
+            <xpath expr="." position="inside">
+                <script type="text/javascript" src="/udes_security/static/src/js/binary_fields.js"></script>
+            </xpath>
+        </template>
+    </data>
+</odoo>


### PR DESCRIPTION
Prevent users from uploading/download executable files via a blocked file type list which is configurable by admin.

Added Blocked File Type entity which allows admin user to add file types which non-admin users will not be able to download.

Attachments matching blocked file types now hidden. Upload and Download controllers overridden to explicitly prevent blocked file types from being uploaded/downloaded.

Added override to BinaryFile/BinaryImage widgets so that the file type is checked and upload is prevented if file type is blocked.

Common executable file types added as Blocked File Types.