### PR TITLE
Story/10703 - Restrict Multi Lot Transfers flag on Picking Types

### DIFF
--- a/addons/udes_stock/models/stock_picking_type.py
+++ b/addons/udes_stock/models/stock_picking_type.py
@@ -335,6 +335,16 @@ class StockPickingType(models.Model):
         " for any empty picking in the system.",
     )
 
+    u_restrict_multi_lot_pickings = fields.Boolean(
+        string="Restrict Multi Lot Transfers",
+        default=False,
+        help="""
+        If set, transfers can only be validated if all move lines have the same lot.
+        This does not apply to serial number or non-tracked products. However, transfers which
+        contain both set lot and empty lot move lines are restricted.
+        """
+    )
+
     def do_refactor_action(self, action, moves):
         """Resolve and call the method to be executed on the moves.
 
@@ -395,6 +405,7 @@ class StockPickingType(models.Model):
             - u_new_package_policy: string
             - u_num_reservable_pickings: int
             - u_reserve_batches: boolean
+            - u_restrict_multi_lot_pickings: boolean
         """
         self.ensure_one()
         Batch = self.env["stock.picking.batch"]
@@ -446,6 +457,7 @@ class StockPickingType(models.Model):
                 'u_use_part_pallets': self.u_use_part_pallets,
                 'u_num_reservable_pickings': self.u_num_reservable_pickings,
                 'u_reserve_batches': self.u_reserve_batches,
+                'u_restrict_multi_lot_pickings': self.u_restrict_multi_lot_pickings,
                 }
 
     def get_info(self):

--- a/addons/udes_stock/views/stock_picking_type.xml
+++ b/addons/udes_stock/views/stock_picking_type.xml
@@ -56,6 +56,7 @@
                     <field name="u_num_reservable_pickings" />
                     <field name="u_reserve_batches" />
                     <field name="u_auto_unlink_empty" />
+                    <field name="u_restrict_multi_lot_pickings" />
                 </group>
                 <group string="Pick Refactoring" groups='base.group_no_one'>
                     <field name="u_move_line_key_format" />


### PR DESCRIPTION
Added Restrict Multi Lot Transfers flag to Picking Types. When validating a picking a check is carried out to see if the Picking Type restricts multi lot transfers. If it does and the move lines contain more than one unique lot an exception is raised.

Added Unit Test for multi lot picking restriction in TestPickingType.