### PR TITLE
[IMP] udes_open: Moved at/post_install from BaseUDES to UnconfiguredB…

### DIFF
--- a/addons/udes_stock/tests/common.py
+++ b/addons/udes_stock/tests/common.py
@@ -11,7 +11,8 @@ SECURITY_GROUPS = [
 ]
 
 
-
+@common.at_install(False)
+@common.post_install(True)
 class UnconfiguredBaseUDES(common.SavepointCase):
     """Defines helper methods without automatic warehouse setup."""
 
@@ -547,8 +548,6 @@ class UnconfiguredBaseUDES(common.SavepointCase):
         return StockInventory.create(vals)
 
 
-@common.at_install(False)
-@common.post_install(True)
 class BaseUDES(UnconfiguredBaseUDES):
 
     @classmethod


### PR DESCRIPTION
…aseUDES

This will ensure any test class that inherits UnconfiguredBaseUDES directly will have its tests run on CI.

Story/11475

Signed-off-by: Peter Clark <peter.clark@unipart.io>