### PR TITLE
Story/10507 - UDES Sale Stock - Make Requested Date and Customer Reference fields required for Sales Orders

### DIFF
--- a/addons/udes_sale_stock/__manifest__.py
+++ b/addons/udes_sale_stock/__manifest__.py
@@ -2,36 +2,27 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 {
-    'name': 'UDES Sale Stock Functionality',
-    'version': '11.0',
-    'summary': 'Inventory, Logistics, Warehousing',
-    'description': "Extension of sale_stock model for UDES",
-    'depends': [
-        'edi_sale',
-        'sale_order_dates',
-        'sale_stock',
-        'udes_stock',
-        'l10n_uk',
+    "name": "UDES Sale Stock Functionality",
+    "version": "11.0",
+    "summary": "Inventory, Logistics, Warehousing",
+    "description": "Extension of sale_stock model for UDES",
+    "depends": ["edi_sale", "sale_order_dates", "sale_stock", "udes_stock", "l10n_uk",],
+    "category": "Warehouse",
+    "sequence": 12,
+    "demo": [],
+    "data": [
+        "security/ir.model.access.csv",
+        "security/udes_sale_stock_security.xml",
+        "data/stock_config.xml",
+        "data/ir_cron.xml",
+        "views/sale_order_views.xml",
+        "views/stock_warehouse.xml",
+        "views/res_users_views.xml",
+        "views/res_groups_views.xml",
     ],
-    'category': 'Warehouse',
-    'sequence': 12,
-    'demo': [
-    ],
-    'data': [
-        'security/ir.model.access.csv',
-        'security/udes_sale_stock_security.xml',
-        'data/stock_config.xml',
-        'data/ir_cron.xml',
-        'views/sale_order_views.xml',
-        'views/stock_warehouse.xml',
-        'views/res_users_views.xml',
-        'views/res_groups_views.xml',
-    ],
-    'qweb': [
-    ],
-    'test': [
-    ],
-    'installable': True,
-    'application': False,
-    'auto_install': False,
+    "qweb": [],
+    "test": [],
+    "installable": True,
+    "application": False,
+    "auto_install": False,
 }

--- a/addons/udes_sale_stock/__manifest__.py
+++ b/addons/udes_sale_stock/__manifest__.py
@@ -15,6 +15,7 @@
         "security/udes_sale_stock_security.xml",
         "data/stock_config.xml",
         "data/ir_cron.xml",
+        "views/edi_sale_request_views.xml",
         "views/sale_order_views.xml",
         "views/stock_warehouse.xml",
         "views/res_users_views.xml",

--- a/addons/udes_sale_stock/models/__init__.py
+++ b/addons/udes_sale_stock/models/__init__.py
@@ -8,4 +8,5 @@ from . import res_users
 from . import res_groups
 from . import partner_pii
 from . import edi_sale_request_document
+from . import edi_sale_request_record
 from . import stock_warehouse

--- a/addons/udes_sale_stock/models/edi_sale_request_document.py
+++ b/addons/udes_sale_stock/models/edi_sale_request_document.py
@@ -9,7 +9,7 @@ _logger = logging.getLogger(__name__)
 class EdiSaleRequestDocument(models.AbstractModel):
     """Extend ``edi.sale.request.document`` to trigger pick factorisation"""
 
-    _inherit = 'edi.sale.request.document'
+    _inherit = "edi.sale.request.document"
 
     @api.model
     def execute(self, doc):
@@ -17,13 +17,11 @@ class EdiSaleRequestDocument(models.AbstractModel):
         SaleLineRequestRecord = self.sale_line_request_record_model(doc)
 
         # Execute document with pick factorisation disabled
-        super(EdiSaleRequestDocument,
-              self.with_context(disable_move_refactor=True)).execute(doc)
+        super(EdiSaleRequestDocument, self.with_context(disable_move_refactor=True)).execute(doc)
 
         # Perform pick factorisation
-        reqs = SaleLineRequestRecord.search([('doc_id', '=', doc.id)])
+        reqs = SaleLineRequestRecord.search([("doc_id", "=", doc.id)])
         with self.statistics() as stats:
-            moves = reqs.mapped('sale_line_id.move_ids')
+            moves = reqs.mapped("sale_line_id.move_ids")
             moves._action_refactor()
-        _logger.info("%s refactored in %.2fs, %d queries",
-                     doc.name, stats.elapsed, stats.count)
+        _logger.info("%s refactored in %.2fs, %d queries", doc.name, stats.elapsed, stats.count)

--- a/addons/udes_sale_stock/models/edi_sale_request_record.py
+++ b/addons/udes_sale_stock/models/edi_sale_request_record.py
@@ -1,0 +1,31 @@
+import logging
+from odoo import api, models, fields
+
+_logger = logging.getLogger(__name__)
+
+
+class EdiSaleRequestRecord(models.AbstractModel):
+    """
+    Extend ``edi.sale.request.record`` to add 
+    Requested Date and Customer Reference fields
+    """
+
+    _inherit = "edi.sale.request.record"
+
+    requested_date = fields.Datetime("Requested Date")
+    client_order_ref = fields.Char(string="Customer Reference", readonly=True)
+
+    @api.model
+    def target_values(self, record_vals):
+        """
+        Override to add Requested Date and Customer Reference fields 
+        to ``sale.order`` value dictionary
+        """
+        so_vals = super().target_values(record_vals)
+        so_vals.update(
+            {
+                "requested_date": record_vals["requested_date"],
+                "client_order_ref": record_vals["client_order_ref"],
+            }
+        )
+        return so_vals

--- a/addons/udes_sale_stock/models/partner_pii.py
+++ b/addons/udes_sale_stock/models/partner_pii.py
@@ -8,11 +8,17 @@ import logging
 _logger = logging.getLogger(__name__)
 
 
-REDACTED_TXT = _('Redacted')
+REDACTED_TXT = _("Redacted")
 PII_RELATIONS = [
-    'partner_id', 'res_partner_id', 'author_id', 'partner_address_id',
-    'owner_id', 'partner_shipping_id', 'partner_invoice_id',
-    'order_partner_id', 'customer_id'
+    "partner_id",
+    "res_partner_id",
+    "author_id",
+    "partner_address_id",
+    "owner_id",
+    "partner_shipping_id",
+    "partner_invoice_id",
+    "order_partner_id",
+    "customer_id",
 ]
 
 
@@ -25,23 +31,32 @@ def _read(self, result):
     if self.env.user.u_view_customers:
         for record in result:
             for field in record:
-                if (field in PII_RELATIONS
-                        and isinstance(record[field], tuple)
-                        and self.env['res.partner'].sudo().search_count([
-                            ('id', '=', record[field][0]),
-                            ('customer', '=', True)])):
-                                # Log PII has been viewed
-                                _logger.info("User %s viewed Customer %s via %s.%s",
-                                             self.env.uid, record[field][0], self._name, field)
+                if (
+                    field in PII_RELATIONS
+                    and isinstance(record[field], tuple)
+                    and self.env["res.partner"]
+                    .sudo()
+                    .search_count([("id", "=", record[field][0]), ("customer", "=", True)])
+                ):
+                    # Log PII has been viewed
+                    _logger.info(
+                        "User %s viewed Customer %s via %s.%s",
+                        self.env.uid,
+                        record[field][0],
+                        self._name,
+                        field,
+                    )
         return result
 
     for record in result:
         for field in record:
-            if (field in PII_RELATIONS
-                    and isinstance(record[field], tuple)
-                    and self.env['res.partner'].sudo().search_count([
-                        ('id', '=', record[field][0]),
-                        ('customer', '=', True)])):
+            if (
+                field in PII_RELATIONS
+                and isinstance(record[field], tuple)
+                and self.env["res.partner"]
+                .sudo()
+                .search_count([("id", "=", record[field][0]), ("customer", "=", True)])
+            ):
                 # Record ID remains and string value redacted
                 record[field] = (record[field][0], REDACTED_TXT)
                 _logger.info("%s: %s.%s", REDACTED_TXT, self._name, field)
@@ -50,7 +65,7 @@ def _read(self, result):
 
 
 class ResPartner(models.Model):
-    _inherit = 'res.partner'
+    _inherit = "res.partner"
 
     @api.multi
     def name_get(self):
@@ -63,20 +78,22 @@ class ResPartner(models.Model):
 
         if self.env.user.u_view_customers:
             for record in result:
-                if (isinstance(record, tuple)
-                        and self.sudo().search_count([('id', '=', record[0]),
-                                                      ('customer', '=', True)])):
+                if isinstance(record, tuple) and self.sudo().search_count(
+                    [("id", "=", record[0]), ("customer", "=", True)]
+                ):
                     # Log PII viewed
-                    _logger.info("User %s viewed Customer %s via res.partner", self.env.uid, record[0])
-                    
+                    _logger.info(
+                        "User %s viewed Customer %s via res.partner", self.env.uid, record[0]
+                    )
+
             return result
 
         redacted_result = []
 
         for record in result:
-            if (isinstance(record, tuple)
-                    and self.sudo().search_count([('id', '=', record[0]),
-                                                  ('customer', '=', True)])):
+            if isinstance(record, tuple) and self.sudo().search_count(
+                [("id", "=", record[0]), ("customer", "=", True)]
+            ):
                 # Record ID remains and string value redacted
                 redacted_result.append((record[0], REDACTED_TXT))
                 _logger.info(REDACTED_TXT + ": res.partner")
@@ -90,7 +107,7 @@ class SaleOrder(models.Model):
     _inherit = "sale.order"
 
     @api.multi
-    def read(self, fields=None, load='_classic_read'):
+    def read(self, fields=None, load="_classic_read"):
         result = super(SaleOrder, self).read(fields=fields, load=load)
         return _read(self, result)
 
@@ -99,15 +116,15 @@ class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
     @api.multi
-    def read(self, fields=None, load='_classic_read'):
+    def read(self, fields=None, load="_classic_read"):
         result = super(SaleOrderLine, self).read(fields=fields, load=load)
         return _read(self, result)
 
 
 class StockPicking(models.Model):
-    _inherit = 'stock.picking'
+    _inherit = "stock.picking"
 
     @api.multi
-    def read(self, fields=None, load='_classic_read'):
+    def read(self, fields=None, load="_classic_read"):
         result = super(StockPicking, self).read(fields=fields, load=load)
         return _read(self, result)

--- a/addons/udes_sale_stock/models/res_groups.py
+++ b/addons/udes_sale_stock/models/res_groups.py
@@ -5,10 +5,8 @@ from odoo import api, fields, models, _
 
 class ResGroups(models.Model):
 
-    _inherit = 'res.groups'
+    _inherit = "res.groups"
 
     u_view_customers = fields.Boolean(
-        string='Customers',
-        help='If a user is allowed to view customers',
-        default=False,
+        string="Customers", help="If a user is allowed to view customers", default=False,
     )

--- a/addons/udes_sale_stock/models/res_users.py
+++ b/addons/udes_sale_stock/models/res_users.py
@@ -5,22 +5,20 @@ from odoo import fields, models
 
 class ResUser(models.Model):
 
-    _inherit = 'res.users'
+    _inherit = "res.users"
 
     def _compute_allowed_to_view_customers(self):
         """ User's allowed to view customers if its group is.
         """
         for user in self:
-            user.u_view_customers = any(
-                user.mapped('groups_id.u_view_customers'))
+            user.u_view_customers = any(user.mapped("groups_id.u_view_customers"))
 
     u_view_customers = fields.Boolean(
-        string='Allowed to view customers',
-        help='If a user is allowed to view customers',
+        string="Allowed to view customers",
+        help="If a user is allowed to view customers",
         compute=_compute_allowed_to_view_customers,
         readonly=True,
     )
 
     # Partners are customers by default. Partners auto-created for a user shouldn't be.
-    customer = fields.Boolean(related='partner_id.customer', inherited=True, default=False)
-       
+    customer = fields.Boolean(related="partner_id.customer", inherited=True, default=False)

--- a/addons/udes_sale_stock/models/sale_order.py
+++ b/addons/udes_sale_stock/models/sale_order.py
@@ -25,23 +25,26 @@ class SaleOrder(models.Model):
     _order = "requested_date asc, priority desc, id asc"
 
     # Add index to origin as this field is frequently used in searches
-    origin = fields.Char(string='Source Document',
-                         help="Reference of the document that generated this sales order request.",
-                         index=True)
+    origin = fields.Char(
+        string="Source Document",
+        help="Reference of the document that generated this sales order request.",
+        index=True,
+    )
 
     # Rename states
-    state = fields.Selection(selection_add=[
-        ('sale', 'In Progress'),
-        ('done', 'Done'),
-    ])
+    state = fields.Selection(selection_add=[("sale", "In Progress"), ("done", "Done"),])
 
-    picking_ids = fields.One2many('stock.picking', inverse_name=None,
-                                  compute="_compute_picking_ids_by_line")
+    picking_ids = fields.One2many(
+        "stock.picking", inverse_name=None, compute="_compute_picking_ids_by_line"
+    )
 
     priority = fields.Selection(
-        selection=common.PRIORITIES, inverse='_set_priority',
-        default='1', string='Priority', index=True,
-        states={'done': [('readonly', True)], 'cancel': [('readonly', True)]}
+        selection=common.PRIORITIES,
+        inverse="_set_priority",
+        default="1",
+        string="Priority",
+        index=True,
+        states={"done": [("readonly", True)], "cancel": [("readonly", True)]},
     )
 
     # Set Customer Reference and Requested Date fields to be required
@@ -49,11 +52,11 @@ class SaleOrder(models.Model):
     client_order_ref = fields.Char(required=True, copy=True)
     requested_date = fields.Datetime(required=True, copy=True)
 
-    @api.depends('order_line.move_ids.picking_id')
+    @api.depends("order_line.move_ids.picking_id")
     def _compute_picking_ids_by_line(self):
-        self.mapped('order_line.move_ids.picking_id')
+        self.mapped("order_line.move_ids.picking_id")
         for order in self:
-            order.picking_ids = order.mapped('order_line.move_ids.picking_id')
+            order.picking_ids = order.mapped("order_line.move_ids.picking_id")
 
     @api.model_cr
     def init(self):
@@ -62,9 +65,9 @@ class SaleOrder(models.Model):
 
         tools.create_index(
             self._cr,
-            'sale_order_requested_date_priority_id_index',
+            "sale_order_requested_date_priority_id_index",
             self._table,
-            ['requested_date ASC', 'priority DESC', 'id ASC'],
+            ["requested_date ASC", "priority DESC", "id ASC"],
         )
 
     @api.multi
@@ -76,34 +79,32 @@ class SaleOrder(models.Model):
     @api.multi
     def _set_priority(self):
         for order in self:
-            order.mapped('order_line.move_ids').write({
-                'priority': order.priority
-            })
+            order.mapped("order_line.move_ids").write({"priority": order.priority})
 
     @api.model
     def get_available_stock_locations(self):
         """ Method returns stock locations that are considered (along with
          their children) stock available for fulfilling orders. Should be
         overridden where necessary """
-        return self.env.ref('stock.stock_location_stock')
+        return self.env.ref("stock.stock_location_stock")
 
     @api.model
     def get_available_quantity(self, product, locations):
         """ Get available quantity of product_id within locations """
-        Stock = self.env['stock.quant']
-        domain = [('product_id', '=', product.id),
-                  ('location_id', 'child_of', locations.ids)]
+        Stock = self.env["stock.quant"]
+        domain = [("product_id", "=", product.id), ("location_id", "child_of", locations.ids)]
         quants = Stock.search(domain)
-        available_quantity = sum(quants.mapped('quantity')) - \
-                             sum(quants.mapped('reserved_quantity'))
+        available_quantity = sum(quants.mapped("quantity")) - sum(
+            quants.mapped("reserved_quantity")
+        )
         return available_quantity
 
     @api.model
     def cancel_orders_without_availability(self):
         """ From the current list of unconfirmed SO lines, cancel lines that
         cannot be fulfilled with current stock holding """
-        OrderLine = self.env['sale.order.line']
-        Order = self.env['sale.order']
+        OrderLine = self.env["sale.order.line"]
+        Order = self.env["sale.order"]
 
         _logger.info("Checking orders to cancel due to stock shortage")
         # Get unreserved stock for each product in locations
@@ -114,10 +115,10 @@ class SaleOrder(models.Model):
         cant_fulfill = OrderLine.browse()
 
         # Get order lines
-        orders = Order.search([('state', 'in', ['sale', 'draft'])])
+        orders = Order.search([("state", "in", ["sale", "draft"])])
 
         for r, batch in orders.batched(size=1000):
-            _logger.info('Checking orders %d-%d', r[0], r[-1])
+            _logger.info("Checking orders %d-%d", r[0], r[-1])
             # Cache the needed fields and only the needed fields
             # This code has to process tens of thousands of sale order lines
             # and hundreds of thousands of stock moves.
@@ -134,14 +135,12 @@ class SaleOrder(models.Model):
             # mapped() will load in as many fields as it can due to prefetching.
             # with_context(prefetch_fields=False) could be used with mapped()
             # but is limited to a single column at a time.
-            batch.mapped('order_line')
-            batch.mapped('order_line').read(['is_cancelled',
-                                             'product_id',
-                                             'product_uom_qty'],
-                                            load='_classic_write')
-            batch.mapped('order_line.move_ids')
-            batch.mapped('order_line.move_ids').read(['state'],
-                                                     load='_classic_write')
+            batch.mapped("order_line")
+            batch.mapped("order_line").read(
+                ["is_cancelled", "product_id", "product_uom_qty"], load="_classic_write"
+            )
+            batch.mapped("order_line.move_ids")
+            batch.mapped("order_line.move_ids").read(["state"], load="_classic_write")
             # NB: Using with_context(prefetch_fields=False) then
             #     mapped('order_line.move_ids.state') results in unwanted
             #     extra SQL queries. mapped('order_line.move_ids') followed by
@@ -152,51 +151,48 @@ class SaleOrder(models.Model):
                 # can or cant fulfill record sets
                 # If this code is modified, the caching above needs to be
                 # kept up to date to ensure good performance
-                for line in order.order_line.filtered(lambda x:
-                                                      not x.is_cancelled):
+                for line in order.order_line.filtered(lambda x: not x.is_cancelled):
 
                     # If any of the mls are done or assigned then skip this line
-                    line_states = line.mapped('move_ids.state')
-                    skip_states = ('assigned', 'done', 'cancel')
+                    line_states = line.mapped("move_ids.state")
+                    skip_states = ("assigned", "done", "cancel")
                     if any(x in line_states for x in skip_states):
                         continue
 
                     product = line.product_id
 
                     if product not in stock.keys():
-                        stock[product] = self.get_available_quantity(product,
-                                                                     locations)
+                        stock[product] = self.get_available_quantity(product, locations)
                     qty_ordered = line.product_uom_qty
                     if stock[product] >= qty_ordered:
-                        stock[product] = stock[product]-qty_ordered
+                        stock[product] = stock[product] - qty_ordered
                     else:
                         cant_fulfill |= line
 
             # Empty cached stuff
             batch.invalidate_cache()
 
-        _logger.info("Cancelling %s unfulfillable order lines",
-                     len(cant_fulfill))
+        _logger.info("Cancelling %s unfulfillable order lines", len(cant_fulfill))
         if cant_fulfill:
             # Cancel these lines
             with self.statistics() as stats:
                 cant_fulfill.action_cancel()
-                cant_fulfill.write({'is_cancelled_due_shortage': True})
+                cant_fulfill.write({"is_cancelled_due_shortage": True})
 
             _logger.info(
-                "Sale lines on orders %s cancelled in %.2fs, %d queries, due to"
-                " stock shortage,",
-                ', '.join(cant_fulfill.mapped('order_id.name')),
+                "Sale lines on orders %s cancelled in %.2fs, %d queries, due to" " stock shortage,",
+                ", ".join(cant_fulfill.mapped("order_id.name")),
                 stats.elapsed,
-                stats.count
+                stats.count,
             )
 
-            cancelled_sales = cant_fulfill.mapped('order_id') \
-                .filtered(lambda x: x.state == 'cancel')
+            cancelled_sales = cant_fulfill.mapped("order_id").filtered(
+                lambda x: x.state == "cancel"
+            )
             if cancelled_sales:
                 _logger.info(
                     "Sales %s cancelling due to missing stock",
-                    ', '.join(cancelled_sales.mapped('name'))
+                    ", ".join(cancelled_sales.mapped("name")),
                 )
 
         return cant_fulfill
@@ -209,15 +205,11 @@ class SaleOrder(models.Model):
             terminal state (at least one of which is in state done).
         """
         for order in self:
-            last_pickings = order.picking_ids.filtered(
-                lambda p: len(p.u_next_picking_ids) == 0
-            )
+            last_pickings = order.picking_ids.filtered(lambda p: len(p.u_next_picking_ids) == 0)
             completed_last_pickings = last_pickings.filtered(
-                lambda p: p.state in ['done', 'cancel']
+                lambda p: p.state in ["done", "cancel"]
             )
-            cancelled_last_pickings = last_pickings.filtered(
-                lambda p: p.state == 'cancel'
-            )
+            cancelled_last_pickings = last_pickings.filtered(lambda p: p.state == "cancel")
             if last_pickings == cancelled_last_pickings:
                 order.with_context(from_sale=True).action_cancel()
             elif last_pickings == completed_last_pickings:
@@ -225,18 +217,16 @@ class SaleOrder(models.Model):
 
     def action_cancel(self):
         """Override to cancel by moves instead of by pickings"""
-        self.mapped('order_line').action_cancel()
-        return self.write({'state': 'cancel'})
+        self.mapped("order_line").action_cancel()
+        return self.write({"state": "cancel"})
 
     def check_state_cancelled(self):
         to_cancel = self.browse()
-        for order in self.filtered(
-                lambda o: o.state not in ['done', 'cancel']):
-            non_cancelled = order.order_line.filtered(
-                lambda l: not l.is_cancelled)
+        for order in self.filtered(lambda o: o.state not in ["done", "cancel"]):
+            non_cancelled = order.order_line.filtered(lambda l: not l.is_cancelled)
             if len(non_cancelled) == 0:
                 to_cancel |= order
-        to_cancel.write({'state': 'cancel'})
+        to_cancel.write({"state": "cancel"})
 
     @api.model
     def confirm_if_due(self):
@@ -246,20 +236,16 @@ class SaleOrder(models.Model):
 
         Returns recordset of orders where confirmation was attempted
         """
-        days = self.env.ref('stock.warehouse0').u_so_auto_confirm_ahead_days
-        unconfirmed_states = ('draft', 'sent')
-        unconfirmed_so = self or self.search(
-            [('state', 'in', unconfirmed_states)]
-        )
+        days = self.env.ref("stock.warehouse0").u_so_auto_confirm_ahead_days
+        unconfirmed_states = ("draft", "sent")
+        unconfirmed_so = self or self.search([("state", "in", unconfirmed_states)])
 
         # If ahead days set to -1, confirm all.
         if days == -1:
             return unconfirmed_so.action_confirm()
 
         to_date = fields.Datetime.to_string(date.today() + timedelta(days=days))
-        so_to_confirm = unconfirmed_so.filtered(
-            lambda so: so.requested_date <= to_date
-        )
+        so_to_confirm = unconfirmed_so.filtered(lambda so: so.requested_date <= to_date)
         return so_to_confirm.action_confirm()
 
     def get_current_demand(self, products=None):
@@ -268,29 +254,27 @@ class SaleOrder(models.Model):
 
         Returns defaultdict(int, {product.product(1,): 12.0})
         """
-        OrderLine = self.env['sale.order.line']
+        OrderLine = self.env["sale.order.line"]
 
         # Get order lines
-        domain = [('state', '=', 'sale'),
-                  ('is_cancelled', '=', False)]
+        domain = [("state", "=", "sale"), ("is_cancelled", "=", False)]
         if products:
-            domain.append(('product_id', 'in', products.ids))
+            domain.append(("product_id", "in", products.ids))
         # Override the search order since the default model order can involve
         # joins, which perform poorly, and the order does not matter here.
-        order_lines = OrderLine.search(domain, order='id')
+        order_lines = OrderLine.search(domain, order="id")
         demand = defaultdict(int)
 
         for r, batch in order_lines.batched(size=1000):
             # Cache the needed fields and only the needed fields
             # See cancel_sale_orders_without_availability for details
-            batch.read(['is_cancelled', 'product_id', 'product_uom_qty'],
-                       load='_classic_write')
-            batch.mapped('move_ids')
-            batch.mapped('move_ids').read(['state'], load='_classic_write')
+            batch.read(["is_cancelled", "product_id", "product_uom_qty"], load="_classic_write")
+            batch.mapped("move_ids")
+            batch.mapped("move_ids").read(["state"], load="_classic_write")
             for line in batch:
                 # If any of the moves are done or cancelled then skip this line
-                line_states = line.mapped('move_ids.state')
-                if any(x in line_states for x in ('done', 'cancel')):
+                line_states = line.mapped("move_ids.state")
+                if any(x in line_states for x in ("done", "cancel")):
                     continue
                 product = line.product_id
                 demand[product] += line.product_uom_qty
@@ -308,7 +292,7 @@ class SaleOrder(models.Model):
         """Process sale and cancel, confirm or ignore sale orders according to
            order processing configuration.
         """
-        to_confirm = self.search([('state', '=', 'draft')])
+        to_confirm = self.search([("state", "=", "draft")])
         for _, batch in to_confirm.batched(size=1000):
             tries = 0
             while True:
@@ -340,7 +324,7 @@ class SaleOrder(models.Model):
                     )
                     time.sleep(wait_time)
                 except Exception:
-                    _logger.exception('Error confirming orders.')
+                    _logger.exception("Error confirming orders.")
                     self.invalidate_cache()
                     break
             if tries >= MAX_TRIES_ON_CONCURRENCY_FAILURE:
@@ -356,30 +340,32 @@ class SaleOrder(models.Model):
 
 class SaleOrderCancelWizard(models.TransientModel):
     """ This only exists to allow a confirm dialogue from a menu item """
+
     _name = "sale.order.cancel.wizard"
-    result = fields.Char('Result')
+    result = fields.Char("Result")
 
     def cancel_unfulfillable_sales(self):
         with self.statistics() as stats:
-            lines = self.env['sale.order'].cancel_orders_without_availability()
+            lines = self.env["sale.order"].cancel_orders_without_availability()
 
         if lines:
-            message = "%s sale lines on %s orders cancelled in %.2fs" %\
-                      (len(lines),
-                       len(lines.mapped('order_id')),
-                       stats.elapsed)
+            message = "%s sale lines on %s orders cancelled in %.2fs" % (
+                len(lines),
+                len(lines.mapped("order_id")),
+                stats.elapsed,
+            )
         else:
             message = "No orders cancelled"
 
         self.result = message
-        template = self.env.ref('udes_sale_stock.view_cancellation_result')
+        template = self.env.ref("udes_sale_stock.view_cancellation_result")
         return {
-            'name': 'Cancellation Result',
-            'res_model': 'sale.order.cancel.wizard',
-            'type': 'ir.actions.act_window',
-            'view_type': 'form',
-            'view_mode': 'form',
-            'target': 'new',
-            'res_id': self.id,
-            'view_id': template.id
+            "name": "Cancellation Result",
+            "res_model": "sale.order.cancel.wizard",
+            "type": "ir.actions.act_window",
+            "view_type": "form",
+            "view_mode": "form",
+            "target": "new",
+            "res_id": self.id,
+            "view_id": template.id,
         }

--- a/addons/udes_sale_stock/models/sale_order_line.py
+++ b/addons/udes_sale_stock/models/sale_order_line.py
@@ -6,24 +6,24 @@ from odoo import api, models, fields
 
 
 class SaleOrderLine(models.Model):
-    _inherit = 'sale.order.line'
+    _inherit = "sale.order.line"
 
-    is_cancelled = fields.Boolean(string='Cancelled', readonly=True,
-                                  default=False, index=True)
-    cancel_date = fields.Datetime(string='Cancel Date',
-                                  help='Time of cancellation',
-                                  readonly=True, index=True)
+    is_cancelled = fields.Boolean(string="Cancelled", readonly=True, default=False, index=True)
+    cancel_date = fields.Datetime(
+        string="Cancel Date", help="Time of cancellation", readonly=True, index=True
+    )
     is_cancelled_due_shortage = fields.Boolean(
-        string='Cancelled due to a Shortage',
-        help='Whether the sale order line was cancelled due to a stock shortage',
+        string="Cancelled due to a Shortage",
+        help="Whether the sale order line was cancelled due to a stock shortage",
         default=False,
-        index=True)
+        index=True,
+    )
 
     def _prepare_procurement_values(self, group_id=False):
         values = super()._prepare_procurement_values(group_id)
-        values.update({
-            'priority': self.order_id.priority,
-        })
+        values.update(
+            {"priority": self.order_id.priority,}
+        )
         return values
 
     def action_cancel(self):
@@ -34,11 +34,11 @@ class SaleOrderLine(models.Model):
             return False
 
         now_date = datetime.now()
-        to_cancel.write({'is_cancelled': True,
-                         'cancel_date': fields.Datetime.to_string(now_date)})
-        to_cancel.mapped('move_ids').filtered(
-            lambda m: m.state not in ('done', 'cancel'))._action_cancel()
-        to_cancel.mapped('order_id').check_state_cancelled()
+        to_cancel.write({"is_cancelled": True, "cancel_date": fields.Datetime.to_string(now_date)})
+        to_cancel.mapped("move_ids").filtered(
+            lambda m: m.state not in ("done", "cancel")
+        )._action_cancel()
+        to_cancel.mapped("order_id").check_state_cancelled()
 
     def _action_launch_procurement_rule(self):
         not_cancelled_lines = self.filtered(lambda l: not l.is_cancelled)

--- a/addons/udes_sale_stock/models/stock_move.py
+++ b/addons/udes_sale_stock/models/stock_move.py
@@ -3,35 +3,36 @@ from odoo import api, fields, models
 from datetime import datetime
 
 import logging
+
 _logger = logging.getLogger(__name__)
 
 
 class StockMove(models.Model):
 
-    _inherit = 'stock.move'
+    _inherit = "stock.move"
 
     def _action_done(self):
         result = super(StockMove, self)._action_done()
-        result.mapped('sale_line_id.order_id').check_delivered()
+        result.mapped("sale_line_id.order_id").check_delivered()
 
         return result
 
     def _action_cancel(self):
-        location_customers = self.env.ref('stock.stock_location_customers')
-        from_sale = self.env.context.get('from_sale', False)
+        location_customers = self.env.ref("stock.stock_location_customers")
+        from_sale = self.env.context.get("from_sale", False)
         result = True
         if not from_sale:
             result = super(StockMove, self)._action_cancel()
-            self.mapped('sale_line_id.order_id').check_delivered()
+            self.mapped("sale_line_id.order_id").check_delivered()
 
         def not_cancelled_filter(m):
-            return m.state not in ['cancel'] \
-                   and m.location_dest_id == location_customers
+            return m.state not in ["cancel"] and m.location_dest_id == location_customers
 
-        lines_to_cancel = self.filtered(
-            lambda m: m.location_dest_id == location_customers) \
-            .mapped('sale_line_id').filtered(
-            lambda s: len(s.move_ids.filtered(not_cancelled_filter)) == 0)
+        lines_to_cancel = (
+            self.filtered(lambda m: m.location_dest_id == location_customers)
+            .mapped("sale_line_id")
+            .filtered(lambda s: len(s.move_ids.filtered(not_cancelled_filter)) == 0)
+        )
         if lines_to_cancel:
             lines_to_cancel.action_cancel()
 

--- a/addons/udes_sale_stock/models/stock_move_line.py
+++ b/addons/udes_sale_stock/models/stock_move_line.py
@@ -2,24 +2,22 @@ from odoo import models
 
 
 class StockMoveLine(models.Model):
-    _inherit = 'stock.move.line'
+    _inherit = "stock.move.line"
 
     def _prepare_task_info(self):
         """ Prepares info of a task
         """
         task = super(StockMoveLine, self)._prepare_task_info()
-        picking = self.mapped('picking_id')
+        picking = self.mapped("picking_id")
         picking.ensure_one()
         user_scans = picking.picking_type_id.u_user_scans
         use_packaging = picking.picking_type_id.u_use_product_packaging
-        if user_scans == 'product' and use_packaging:
+        if user_scans == "product" and use_packaging:
             product_packaging = None
-            privacy = self.env.ref('udes_stock.privacy_wrapping')
-            if privacy in self.mapped('move_id.sale_line_id.product_packaging'):
+            privacy = self.env.ref("udes_stock.privacy_wrapping")
+            if privacy in self.mapped("move_id.sale_line_id.product_packaging"):
                 product_packaging = privacy.name
 
-            task.update({
-                'product_packaging': product_packaging
-            })
+            task.update({"product_packaging": product_packaging})
 
         return task

--- a/addons/udes_sale_stock/models/stock_warehouse.py
+++ b/addons/udes_sale_stock/models/stock_warehouse.py
@@ -2,11 +2,10 @@ from odoo import fields, models, _
 
 
 class StockWarehouse(models.Model):
-    _inherit = 'stock.warehouse'
+    _inherit = "stock.warehouse"
 
     u_so_auto_confirm_ahead_days = fields.Integer(
         "Auto Confirm sale order within (days)",
         default=1,
-        help="Days ahead to auto confirm sales orders for. "
-             "0 = Today, 1 = Tomorrow, -1 = All"
+        help="Days ahead to auto confirm sales orders for. " "0 = Today, 1 = Tomorrow, -1 = All",
     )

--- a/addons/udes_sale_stock/tests/common.py
+++ b/addons/udes_sale_stock/tests/common.py
@@ -1,5 +1,7 @@
 from odoo.addons.udes_stock.tests import common
 
+from datetime import datetime
+
 
 class BaseSaleUDES(common.BaseUDES):
 
@@ -30,6 +32,9 @@ class BaseSaleUDES(common.BaseUDES):
             'partner_invoice_id': customer.id,
             'partner_shipping_id': customer.id,
             'pricelist_id': cls.env.ref('product.list0').id,
+            'client_order_ref': 'Test',
+            'requested_date': datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+
         }
         create_values.update(kwargs)
         return cls.env['sale.order'].create(create_values)

--- a/addons/udes_sale_stock/tests/common.py
+++ b/addons/udes_sale_stock/tests/common.py
@@ -4,37 +4,35 @@ from datetime import datetime
 
 
 class BaseSaleUDES(common.BaseUDES):
-
     @classmethod
     def setUpClass(cls):
         super(BaseSaleUDES, cls).setUpClass()
-        cls.customer = cls.env.ref('base.public_partner')
+        cls.customer = cls.env.ref("base.public_partner")
 
     @classmethod
     def create_sale_line(cls, sale, product, qty, **kwargs):
         """Create a sale order line and attach it a sale order"""
         create_values = {
-            'name': product.name,
-            'order_id': sale.id,
-            'product_id': product.id,
-            'product_uom_qty': qty,
-            'product_uom': product.uom_id.id,
-            'price_unit': product.list_price,
+            "name": product.name,
+            "order_id": sale.id,
+            "product_id": product.id,
+            "product_uom_qty": qty,
+            "product_uom": product.uom_id.id,
+            "price_unit": product.list_price,
         }
         create_values.update(kwargs)
-        return cls.env['sale.order.line'].create(create_values)
+        return cls.env["sale.order.line"].create(create_values)
 
     @classmethod
     def create_sale(cls, customer, **kwargs):
         """Create a sale order"""
         create_values = {
-            'partner_id': customer.id,
-            'partner_invoice_id': customer.id,
-            'partner_shipping_id': customer.id,
-            'pricelist_id': cls.env.ref('product.list0').id,
-            'client_order_ref': 'Test',
-            'requested_date': datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-
+            "partner_id": customer.id,
+            "partner_invoice_id": customer.id,
+            "partner_shipping_id": customer.id,
+            "pricelist_id": cls.env.ref("product.list0").id,
+            "client_order_ref": "Test",
+            "requested_date": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
         }
         create_values.update(kwargs)
-        return cls.env['sale.order'].create(create_values)
+        return cls.env["sale.order"].create(create_values)

--- a/addons/udes_sale_stock/tests/test_cancel_unfulfillable.py
+++ b/addons/udes_sale_stock/tests/test_cancel_unfulfillable.py
@@ -2,50 +2,49 @@ from . import common
 
 
 class TestCancelUnfulfillable(common.BaseSaleUDES):
-
     @classmethod
     def setUpClass(cls):
         super(TestCancelUnfulfillable, cls).setUpClass()
-        cls.Customer = cls.env['res.partner']
-        cls.Sale = cls.env['sale.order']
+        cls.Customer = cls.env["res.partner"]
+        cls.Sale = cls.env["sale.order"]
 
     def test01_test_cancel_in_order(self):
         """
         Test that sale order cancellation works as expected
         """
-        customer = self.Customer.create({
-            'name': 'Bob',
-            'street': '1 Bobs House',
-            'street2': 'Bobs street',
-            'city': 'The city of Bob',
-            'zip': 'EN1 4LS'
-        })
-        quant = self.create_quant(self.apple.id,
-                                  self.test_location_01.id,
-                                  30,
-                                  package_id=self.create_package().id)
-        quant2 = self.create_quant(self.cherry.id,
-                                   self.test_location_01.id,
-                                   20,
-                                   package_id=self.create_package().id)
+        customer = self.Customer.create(
+            {
+                "name": "Bob",
+                "street": "1 Bobs House",
+                "street2": "Bobs street",
+                "city": "The city of Bob",
+                "zip": "EN1 4LS",
+            }
+        )
+        quant = self.create_quant(
+            self.apple.id, self.test_location_01.id, 30, package_id=self.create_package().id
+        )
+        quant2 = self.create_quant(
+            self.cherry.id, self.test_location_01.id, 20, package_id=self.create_package().id
+        )
 
         # Order 1
         sale = self.create_sale(customer)
         sale1l1 = self.create_sale_line(sale, self.apple, 15)
         sale1l2 = self.create_sale_line(sale, self.cherry, 2)
-        sale.requested_date = '2020-01-03'
+        sale.requested_date = "2020-01-03"
 
         # Order 2
         sale2 = self.create_sale(customer)
         sale2l1 = self.create_sale_line(sale2, self.apple, 10)
         sale2l2 = self.create_sale_line(sale2, self.cherry, 10)
-        sale2.requested_date = '2020-01-04'
+        sale2.requested_date = "2020-01-04"
 
         # Order 3
         sale3 = self.create_sale(customer)
         sale3l1 = self.create_sale_line(sale3, self.apple, 5)
         sale3l2 = self.create_sale_line(sale3, self.cherry, 8)
-        sale3.requested_date = '2020-01-03'
+        sale3.requested_date = "2020-01-03"
 
         # Confirm sales
         sales = sale | sale2 | sale3
@@ -55,25 +54,25 @@ class TestCancelUnfulfillable(common.BaseSaleUDES):
         self.Sale.cancel_orders_without_availability()
 
         # Unreserve moves, won't cancel sale lines with stock that is reserved
-        sales.mapped('order_line.move_ids')._do_unreserve()
+        sales.mapped("order_line.move_ids")._do_unreserve()
 
         # Verify all are confirmed
-        self.assertTrue(all(x == 'sale' for x in sales.mapped('state')))
+        self.assertTrue(all(x == "sale" for x in sales.mapped("state")))
 
         # Adjust quants and check availability again
         quant.quantity = 20
         quant2.quantity = 5
         self.Sale.cancel_orders_without_availability()
 
-        self.assertEqual(sale.state, 'sale')
+        self.assertEqual(sale.state, "sale")
         self.assertFalse(sale1l1.is_cancelled)
         self.assertFalse(sale1l2.is_cancelled)
 
-        self.assertEqual(sale2.state, 'cancel')
+        self.assertEqual(sale2.state, "cancel")
         self.assertTrue(sale2l1.is_cancelled)
         self.assertTrue(sale2l2.is_cancelled)
 
-        self.assertEqual(sale3.state, 'sale')
+        self.assertEqual(sale3.state, "sale")
         self.assertFalse(sale3l1.is_cancelled)
         self.assertTrue(sale3l2.is_cancelled)
 
@@ -82,15 +81,15 @@ class TestCancelUnfulfillable(common.BaseSaleUDES):
         quant2.quantity = 2
         self.Sale.cancel_orders_without_availability()
 
-        self.assertEqual(sale.state, 'sale')
+        self.assertEqual(sale.state, "sale")
         self.assertTrue(sale1l1.is_cancelled)
         self.assertFalse(sale1l2.is_cancelled)
 
-        self.assertEqual(sale2.state, 'cancel')
+        self.assertEqual(sale2.state, "cancel")
         self.assertTrue(sale2l1.is_cancelled)
         self.assertTrue(sale2l2.is_cancelled)
 
-        self.assertEqual(sale3.state, 'sale')
+        self.assertEqual(sale3.state, "sale")
         self.assertFalse(sale3l1.is_cancelled)
         self.assertTrue(sale3l2.is_cancelled)
 
@@ -100,5 +99,5 @@ class TestCancelUnfulfillable(common.BaseSaleUDES):
         self.Sale.cancel_orders_without_availability()
 
         # Check everything is cancelled
-        self.assertTrue(all(x == 'cancel' for x in sales.mapped('state')))
-        self.assertTrue(all(sales.mapped('order_line.is_cancelled')))
+        self.assertTrue(all(x == "cancel" for x in sales.mapped("state")))
+        self.assertTrue(all(sales.mapped("order_line.is_cancelled")))

--- a/addons/udes_sale_stock/tests/test_get_current_demand.py
+++ b/addons/udes_sale_stock/tests/test_get_current_demand.py
@@ -3,25 +3,26 @@ from collections import defaultdict
 
 
 class TestGetCurrentDemand(common.BaseSaleUDES):
-
     @classmethod
     def setUpClass(cls):
         super(TestGetCurrentDemand, cls).setUpClass()
-        cls.Customer = cls.env['res.partner']
-        cls.Sale = cls.env['sale.order']
-        cls.SaleLine = cls.env['sale.order.line']
+        cls.Customer = cls.env["res.partner"]
+        cls.Sale = cls.env["sale.order"]
+        cls.SaleLine = cls.env["sale.order.line"]
 
     def test_01_get_current_demand(self):
         """
         Test that sale order cancellation works as expected
         """
-        customer = self.Customer.create({
-            'name': 'Joe',
-            'street': '1 Joes House',
-            'street2': 'Joes street',
-            'city': 'The city of Joe',
-            'zip': 'AB1 2CD'
-        })
+        customer = self.Customer.create(
+            {
+                "name": "Joe",
+                "street": "1 Joes House",
+                "street2": "Joes street",
+                "city": "The city of Joe",
+                "zip": "AB1 2CD",
+            }
+        )
         self.create_quant(self.apple.id, self.test_location_01.id, 30)
         self.create_quant(self.cherry.id, self.test_location_01.id, 20)
 
@@ -29,19 +30,19 @@ class TestGetCurrentDemand(common.BaseSaleUDES):
         sale = self.create_sale(customer)
         self.create_sale_line(sale, self.apple, 15)
         self.create_sale_line(sale, self.cherry, 2)
-        sale.requested_date = '2020-01-03'
+        sale.requested_date = "2020-01-03"
 
         # Order 2
         sale2 = self.create_sale(customer)
         self.create_sale_line(sale2, self.apple, 10)
         self.create_sale_line(sale2, self.cherry, 10)
-        sale2.requested_date = '2020-01-04'
+        sale2.requested_date = "2020-01-04"
 
         # Order 3
         sale3 = self.create_sale(customer)
         self.create_sale_line(sale3, self.apple, 5)
         sale3l2 = self.create_sale_line(sale3, self.cherry, 8)
-        sale3.requested_date = '2020-01-03'
+        sale3.requested_date = "2020-01-03"
 
         sales = sale | sale2 | sale3
 
@@ -67,10 +68,10 @@ class TestGetCurrentDemand(common.BaseSaleUDES):
         self.assertEqual(demand[self.cherry], 12)
 
         # Complete pickings and confirm no further demand
-        pickings = sales.mapped('order_line.move_ids.picking_id')
+        pickings = sales.mapped("order_line.move_ids.picking_id")
         pickings.action_assign()
         for ml in pickings.move_line_ids:
-            ml.write({'qty_done': ml.product_uom_qty})
+            ml.write({"qty_done": ml.product_uom_qty})
         pickings.action_done()
         demand = self.Sale.get_current_demand()
         self.assertEqual(demand, defaultdict(int))

--- a/addons/udes_sale_stock/views/edi_sale_request_views.xml
+++ b/addons/udes_sale_stock/views/edi_sale_request_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<odoo>
+  <data>
+    <!-- EDI sale request records field -->
+      <record id="sale_request_document_form" model="ir.ui.view">
+      <field name="name">edi.sale.request.document.form</field>
+      <field name="model">edi.document</field>
+      <field name="inherit_id" ref="edi.document_form"/>
+      <field name="arch" type="xml">
+        <xpath expr="//field[@name='customer_id']" position="after">
+          <field name="requested_date"/>
+          <field name="client_order_ref"/>
+        </xpath>
+      </field>
+    </record>
+
+  </data>
+</odoo>

--- a/addons/udes_sale_stock/views/sale_order_views.xml
+++ b/addons/udes_sale_stock/views/sale_order_views.xml
@@ -15,6 +15,25 @@
                position="before">
           <field name="is_cancelled"/>
         </xpath>
+
+        <xpath expr="//field[@name='client_order_ref']" position="replace"/>
+
+        <xpath expr="//field[@name='partner_shipping_id']" position="after">
+          <field name="client_order_ref"/>
+        </xpath>
+      </field>
+    </record>
+
+    <record id="view_order_form_inherit_sale_stock_inherit_sale_order_dates_udes" model="ir.ui.view">
+      <field name="name">udes_sale_stock.sale.order.form.sale_order_dates.sale.stock</field>
+      <field name="model">sale.order</field>
+      <field name="inherit_id" ref="sale_order_dates.view_order_form_inherit_sale_stock_inherit_sale_order_dates"/>
+      <field name="arch" type="xml">
+        <xpath expr="//field[@name='requested_date']" position="replace"/>
+
+        <xpath expr="//field[@name='partner_shipping_id']" position="after">
+          <field name="requested_date"/>
+        </xpath>
       </field>
     </record>
 


### PR DESCRIPTION
Customer Reference and Requested Date fields on Sales Orders now required.

Customer Reference and Requested Date fields also moved to the top section of Sales Orders view to be more prominent.

"(copy)" appended to Customer Reference when an Order is copied, as this field now needs to be set on a copied Order.

Updated create_sale function in BaseSaleUDES unit test class to now put in default Customer Reference and Requested Date.

Black formatting run on Python files.