### PR TITLE
[IMP] udes_stock: Enabled ability to create partners on pickings

### DIFF
--- a/addons/udes_stock/views/stock_picking.xml
+++ b/addons/udes_stock/views/stock_picking.xml
@@ -59,7 +59,7 @@
 
             <!-- Partner field filtered to only see suppliers -->
             <xpath expr="//field[@name='partner_id']" position="replace">
-                <field name="partner_id" domain="[('supplier', '=', True)]" options="{'no_create': True}"/>
+                <field name="partner_id" domain="[('supplier', '=', True)]" context="{'default_supplier': True, 'default_customer': False}"/>
             </xpath>
 
             <!-- Destination location field changed to read-only for goods-in -->


### PR DESCRIPTION
Partners/ Suppliers can now be created quickly via the stock.picking form.

Story/11792

Signed-off-by: Adam Patrick <adam.patrick@unipart.io>