### PR TITLE
[ADD] udes_stock: Add field to disable the `No backorder` button

### DIFF
--- a/addons/udes_stock/README.md
+++ b/addons/udes_stock/README.md
@@ -181,25 +181,26 @@ A move of a specific, handleable item of stock - such as 5 phones, or 1 car door
 
 Configuration information for the an entire warehouse.
 
-| Field Name                         | Type             | Description                    |
-| ---------------------------------- | ---------------- | ------------------------------ |
-| u_handle_damages_picking_type_ids  | [int]            | |
-| u_print_labels_picking_type_ids    | [int]            | |
-| in_type_id                         | int              | |
-| out_type_id                        | int              | |
-| pack_type_id                       | int              | |
-| pick_type_id                       | int              | |
-| int_type_id                        | int              | |
-| u_missing_stock_location_id        | int              | |
-| u_damaged_location_id              | int              | |
-| u_temp_dangerous_location_id       | int              | |
-| u_probres_location_id              | int              | |
-| u_incomplete_location_id           | int              | |
-| u_dangerous_location_id            | int              | |
-| u_package_barcode_regex            | string           | |
-| u_pallet_barcode_regex             | string           | |
-| u_pi_count_move_picking_type       | string           | |
-| u_stock_investigation_picking_type | string           | |
+| Field Name                                     | Type             | Description                    |
+| ---------------------------------------------- | ---------------- | ------------------------------ |
+| u_handle_damages_picking_type_ids              | [int]            | |
+| u_print_labels_picking_type_ids                | [int]            | |
+| u_disable_no_backorder_button_picking_type_ids | [int]            | A list of picking type ids where the user must awlays create a backorder if that is an option |
+| in_type_id                                     | int              | |
+| out_type_id                                    | int              | |
+| pack_type_id                                   | int              | |
+| pick_type_id                                   | int              | |
+| int_type_id                                    | int              | |
+| u_missing_stock_location_id                    | int              | |
+| u_damaged_location_id                          | int              | |
+| u_temp_dangerous_location_id                   | int              | |
+| u_probres_location_id                          | int              | |
+| u_incomplete_location_id                       | int              | |
+| u_dangerous_location_id                        | int              | |
+| u_package_barcode_regex                        | string           | |
+| u_pallet_barcode_regex                         | string           | |
+| u_pi_count_move_picking_type                   | string           | |
+| u_stock_investigation_picking_type             | string           | |
 
 ## Picking Batches (model: stock.picking.batch)
 

--- a/addons/udes_stock/__manifest__.py
+++ b/addons/udes_stock/__manifest__.py
@@ -63,6 +63,7 @@
         'wizard/refactor_views.xml',
         'wizard/replen_views.xml',
         'wizard/reservation_views.xml',
+        "wizard/stock_backorder_confirmation.xml",
         'wizard/stock_picking_to_batch_views.xml',
         'security/ir.model.access.csv',
         'security/ir_module_category.xml',

--- a/addons/udes_stock/models/stock_warehouse.py
+++ b/addons/udes_stock/models/stock_warehouse.py
@@ -19,6 +19,15 @@ class StockWarehouse(models.Model):
 
         return [('id', 'not in', stock_children_locations)]
 
+    def _domain_warehouse_picking_types(self):
+        """
+        Domain for getting picking types in the current warehouse
+        """
+        User = self.env["res.users"]
+
+        warehouse = User.get_user_warehouse()
+        return [("warehouse_id", "=", warehouse.id)]
+
     u_handle_damages_picking_type_ids = fields.Many2many(
         comodel_name='stock.picking.type',
         relation='stock_warehouse_damages_picking_types_rel',
@@ -101,6 +110,15 @@ class StockWarehouse(models.Model):
         help="Allow users to inventory adjust reserved stock."
     )
 
+    u_disable_no_backorder_button_picking_type_ids = fields.Many2many(
+        comodel_name="stock.picking.type",
+        relation="stock_warehouse_disable_no_backorder_button_rel",
+        string="Which Picking Types to hide the `No Backorder`",
+        help="Which Picking Types have to always create backorders on validate when the pickings "
+             "are not fully available, so hide the `No backorder` button.",
+        domain=_domain_warehouse_picking_types
+    )
+
     @lazy_property
     def reserved_package_name(self):
         return list(
@@ -124,6 +142,7 @@ class StockWarehouse(models.Model):
             - u_dangerous_location_id: int
             - u_handle_damages_picking_type_ids: list(int)
             - u_print_labels_picking_type_ids: list(int)
+            - u_disable_no_backorder_button_picking_type_ids: list(int)
             - u_pallet_barcode_regex: string
             - u_package_barcode_regex: string
             - u_show_rpc_timing: boolean
@@ -149,6 +168,7 @@ class StockWarehouse(models.Model):
             'u_dangerous_location_id': self.u_dangerous_location_id.id,
             'u_handle_damages_picking_type_ids': self.u_handle_damages_picking_type_ids.ids,
             'u_print_labels_picking_type_ids': self.u_print_labels_picking_type_ids.ids,
+            "u_disable_no_backorder_button_picking_type_ids": self.u_disable_no_backorder_button_picking_type_ids.ids,
             'u_pallet_barcode_regex': self.u_pallet_barcode_regex,
             'u_package_barcode_regex': self.u_package_barcode_regex,
             'u_pi_count_move_picking_type': self.u_pi_count_move_picking_type.id,

--- a/addons/udes_stock/views/stock_warehouse.xml
+++ b/addons/udes_stock/views/stock_warehouse.xml
@@ -28,6 +28,14 @@
                                    nolabel="1"
                             />
                         </group>
+                        <group name="backorders_picking_type" string="Picking types which must always create a backorder">
+                            <field name="u_disable_no_backorder_button_picking_type_ids"
+                                   widget="many2many_tags"
+                                   placeholder="Picking Types"
+                                   options="{'no_create_edit': True}"
+                                   nolabel="1"
+                            />
+                        </group>
                         <group name="udes_stock_config" string="Stock Config">
                             <field name="u_missing_stock_location_id" />
                             <field name="u_damaged_location_id" />

--- a/addons/udes_stock/wizard/__init__.py
+++ b/addons/udes_stock/wizard/__init__.py
@@ -3,3 +3,4 @@ from . import change_quant_location
 from . import refactor_views
 from . import replen_views
 from . import reservation_views
+from . import stock_backorder_confirmation

--- a/addons/udes_stock/wizard/stock_backorder_confirmation.py
+++ b/addons/udes_stock/wizard/stock_backorder_confirmation.py
@@ -1,0 +1,24 @@
+from odoo import api, fields, models, _
+
+
+class StockBackorderConfirmation(models.TransientModel):
+    _inherit = "stock.backorder.confirmation"
+
+    u_disable_no_backorder_button = fields.Boolean(
+        string="Disable `No Backorder` button",
+        compute="_compute_disable_no_backorder_button",
+        help="Hide the `No Backorder` button if a user must always create a backorder when "
+        "validating a picking not fully available for that picking type.",
+    )
+
+    @api.depends("pick_ids")
+    def _compute_disable_no_backorder_button(self):
+        """Compute if the picking type must always create a backorder"""
+        Users = self.env["res.users"]
+
+        warehouse = Users.get_user_warehouse()
+        picking_type = self.pick_ids.mapped("picking_type_id")
+        picking_type.ensure_one()
+        self.u_disable_no_backorder_button = (
+            picking_type in warehouse.u_disable_no_backorder_button_picking_type_ids
+        )

--- a/addons/udes_stock/wizard/stock_backorder_confirmation.xml
+++ b/addons/udes_stock/wizard/stock_backorder_confirmation.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<odoo>
+    <data>
+        <!-- Change backorder confirmation -->
+        <record id="view_backorder_confirmation" model="ir.ui.view">
+            <field name="name">udes_stock.stock.backorder.confirmation</field>
+            <field name="model">stock.backorder.confirmation</field>
+            <field name="inherit_id" ref="stock.view_backorder_confirmation"/>
+            <field name="arch" type="xml">
+                <xpath expr="//form" position="inside">
+                    <field name="u_disable_no_backorder_button" invisible="1"/>
+                </xpath>
+                <!-- Hide the description as it is no longer ambiguous if the `No backorder` button is disabled -->
+                <xpath expr="//group/p[hasclass('text-muted')]" position="attributes">
+                    <attribute name="attrs">{'invisible': [('u_disable_no_backorder_button', '=', True)]}</attribute>
+                </xpath>
+                <!-- Hide the `No backorder` button for that picking type if necessary-->
+                <xpath expr="//button[@name='process_cancel_backorder']" position="attributes">
+                    <attribute name="attrs">{'invisible': [('u_disable_no_backorder_button', '=', True)]}</attribute>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Add `u_disable_no_backorder_button_picking_type_ids` to stock.warehouse, and
`u_disable_no_backorder_button` to stock.backorder.confirmation. This allows
easier configuration of the picking types that must always create a backorder
when validating in the UI when not everything is available/done.

User-story: 11495

Signed-off-by: Pete Pratt <peter.pratt@unipart.io>