### PR TITLE
[ADD] udes_stock: Restrict inventory adjustment on reserved stock

### DIFF
--- a/addons/udes_stock/models/stock_inventory.py
+++ b/addons/udes_stock/models/stock_inventory.py
@@ -2,6 +2,7 @@
 
 from odoo import api, models, fields, _
 from odoo.exceptions import ValidationError, UserError
+from odoo.addons import decimal_precision as dp
 
 
 class StockInventory(models.Model):
@@ -24,14 +25,56 @@ class StockInventory(models.Model):
         Extends the parent method by ensuring that there are no
         incomplete preceding inventories.
 
+        Also checks that a user is allowed to adjust reserved stock.
+
         Raises a ValidationError otherwise.
         """
+        User = self.env['res.users']
+
         for prec in self.u_preceding_inventory_ids:
             if prec.state != 'done':
                 raise ValidationError(
                     _('There are undone preceding inventories.'))
 
+        if self._is_adjusting_reserved():
+            warehouse = User.get_user_warehouse()
+            if not (warehouse.u_inventory_adjust_reserved or
+                    self.env.user.has_group("udes_security.group_debug_user")):
+                raise ValidationError(
+                    _("You are not allowed to adjust reserved stock. "
+                      "The stock has not been adjusted.")
+                )
+
         return super(StockInventory, self).action_done()
+
+    @api.multi
+    def button_done(self):
+        """Add a popup to inform a user that they are adjusting reserved stock."""
+        self.ensure_one()
+
+        if self._is_adjusting_reserved():
+            return {
+                'name': _('Adjust Reserved Stock?'),
+                'type': 'ir.actions.act_window',
+                'view_type': 'form',
+                'view_mode': 'form',
+                'res_model': 'stock.inventory',
+                'views': [(self.env.ref('udes_stock.view_adjust_reserved').id, 'form')],
+                'view_id': self.env.ref('udes_stock.view_adjust_reserved').id,
+                'target': 'new',
+                'res_id': self.id,
+                'context': self.env.context,
+            }
+        else:
+            return self.action_done()
+
+    def _is_adjusting_reserved(self):
+        """Check if a user is adjusting reserved stock."""
+        self.ensure_one()
+        for line in self.line_ids:
+            if line.reserved_qty and line.theoretical_qty != line.product_qty:
+                return True
+        return False
 
     @api.multi
     def write(self, values):
@@ -40,3 +83,36 @@ class StockInventory(models.Model):
                 _('Cannot write to an adjustment which has already been '
                   'validated'))
         return super(StockInventory, self).write(values)
+
+
+class StockInventoryLine(models.Model):
+    _name = 'stock.inventory.line'
+    _inherit = 'stock.inventory.line'
+
+    reserved_qty = fields.Float(
+        'Reserved Quantity',
+        compute='_compute_reserved_qty',
+        digits=dp.get_precision('Product Unit of Measure'),
+        readonly=True,
+        store=False
+    )
+
+    @api.one
+    @api.depends(
+        'location_id',
+        'product_id',
+        'package_id',
+        'product_uom_id',
+        'company_id',
+        'prod_lot_id',
+        'partner_id'
+    )
+    def _compute_reserved_qty(self):
+        """Compute the reserved quantity for the line."""
+        reserved_qty = sum([quant.reserved_quantity for quant in self._get_quants()])
+        if reserved_qty and self.product_uom_id and self.product_id.uom_id != self.product_uom_id:
+            reserved_qty = self.product_id.uom_id._compute_quantity(
+                reserved_qty,
+                self.product_uom_id
+            )
+        self.reserved_qty = reserved_qty

--- a/addons/udes_stock/models/stock_warehouse.py
+++ b/addons/udes_stock/models/stock_warehouse.py
@@ -95,6 +95,12 @@ class StockWarehouse(models.Model):
         help="Maximum depth for package hierarchy. I.e. a value of 2 would limit the number of levels in hierarchy to 2, one level of packages(with no subpackages) inside an outer package."
     )
 
+    u_inventory_adjust_reserved = fields.Boolean(
+        string="Inventory Adjust Reserved Stock",
+        default=True,
+        help="Allow users to inventory adjust reserved stock."
+    )
+
     @lazy_property
     def reserved_package_name(self):
         return list(

--- a/addons/udes_stock/tests/__init__.py
+++ b/addons/udes_stock/tests/__init__.py
@@ -25,3 +25,4 @@ from . import test_update_picking
 from . import test_picking_print_strategy
 from . import test_limit_orderpoints
 from . import test_package_hierarchy
+from . import test_stock_inventory

--- a/addons/udes_stock/tests/common.py
+++ b/addons/udes_stock/tests/common.py
@@ -534,3 +534,14 @@ class BaseUDES(common.SavepointCase):
         vals = {'name': name}
         vals.update(kwargs)
         return Partner.create(vals)
+
+    @classmethod
+    def create_stock_inventory(cls, name, **kwargs):
+        """Create a stock inventory record."""
+        vals = {
+            "name": name,
+            "location_id": cls.env.ref("stock.stock_location_stock").id,
+            "filter": "none",
+        }
+        vals.update(kwargs)
+        return cls.env["stock.inventory"].create(vals)

--- a/addons/udes_stock/tests/test_stock_inventory.py
+++ b/addons/udes_stock/tests/test_stock_inventory.py
@@ -1,0 +1,118 @@
+from odoo.exceptions import ValidationError
+from . import common
+
+class TestStockInventory(common.BaseUDES):
+
+    @classmethod
+    def setUpClass(cls):
+        """Add a quant in a location to the setUpClass method."""
+        super(TestStockInventory, cls).setUpClass()
+        cls.apple_quant = cls.create_quant(cls.apple.id, cls.test_location_01.id, 5)
+
+    def setUp(self):
+        """Setup data for stock inventory adjustment."""
+        self.User = self.env['res.users']
+
+        super(TestStockInventory, self).setUp()
+        self.warehouse = self.User.get_user_warehouse()
+        self.warehouse.u_inventory_adjust_reserved = False
+        self.apple_quant.reserved_quantity = 1.0
+        self.test_stock_inventory = self.create_stock_inventory(name="Test Stock Check")
+
+    def test01_reserved_correct_qty_allowed(self):
+        """Test that inventory adjustments are allowed for reserved quants with
+        u_inventory_adjust_reserved = False if the correct quantity is counted.
+        """
+        self.test_stock_inventory.action_start()
+        self.assertEqual(len(self.test_stock_inventory.line_ids), 1)
+
+        self.test_stock_inventory.sudo(self.stock_user).action_done()
+        self.assertEqual(self.test_stock_inventory.state, "done")
+
+    def test02_reserved_lower_qty_not_allowed(self):
+        """Test that inventory adjustments are not allowed for reserved quants with
+        u_inventory_adjust_reserved = False if a lower quantity is counted.
+        """
+        self.test_stock_inventory.action_start()
+        self.test_stock_inventory.line_ids.product_qty -= 1
+
+        with self.assertRaises(ValidationError) as e:
+            self.test_stock_inventory.sudo(self.stock_user).action_done()
+        self.assertEqual(
+            e.exception.name,
+            (
+                "You are not allowed to adjust reserved stock. "
+                "The stock has not been adjusted."
+            )
+        )
+
+    def test03_reserved_higher_qty_not_allowed(self):
+        """Test that inventory adjustments are not allowed for reserved quants with
+        u_inventory_adjust_reserved = False if a higher quantity is counted.
+        """
+        self.test_stock_inventory.action_start()
+        self.test_stock_inventory.line_ids.product_qty += 1
+
+        with self.assertRaises(ValidationError) as e:
+            self.test_stock_inventory.sudo(self.stock_user).action_done()
+        self.assertEqual(
+            e.exception.name,
+            (
+                "You are not allowed to adjust reserved stock. "
+                "The stock has not been adjusted."
+            )
+        )
+
+    def test04_reserved_wrong_qty_allowed_with_setting(self):
+        """Test that inventory adjustments are allowed for reserved quants with
+        u_inventory_adjust_reserved = True if a lower quantity is counted.
+        """
+        self.warehouse.u_inventory_adjust_reserved = True
+        self.test_stock_inventory.action_start()
+        self.test_stock_inventory.line_ids.product_qty -= 1
+
+        self.test_stock_inventory.sudo(self.stock_user).action_done()
+        self.assertEqual(self.test_stock_inventory.state, "done")
+
+    def test05_reserved_wrong_qty_allowed_by_debug_user(self):
+        """Test that inventory adjustments are allowed for reserved quants with
+        u_inventory_adjust_reserved = False if a lower quantity is counted
+        by users in the debug group.
+        """
+        # Add stock user to debug group
+        debug_group = self.env.ref('udes_security.group_debug_user')
+        debug_group.write({'users': [(4, self.stock_user.id)]})
+
+        self.test_stock_inventory.action_start()
+        self.test_stock_inventory.line_ids.product_qty -= 1
+
+        self.test_stock_inventory.sudo(self.stock_user).action_done()
+        self.assertEqual(self.test_stock_inventory.state, "done")
+
+class TestStockInventoryLine(common.BaseUDES):
+
+    @classmethod
+    def setUpClass(cls):
+        """Add a quant in a location to the setUpClass method."""
+        super(TestStockInventoryLine, cls).setUpClass()
+        cls.apple_quant = cls.create_quant(cls.apple.id, cls.test_location_01.id, 5)
+
+    def setUp(self):
+        """Setup data to create stock inventory adjustment line."""
+        super(TestStockInventoryLine, self).setUp()
+        self.apple_quant.reserved_quantity = 1.0
+        self.test_stock_inventory = self.create_stock_inventory(name="Test Stock Check")
+        self.test_stock_inventory.action_start()
+
+    def test01_calculate_reserved_qty(self):
+        """Test that reserved quantity is calculated correctly."""
+        self.assertEqual(len(self.test_stock_inventory.line_ids), 1)
+
+        self.assertEqual(self.test_stock_inventory.line_ids.reserved_qty, 1)
+
+    def test02_calculate_reserved_qty_recalculate(self):
+        """Test that reserved quantity can be correctly recalculated."""
+        self.apple_quant.reserved_quantity = 2
+
+        self.test_stock_inventory.line_ids._compute_reserved_qty()
+        self.assertEqual(self.test_stock_inventory.line_ids.reserved_qty, 2)

--- a/addons/udes_stock/views/stock_inventory.xml
+++ b/addons/udes_stock/views/stock_inventory.xml
@@ -16,5 +16,36 @@
                 </xpath>
             </field>
         </record>
+
+        <record id="view_inventory_form" model="ir.ui.view">
+            <field name="name">stock.inventory.form</field>
+            <field name="model">stock.inventory</field>
+            <field name="inherit_id" ref="stock.view_inventory_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//header/button[@name='action_done']" position="attributes">
+                    <attribute name="name">button_done</attribute>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="view_adjust_reserved" model="ir.ui.view">
+            <field name="name">stock.inventory.adjust.reserved.view.form</field>
+            <field name="model">stock.inventory</field>
+            <field name="priority">20</field>
+            <field name="arch" type="xml">
+                <form string="Adjust Reserved Stock?">
+                    <group>
+                        <p>
+                            The stock you are adjusting is reserved for picking(s).
+                            Do you want to continue or cancel?
+                        </p>
+                    </group>
+                    <footer>
+                        <button name="action_done" string="_Continue" type="object" class="btn-primary"/>
+                        <button string="Cancel" class="btn-default" special="cancel" />
+                    </footer>
+                </form>
+            </field>
+        </record>
     </data>
 </odoo>

--- a/addons/udes_stock/views/stock_warehouse.xml
+++ b/addons/udes_stock/views/stock_warehouse.xml
@@ -42,6 +42,7 @@
                             <field name="u_show_rpc_timing" />
                             <field name="u_reserved_package_name" />
                             <field name="u_max_package_depth" />
+                            <field name="u_inventory_adjust_reserved" />
                         </group>
                     </page>
                 </xpath>


### PR DESCRIPTION
A new config option may be specified on the warehouse to disallow
inventory adjustments on reserved quants. A warning will appear
if attempted and the user will be blocked from validating with
this setting or if not performed by a debug user.
