### PR TITLE
Story/11461 - Delivery Control picking type functionality

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ ADD addons /opt/odoo-addons
 # Module installation (without tests)
 #
 RUN odoo-wrapper --without-demo=all -i \
-    udes_stock,udes_mrp,udes_purchase,udes_report,udes_transport_management,udes_security,edi_sale,udes_sale_stock,udes_scanned_by_tracking
+    udes_stock,udes_mrp,udes_purchase,udes_report,udes_transport_management,udes_security,edi_sale,udes_sale_stock,udes_scanned_by_tracking,udes_delivery_control
 
 # Module tests
 #
-CMD ["--test-enable", "-i", "udes_stock,udes_mrp,udes_purchase,udes_report,udes_transport_management,udes_security,edi_notifier,edi_sale_notifier,udes_sale_stock,udes_scanned_by_tracking"]
+CMD ["--test-enable", "-i", "udes_stock,udes_mrp,udes_purchase,udes_report,udes_transport_management,udes_security,edi_notifier,edi_sale_notifier,udes_sale_stock,udes_scanned_by_tracking,udes_delivery_control"]

--- a/addons/udes_delivery_control/__init__.py
+++ b/addons/udes_delivery_control/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import tests

--- a/addons/udes_delivery_control/data/picking_types.xml
+++ b/addons/udes_delivery_control/data/picking_types.xml
@@ -28,5 +28,10 @@
       <field name="u_is_delivery_control">True</field>
     </record>
 
+    <!-- Update "Goods In" picking type -->
+    <record id="stock.picking_type_in" model="stock.picking.type">
+      <field name="u_handle_partials" eval="False"/>
+    </record>
+
   </data>
 </odoo>

--- a/addons/udes_delivery_control/tests/__init__.py
+++ b/addons/udes_delivery_control/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+from . import common
+from . import test_delivery_control_workflow
+from . import test_related_pickings

--- a/addons/udes_delivery_control/tests/common.py
+++ b/addons/udes_delivery_control/tests/common.py
@@ -1,0 +1,25 @@
+from odoo.addons.udes_stock.tests import common
+
+
+class TestDeliveryControl(common.BaseUDES):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestDeliveryControl, cls).setUpClass()
+
+        cls.Picking = cls.env["stock.picking"]
+
+        cls.delivery_control_picking_type = cls.env.ref(
+            "udes_delivery_control.picking_type_delivery_control"
+        )
+
+        cls.test_supplier = cls.create_partner("Test Supplier", supplier=True)
+
+        delivery_control_picking_vals = {
+            "name": "DC Pick",
+            "partner_id": cls.test_supplier.id,
+            "origin": "DCTesting",
+        }
+        cls.delivery_control_picking = cls.create_picking(
+            cls.delivery_control_picking_type, **delivery_control_picking_vals
+        )

--- a/addons/udes_delivery_control/tests/test_delivery_control_workflow.py
+++ b/addons/udes_delivery_control/tests/test_delivery_control_workflow.py
@@ -1,0 +1,205 @@
+from odoo.exceptions import UserError
+
+from odoo.addons.udes_delivery_control.tests import common
+
+
+class TestDeliveryControlWorkflow(common.TestDeliveryControl):
+    @classmethod
+    def setUpClass(cls):
+        super(TestDeliveryControlWorkflow, cls).setUpClass()
+
+        cls.picking_type_goods_in = cls.env.ref("stock.picking_type_in")
+
+    @classmethod
+    def create_goods_in_picking_from_delivery_control(cls, picking, create_move=True, **kwargs):
+        """
+        Manually create and link a Goods In picking from supplied Delivery Control picking
+
+        Create a move for 1 apple if create move flag set to True (default)
+
+        Return the created Goods In picking
+        """
+        picking.ensure_one()
+
+        picking_vals = {
+            "name": "Goods In Pick",
+            "u_delivery_control_picking_id": picking.id,
+        }
+        picking_vals.update(**kwargs)
+
+        products_info = False
+        if create_move:
+            products_info = [{"product": cls.apple, "qty": 1}]
+
+        goods_in_picking = cls.create_picking(
+            cls.picking_type_goods_in, products_info=products_info, **picking_vals
+        )
+        picking.u_goods_in_picking_id = goods_in_picking
+
+        return goods_in_picking
+
+    def _assert_picking_state(self, picking, expected_state):
+        """Assert that supplied picking's state matches the expected state"""
+        picking.ensure_one()
+
+        self.assertEqual(
+            picking.state,
+            expected_state,
+            f"Picking '{picking.name}' should be in '{expected_state}' state",
+        )
+
+    def _assert_goods_in_picking(self, goods_in_picking, delivery_control_picking):
+        """
+        Assert that Goods In picking has been correctly setup by verifying the following:
+
+        - Is in draft state
+        - Has the right Picking Type set
+        - Is linked to supplied Delivery Control picking
+        - Has pulled across supplier from Delivery Control picking
+        - Has pulled across origin from Delivery Control picking
+        """
+        self._assert_picking_state(goods_in_picking, "draft")
+
+        self.assertEqual(
+            goods_in_picking.picking_type_id,
+            self.picking_type_goods_in,
+            "Goods In picking should have the Goods In picking type",
+        )
+        self.assertEqual(
+            goods_in_picking.u_delivery_control_picking_id,
+            delivery_control_picking,
+            "Goods In picking should be linked to Delivery Control picking",
+        )
+
+        fields_to_check_between_pickings = ["partner_id", "origin"]
+
+        for field in fields_to_check_between_pickings:
+            self.assertEqual(
+                goods_in_picking[field],
+                delivery_control_picking[field],
+                f"Value for '{field}' should be {delivery_control_picking[field]}",
+            )
+
+    def test_assert_delivery_control_workflow_progresses_without_stock_moves(self):
+        """
+        Assert that a Delivery Control picking can progress to done without needing to add
+        any Stock Moves
+        """
+        # Confirm Delivery Control picking - should go into assigned state (aka "Ready")
+        self.delivery_control_picking.action_confirm()
+        self._assert_picking_state(self.delivery_control_picking, "assigned")
+
+        # Set Delivery Control picking to done using method used in the UI
+        self.delivery_control_picking.button_validate()
+        self._assert_picking_state(self.delivery_control_picking, "done")
+
+    def test_assert_goods_in_generated_when_delivery_control_complete(self):
+        """
+        Assert that a Goods In picking is generated when a Delivery Control picking is completed,
+        and is correctly setup
+        """
+        # Mark the Delivery Control picking as done
+        self.delivery_control_picking.action_confirm()
+        self.delivery_control_picking.action_done()
+        self._assert_picking_state(self.delivery_control_picking, "done")
+
+        # Assert that a Goods In picking was generated
+        goods_in_picking = self.delivery_control_picking.u_goods_in_picking_id
+        self.assertEqual(
+            len(goods_in_picking),
+            1,
+            "Completed Delivery Control picking should have generated a Goods In picking",
+        )
+
+        # Assert that Goods In picking has been setup correctly
+        self._assert_goods_in_picking(goods_in_picking, self.delivery_control_picking)
+
+    def test_assert_duplicate_goods_in_not_generated(self):
+        """
+        When a Delivery Control picking is completed and it already has a linked Goods In picking,
+        assert that no duplicate Goods In picking is generated
+        """
+        # Create Goods In picking and link it to Delivery Control picking
+        goods_in_picking = self.create_goods_in_picking_from_delivery_control(
+            self.delivery_control_picking
+        )
+
+        goods_in_search_domain = [("picking_type_id", "=", self.picking_type_goods_in.id)]
+        goods_in_picking_count_before = self.Picking.search_count(goods_in_search_domain)
+
+        # Mark the Delivery Control picking as done
+        self.delivery_control_picking.action_confirm()
+        self.delivery_control_picking.action_done()
+
+        # Assert that the original Goods In picking was not replaced
+        self.assertEqual(
+            self.delivery_control_picking.u_goods_in_picking_id,
+            goods_in_picking,
+            "Delivery Control picking should not have a new Goods In picking",
+        )
+
+        # Assert that no new Goods In pickings were created
+        goods_in_picking_count_after = self.Picking.search_count(goods_in_search_domain)
+        self.assertEqual(
+            goods_in_picking_count_before,
+            goods_in_picking_count_after,
+            "A new Goods In picking should not have been created",
+        )
+
+    def test_assert_goods_in_progress_dependant_on_completed_delivery_control(self):
+        """
+        Assert that a Goods In picking cannot be completed if it is linked to a pending
+        Delivery Control picking
+        """
+        # Create Goods In picking and link it to Delivery Control picking
+        goods_in_picking = self.create_goods_in_picking_from_delivery_control(
+            self.delivery_control_picking
+        )
+
+        # Confirm Delivery Control picking
+        self.delivery_control_picking.action_confirm()
+
+        # Confirm Goods In picking - apple stock should be assigned
+        goods_in_picking.action_confirm()
+        self._assert_picking_state(goods_in_picking, "assigned")
+
+        # Set Goods In move line quantity done values to match match requested quantity
+        # Set destination location for move lines to Input/Received
+        input_received_location = self.env.ref("udes_stock.location_input_received")
+        for ml in goods_in_picking.move_line_ids:
+            ml.qty_done = ml.product_uom_qty
+            ml.location_dest_id = input_received_location
+
+        # Attempt to complete the Goods In picking, and assert that relevant error is raised
+        with self.assertRaisesRegex(
+            UserError,
+            f"Cannot validate {goods_in_picking.name} until all of its"
+            " preceding pickings are done.",
+        ):
+            goods_in_picking.action_done()
+
+        # Complete Delivery Control picking
+        self.delivery_control_picking.action_done()
+
+        # Note: Need to manually recompute pending as it doesn't get recomputed in the test
+        goods_in_picking._compute_pending()
+
+        # Complete the Goods In picking now that the Delivery Control picking is no longer pending
+        goods_in_picking.action_done()
+        self._assert_picking_state(goods_in_picking, "done")
+
+    def test_assert_cancelling_delivery_control_cancels_goods_in(self):
+        """
+        Assert that cancelling a Delivery Control picking will also cancel linked Goods In picking
+        """
+        # Create Goods In picking and link it to Delivery Control picking
+        goods_in_picking = self.create_goods_in_picking_from_delivery_control(
+            self.delivery_control_picking
+        )
+
+        # Cancel Delivery Control picking
+        self.delivery_control_picking.action_cancel()
+
+        # Assert that both Delivery Control and Goods In picking have been cancelled
+        self._assert_picking_state(self.delivery_control_picking, "cancel")
+        self._assert_picking_state(goods_in_picking, "cancel")

--- a/addons/udes_delivery_control/tests/test_related_pickings.py
+++ b/addons/udes_delivery_control/tests/test_related_pickings.py
@@ -1,0 +1,158 @@
+from odoo.addons.udes_delivery_control.tests import common
+
+
+class TestRelatedPickings(common.TestDeliveryControl):
+    @classmethod
+    def setUpClass(cls):
+        super(TestRelatedPickings, cls).setUpClass()
+
+        # Complete Delivery Control picking
+        cls.delivery_control_picking.action_confirm()
+        cls.delivery_control_picking.action_done()
+
+        cls.goods_in_picking = cls.delivery_control_picking.u_goods_in_picking_id
+        cls.goods_in_picking.name = "GI Pick"
+
+    def _assert_picking_related_pickings_match_expected_values(self, pickings, expected_values):
+        """
+        Assert that each supplied picking returns the expected related picking records
+
+        :args:
+                - pickings: A recordset of pickings
+                - expected_values: A dictionary with field names to check as keys
+                                   Each value should be another dictionary with the picking as key, 
+                                   and expected pickings (or False for none) to return as value
+        """
+        for picking in pickings:
+            # Loop through all fields that need to be checked
+            for field in expected_values.keys():
+                returned_picks = picking[field]
+                expected_picks = expected_values[field][picking]
+
+                if not expected_picks:
+                    # Assert that the field returns an empty recordset
+                    self.assertFalse(
+                        returned_picks, f"{picking.name} should not have any pickings for '{field}'"
+                    )
+                else:
+                    # Assert that the recordset only contains the expected picks
+                    expected_pick_names = expected_picks.mapped("name")
+
+                    self.assertEqual(
+                        returned_picks,
+                        expected_picks,
+                        f"'{field}' for {picking.name} should be '{expected_pick_names}'",
+                    )
+
+    def test_assert_delivery_control_goods_in_relationship(self):
+        """
+        Assert that the first/previous/next picking fields are computed correctly
+
+        Delivery Control should be the first picking and before the Goods In picking
+        """
+        expected_pickings_by_field = {
+            "u_first_picking_ids": {
+                self.delivery_control_picking: self.delivery_control_picking,
+                self.goods_in_picking: self.delivery_control_picking,
+            },
+            "u_prev_picking_ids": {
+                self.delivery_control_picking: False,
+                self.goods_in_picking: self.delivery_control_picking,
+            },
+            "u_next_picking_ids": {
+                self.delivery_control_picking: self.goods_in_picking,
+                self.goods_in_picking: False
+            },
+        }
+
+        picks = self.delivery_control_picking | self.goods_in_picking
+
+        # Assert that each computed picking field returns the expected result for all picks
+        self._assert_picking_related_pickings_match_expected_values(
+            picks, expected_pickings_by_field
+        )
+
+    def test_assert_related_pickings_computed_correctly_with_additional_pickings(self):
+        """
+        Assert that the first/previous/next picking fields are computed correctly
+        with the following setup in addition to the Delivery Control and Goods In picking:
+
+        3 picks (A, B and C):
+
+        - Pick A - direct parent of Pick C
+        - Pick B - originates from Goods In Pick
+        - Pick C - originates from Goods In Pick and Pick A
+        """
+        # Create extra picks
+        pick_a = self.create_picking(self.picking_type_pick, name="Pick A")
+        pick_b = self.create_picking(self.picking_type_pick, name="Pick B")
+        pick_c = self.create_picking(self.picking_type_pick, name="Pick C")
+
+        # Create moves for Goods In and extra picks
+        goods_in_move = self.create_move(self.apple, 1, self.goods_in_picking)
+        pick_a_move = self.create_move(self.apple, 1, pick_a)
+        pick_b_move = self.create_move(self.apple, 1, pick_b)
+        pick_c_move = self.create_move(self.apple, 1, pick_c)
+
+        # Set Pick B's move to have originated from Goods In's move
+        pick_b_move.move_orig_ids = goods_in_move
+
+        # Set Pick C's move to have originated from Goods In and Pick A's move
+        pick_c_move.move_orig_ids = goods_in_move | pick_a_move
+
+        # Pick Relationship Diagram
+        #
+        # DC        A
+        # |        /
+        # GI____  /
+        # |     \/
+        # B     C
+        #
+        # Expected Results from Computed Fields
+        #
+        # Pick A:
+        #   -- First: Pick A (A doesn't originate from any pick)
+        #   -- Prev:  False (A doesn't originate from any pick)
+        #   -- Next:  Pick C (C originates from A)
+        #
+        # Pick B:
+        #   -- First: Pick DC (B originates from GI, and GI originates from DC)
+        #   -- Prev:  Pick GI (B originates from GI)
+        #   -- Next:  False (No picks originate from B)
+        #
+        # Pick C:
+        #   -- First: Pick DC and A (C originates from A and GI, and GI originates from DC)
+        #   -- Prev:  Pick GI and A (C originates from A and GI)
+        #   -- Next:  False (No picks originate from C)
+
+        expected_pickings_by_field = {
+            "u_first_picking_ids": {
+                self.delivery_control_picking: self.delivery_control_picking,
+                self.goods_in_picking: self.delivery_control_picking,
+                pick_a: pick_a,
+                pick_b: self.delivery_control_picking,
+                pick_c: self.delivery_control_picking | pick_a,
+            },
+            "u_prev_picking_ids": {
+                self.delivery_control_picking: False,
+                self.goods_in_picking: self.delivery_control_picking,
+                pick_a: False,
+                pick_b: self.goods_in_picking,
+                pick_c: self.goods_in_picking | pick_a,
+            },
+            "u_next_picking_ids": {
+                self.delivery_control_picking: self.goods_in_picking,
+                self.goods_in_picking: pick_b | pick_c,
+                pick_a: pick_c,
+                pick_b: False,
+                pick_c: False,
+            },
+        }
+
+        picks = self.delivery_control_picking | self.goods_in_picking | pick_a | pick_b | pick_c
+
+        # Assert that each computed picking field returns the expected result for all picks
+        self._assert_picking_related_pickings_match_expected_values(
+            picks, expected_pickings_by_field
+        )
+

--- a/addons/udes_stock/tests/test_picking.py
+++ b/addons/udes_stock/tests/test_picking.py
@@ -10,6 +10,7 @@ class TestGoodsInPicking(common.BaseUDES):
         super(TestGoodsInPicking, cls).setUpClass()
         Picking = cls.env["stock.picking"]
         products_info = [{"product": cls.apple, "qty": 10}]
+        cls.picking_type_in.u_handle_partials = True
         cls.test_picking = cls.create_picking(
             cls.picking_type_in,
             origin="test_picking_origin",


### PR DESCRIPTION
Allows for Delivery Control pickings to be completed and cancelled without the need for any moves.

Goods In picking generated when Delivery Control picking completed (if it doesn't have one linked already). Cancelling a Delivery Control picking will also cancel the linked Goods In, and Goods In cannot be completed if the linked Delivery Control picking is in a pending state.

Computed first/previous/next picking fields overridden to take into account Delivery Control pickings.

Unit tests added and udes_delivery_control module added to udes_open Dockerfile.

~~Note: There are some TODOs in the code relating to required fields which are part of story 11446. These will be addressed when that story has been merged in.~~