### PR TITLE
[ADD] udes_sale_stock: Can keep sale lines when cancelling moves

### DIFF
--- a/addons/udes_sale_stock/models/sale_order.py
+++ b/addons/udes_sale_stock/models/sale_order.py
@@ -229,7 +229,8 @@ class SaleOrder(models.Model):
                 lambda p: p.state in ["done", "cancel"]
             )
             cancelled_last_pickings = last_pickings.filtered(lambda p: p.state == "cancel")
-            if last_pickings == cancelled_last_pickings:
+            if last_pickings == cancelled_last_pickings and \
+                not self.env.context.get("disable_sale_cancel", False):
                 order.with_context(from_sale=True).action_cancel()
             elif last_pickings == completed_last_pickings:
                 order.action_done()

--- a/addons/udes_sale_stock/models/stock_move.py
+++ b/addons/udes_sale_stock/models/stock_move.py
@@ -28,12 +28,13 @@ class StockMove(models.Model):
         def not_cancelled_filter(m):
             return m.state not in ["cancel"] and m.location_dest_id == location_customers
 
-        lines_to_cancel = (
-            self.filtered(lambda m: m.location_dest_id == location_customers)
-            .mapped("sale_line_id")
-            .filtered(lambda s: len(s.move_ids.filtered(not_cancelled_filter)) == 0)
-        )
-        if lines_to_cancel:
-            lines_to_cancel.action_cancel()
+        if not self.env.context.get("disable_sale_cancel", False):
+            lines_to_cancel = (
+                self.filtered(lambda m: m.location_dest_id == location_customers)
+                .mapped("sale_line_id")
+                .filtered(lambda s: len(s.move_ids.filtered(not_cancelled_filter)) == 0)
+            )
+            if lines_to_cancel:
+                lines_to_cancel.action_cancel()
 
         return result


### PR DESCRIPTION
- Added ability to not cancel sale lines when cancelling move
lines using a context variable

User-story: 10626
Signed-off-by: ajrwilliams <anthony.williams@unipart.io>