### PR TITLE
[IMP] udes_stock: Raise error when result parent package has wrong location

### DIFF
--- a/addons/udes_stock/models/stock_move_line.py
+++ b/addons/udes_stock/models/stock_move_line.py
@@ -208,6 +208,19 @@ class StockMoveLine(models.Model):
         # to be marked as done only
         move_lines._assert_result_package(result_package)
 
+        if (
+            loc_dest_instance is not None
+            and parent_package
+            and parent_package.location_id
+            and parent_package.location_id != loc_dest_instance
+        ):
+            # complain now rather than at validation time which could be much
+            # later
+            raise ValidationError(
+                _("Package is already in a different location: %s in %s")
+                % (parent_package.name, parent_package.location_id.name)
+            )
+
         mls_done = MoveLine.browse()
         for ml in move_lines:
             ml_values = values.copy()


### PR DESCRIPTION
Raise an error if a move line would end up with its result parent package
in multiple locations. An error would usually be raised at picking validation
time, but this is too late - by this time other move lines may also have an
invalid result parent package set and labels may have been printed.

User-story: 10539

Signed-off-by: Sean Quah <sean.quah@unipart.io>