### PR TITLE
[FIX] udes_open: Do not suggest locations with partially available lines

### DIFF
--- a/addons/udes_stock/models/stock_picking.py
+++ b/addons/udes_stock/models/stock_picking.py
@@ -1999,7 +1999,7 @@ class StockPicking(models.Model):
             # remove locations which are already used in move lines
             valid_locations -= MoveLines.search(
                 [
-                    ("state", "=", "assigned"),
+                    ("state", "in", ["assigned", "partially_available"]),
                     ("location_dest_id", "in", valid_locations.ids),
                 ]
             ).mapped("location_dest_id")


### PR DESCRIPTION
User-story/10682
Task/10863

Signed-off-by: Kevin Dwyer <kevin.dwyer@unipart.io>

The suggested locations feature should consider partially available move
lines when determining available locations.