### PR TITLE
[FIX] udes_sale_stock: Ignore cancelled lines at _action_launch_procurement_rule()

### DIFF
--- a/addons/udes_sale_stock/models/sale_order_line.py
+++ b/addons/udes_sale_stock/models/sale_order_line.py
@@ -39,3 +39,7 @@ class SaleOrderLine(models.Model):
         to_cancel.mapped('move_ids').filtered(
             lambda m: m.state not in ('done', 'cancel'))._action_cancel()
         to_cancel.mapped('order_id').check_state_cancelled()
+
+    def _action_launch_procurement_rule(self):
+        not_cancelled_lines = self.filtered(lambda l: not l.is_cancelled)
+        super(SaleOrderLine, not_cancelled_lines)._action_launch_procurement_rule()


### PR DESCRIPTION

If the lines are flagged as is_cancelled when in state draft, the confirmation of
the order will create moves for them anyway. Therefore, they have to be filtered
out so moves are not created.
