### PR TITLE
[FIX] udes_stock: Remove warehouse stock location barcode

### DIFF
--- a/addons/udes_stock/data/locations.xml
+++ b/addons/udes_stock/data/locations.xml
@@ -5,6 +5,8 @@
     <!-- Update "Warehouse/Stock" view location -->
     <record id="stock.stock_location_stock" model="stock.location">
       <field name="usage">view</field>
+      <!-- Changing a non-view to view so remove the barcode -->
+      <field name="barcode" eval="False"/>
     </record>
 
 


### PR DESCRIPTION
As we set the existing stock location to a view, it already has a barcode
assigned. We search for empty children in stock.picking by checking
there are no quants and the barcode is False, so get_empty_children also
returns view locations with a barcode. This means suggested_locations,
which calls get_empty_children, suggests view locations which is not desirable.

Signed-off-by: Pete Pratt <peter.pratt@unipart.io>