### PR TITLE
[IMP] udes_stock: Drop off support in update_picking and allow drop off at damaged stock locations

### DIFF
--- a/addons/udes_stock/models/stock_move_line.py
+++ b/addons/udes_stock/models/stock_move_line.py
@@ -94,7 +94,7 @@ class StockMoveLine(models.Model):
             # CASE C: wrong combination of package names given
             elif products_info:
                 raise ValidationError(
-                    _("Invalid parameters for target storage format," " expecting result package.")
+                    _("Invalid parameters for target storage format, expecting result package.")
                 )
 
         elif target_storage_format == "pallet_products":
@@ -104,7 +104,7 @@ class StockMoveLine(models.Model):
                 result_package = Package.get_package(result_package, create=True).name
             elif products_info and not result_package and not scan_parent_package_end:
                 raise ValidationError(
-                    _("Invalid parameters for target storage format," " expecting result package.")
+                    _("Invalid parameters for target storage format, expecting result package.")
                 )
 
         elif target_storage_format == "package":
@@ -119,7 +119,7 @@ class StockMoveLine(models.Model):
             # when result storage format is products
             if result_package:
                 raise ValidationError(
-                    _("Invalid parameters for products target" " storage format.")
+                    _("Invalid parameters for products target storage format.")
                 )
 
         return (result_package, parent_package)
@@ -288,7 +288,7 @@ class StockMoveLine(models.Model):
             repeated_lot_numbers = [sn for sn, num in Counter(lot_numbers).items() if num > 1]
             if len(repeated_lot_numbers) > 0:
                 raise ValidationError(
-                    _("Lot numbers %s are repeated in picking %s for " "product %s")
+                    _("Lot numbers %s are repeated in picking %s for product %s")
                     % (
                         " ".join(repeated_lot_numbers),
                         move_lines.mapped("picking_id").name,
@@ -303,7 +303,7 @@ class StockMoveLine(models.Model):
                 # all mls should have lot id
                 if not mls_with_lot_id == product_mls:
                     raise ValidationError(
-                        _("Some move lines don't have lot_id in picking %s for " "product %s")
+                        _("Some move lines don't have lot_id in picking %s for product %s")
                         % (product_mls.mapped("picking_id").name, product.name)
                     )
 
@@ -315,14 +315,14 @@ class StockMoveLine(models.Model):
                     diff = set(lot_numbers) - set(mls_lot_numbers)
                     if product.tracking == "serial" and set(lot_numbers) != set(mls_lot_numbers):
                         raise ValidationError(
-                            _("Lot numbers %s for product %s not found in " "picking %s")
+                            _("Lot numbers %s for product %s not found in picking %s")
                             % (" ".join(diff), product.name, product_mls.mapped("picking_id").name)
                         )
 
                 done_mls = product_mls_in_lot_numbers.filtered(lambda ml: ml.qty_done > 0)
                 if product.tracking == "serial" and done_mls == product_mls_in_lot_numbers:
                     raise ValidationError(
-                        _("Operations for product %s with lot numbers %s are " "already done.")
+                        _("Operations for product %s with lot numbers %s are already done.")
                         % (product.name, ",".join(done_mls.mapped("lot_id.name")))
                     )
 
@@ -571,7 +571,7 @@ class StockMoveLine(models.Model):
             if self.lot_name:
                 # lot_name is set when it does not exist in the system
                 raise ValidationError(
-                    _("Trying to mark as done a move line with lot" " name already set: %s")
+                    _("Trying to mark as done a move line with lot name already set: %s")
                     % self.lot_name
                 )
             # lot_id is set when it already exists in the system
@@ -579,7 +579,7 @@ class StockMoveLine(models.Model):
             if ml_lot_name:
                 if ml_lot_name not in info["lot_names"]:
                     raise ValidationError(
-                        _("Cannot find lot number %s in the list" " of lot numbers to validate")
+                        _("Cannot find lot number %s in the list of lot numbers to validate")
                         % ml_lot_name
                     )
             else:
@@ -593,7 +593,7 @@ class StockMoveLine(models.Model):
         self.ensure_one()
         if "qty_done" not in values:
             raise ValidationError(
-                _("Cannot mark as done move line %s of picking %s without " "quantity done")
+                _("Cannot mark as done move line %s of picking %s without quantity done")
                 % (self.id, self.picking_id.name)
             )
 
@@ -668,7 +668,7 @@ class StockMoveLine(models.Model):
         res = self
         if self.qty_done > 0:
             raise ValidationError(
-                _("Trying to split a move line by quantity when the move line " "is alreay done")
+                _("Trying to split a move line by quantity when the move line is alreay done")
             )
         if (
             qty > 0
@@ -895,7 +895,7 @@ class StockMoveLine(models.Model):
             pt.u_move_line_key_format is False for pt in self.mapped("picking_id.picking_type_id")
         ):
             raise UserError(
-                _("Cannot group move lines when their picking type" "has no grouping key set.")
+                _("Cannot group move lines when their picking type has no grouping key set.")
             )
 
         by_key = lambda ml: ml.u_grouping_key
@@ -979,7 +979,7 @@ class StockMoveLine(models.Model):
                 # location should be one of the suggested locations, if any
                 if locations and location not in locations:
                     raise ValidationError(
-                        _("Drop off location must be one of the suggested " "locations")
+                        _("Drop off location must be one of the suggested locations")
                     )
 
     def any_destination_locations_default(self):

--- a/addons/udes_stock/tests/test_update_picking.py
+++ b/addons/udes_stock/tests/test_update_picking.py
@@ -742,7 +742,7 @@ class TestUpdatePickingMarksMoveLinesAsDone(common.BaseUDES):
     @classmethod
     def setUpClass(cls):
         super(TestUpdatePickingMarksMoveLinesAsDone, cls).setUpClass()
-        cls.picking_type_in.u_target_storage_format = 'product'
+        cls.picking_type_pick.u_target_storage_format = 'product'
 
     def test01_child_drop_location_success(self):
         """ If the updated destination location is a child of the

--- a/addons/udes_stock/tests/test_update_picking.py
+++ b/addons/udes_stock/tests/test_update_picking.py
@@ -862,3 +862,110 @@ class TestUpdatePickingMarksMoveLinesAsDone(common.BaseUDES):
                                    location_dest_id=self.test_location_01.id)
 
         self.assertEqual(e_2.exception.name, err)
+
+class TestUpdatePickingExplicitDropOff(common.BaseUDES):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestUpdatePickingExplicitDropOff, cls).setUpClass()
+        cls.picking_type_pick.u_target_storage_format = 'pallet_products'
+
+        cls.create_quant(cls.apple.id, cls.test_location_01.id, 4)
+        cls.create_quant(cls.banana.id, cls.test_location_01.id, 4)
+        cls.create_quant(cls.cherry.id, cls.test_location_01.id, 4)
+        create_info = [
+            {'product': cls.apple,
+             'qty': 4,
+             'location_dest_id': cls.test_output_location_01.id},
+            {'product': cls.banana,
+             'qty': 4,
+             'location_dest_id': cls.test_output_location_01.id},
+            {'product': cls.cherry,
+             'qty': 4,
+             'location_dest_id': cls.test_output_location_01.id}]
+
+        cls.picking = cls.create_picking(cls.picking_type_pick,
+                                         products_info=create_info,
+                                         confirm=True,
+                                         assign=True)
+        cls.picking = cls.picking.sudo(cls.outbound_user)
+        cls.apple_move_line = cls.picking.move_line_ids.filtered(lambda ml: ml.product_id == cls.apple)
+        cls.banana_move_line = cls.picking.move_line_ids.filtered(lambda ml: ml.product_id == cls.banana)
+        cls.cherry_move_line = cls.picking.move_line_ids.filtered(lambda ml: ml.product_id == cls.cherry)
+
+    def test01_explicit_drop_off_all(self):
+        """ Test that update_picking updates the destination location of
+            completed move lines and only completed move lines when no products
+            are given.
+        """
+        product_ids = [
+            {'barcode': self.apple.barcode,
+             'qty': 4},
+            {'barcode': self.banana.barcode,
+             'qty': 4}]
+
+        self.picking.update_picking(product_ids=product_ids,
+                                    result_package_name='UDES100000',
+                                    location_dest_id=self.test_output_location_01.id)
+
+        self.assertEqual(self.apple_move_line.location_dest_id,
+                         self.test_output_location_01)
+        self.assertEqual(self.banana_move_line.location_dest_id,
+                         self.test_output_location_01)
+        self.assertEqual(self.cherry_move_line.location_dest_id,
+                         self.test_output_location_01)
+
+        # Drop off
+        self.picking.update_picking(location_dest_id=self.test_output_location_02.id)
+
+        self.assertEqual(self.apple_move_line.location_dest_id,
+                         self.test_output_location_02)
+        self.assertEqual(self.banana_move_line.location_dest_id,
+                         self.test_output_location_02)
+        self.assertEqual(self.cherry_move_line.location_dest_id,
+                         self.test_output_location_01)
+
+    def test02_explicit_drop_off_by_pallet(self):
+        """ Test that update_picking updates the destination location of
+            completed move lines with a given destination pallet.
+        """
+        product_ids_1 = [
+            {'barcode': self.apple.barcode,
+             'qty': 4},
+            {'barcode': self.banana.barcode,
+             'qty': 4}]
+        product_ids_2 = [
+            {'barcode': self.cherry.barcode,
+             'qty': 4}]
+
+        self.picking.update_picking(product_ids=product_ids_1,
+                                    result_package_name='UDES100000',
+                                    location_dest_id=self.test_output_location_01.id)
+        self.picking.update_picking(product_ids=product_ids_2,
+                                    result_package_name='UDES100001',
+                                    location_dest_id=self.test_output_location_01.id)
+
+        self.assertEqual(self.apple_move_line.location_dest_id,
+                         self.test_output_location_01)
+        self.assertEqual(self.banana_move_line.location_dest_id,
+                         self.test_output_location_01)
+        self.assertEqual(self.cherry_move_line.location_dest_id,
+                         self.test_output_location_01)
+
+        # Drop off first pallet
+        self.picking.update_picking(result_package_name='UDES100000',
+                                    location_dest_id=self.test_output_location_02.id)
+
+        self.assertEqual(self.apple_move_line.location_dest_id,
+                         self.test_output_location_02)
+        self.assertEqual(self.banana_move_line.location_dest_id,
+                         self.test_output_location_02)
+        self.assertEqual(self.cherry_move_line.location_dest_id,
+                         self.test_output_location_01)
+
+        # Drop off second pallet
+        self.picking.update_picking(result_package_name='UDES100001',
+                                    location_dest_id=self.test_output_location_02.id)
+
+        self.assertEqual(self.cherry_move_line.location_dest_id,
+                         self.test_output_location_02)


### PR DESCRIPTION
[FIX] udes_stock: Fix typo in update_picking drop location tests

All the drop location tests use the Pick picking type, but the setup method
was setting the target storage format for Goods In instead.

Signed-off-by: Sean Quah <sean.quah@unipart.io>

-------------------------------------------------------------------------------

[IMP] udes_stock: Add drop off support to update_picking

When a destination location is passed to update_picking and no source package
name or products are specified, update the destination location of all done
move lines. This models a drop off operation.

The set of move lines to be updated may be narrowed down by passing a result
package name / pallet name.

User-story: 10335

Signed-off-by: Sean Quah <sean.quah@unipart.io>

-------------------------------------------------------------------------------

[FIX] udes_stock: Fix bad string formatting in stock_move_line.py

Signed-off-by: Sean Quah <sean.quah@unipart.io>

-------------------------------------------------------------------------------

[IMP] udes_stock: Allow drop off at damaged stock location

When enforcing drop off policy for picking types which are set up to handle
damages, allow the damaged stock location to be used as a drop off location
even if it is not in the list of suggested locations.

User-story: 10335

Signed-off-by: Sean Quah <sean.quah@unipart.io>
