### PR TITLE
[FIX] udes_security: Credentials checked before resetting signup token

### DIFF
--- a/addons/udes_security/models/__init__.py
+++ b/addons/udes_security/models/__init__.py
@@ -2,4 +2,5 @@ from . import blocked_file_type
 from . import ir_attachment
 from . import res_authentication_attempt
 from . import res_groups
+from . import res_partner
 from . import res_users

--- a/addons/udes_security/models/res_partner.py
+++ b/addons/udes_security/models/res_partner.py
@@ -1,0 +1,14 @@
+from odoo import api, models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    @api.multi
+    def write(self, vals):
+        password = self._context.get("password")
+        if password:
+            partner_user = self.user_ids and self.user_ids[0]
+
+            partner_user._check_password(password)
+        return super(ResPartner, self).write(vals)


### PR DESCRIPTION
Ensured that the strength and history of the password are checked prior to resetting the signup token. This means that any discrepancies are found earlier and will allow the user to subsequently provide a valid password successfully.

Story/1380

Signed-off-by: Adam Patrick <adam.patrick@unipart.io>