### PR TITLE
Story 11973

### DIFF
--- a/addons/udes_stock/views/stock_picking.xml
+++ b/addons/udes_stock/views/stock_picking.xml
@@ -260,6 +260,22 @@
             <xpath expr="//a[@name='%(stock.action_picking_form)d' and not(@context)]" position="attributes">
                 <attribute name="invisible">1</attribute>
             </xpath>
+            <xpath expr="//div[@class='col-xs-6 o_kanban_primary_left']" position="inside">
+                <field name="u_show_package_count" invisible="1"/>
+                <field name="u_package_count_button_name" invisible="1"/>
+                <field name="u_package_count" invisible="1"/>
+                <field name="u_show_transfer_count" invisible="1"/>
+                <t t-if="record.u_show_package_count.raw_value">
+                    <button class="btn btn-primary" name="get_action_package_tree" type="object" id="btn_package_count">
+                        <span>
+                            <t t-esc="record.u_package_count.value"/> <t t-esc="record.u_package_count_button_name.raw_value"/>
+                        </span>
+                    </button>
+                </t>
+            </xpath>
+            <xpath expr="//button[@name='get_action_picking_tree_ready']" position="attributes">
+                <attribute name="t-if">record.u_show_transfer_count.raw_value</attribute>
+            </xpath>
         </field>
     </record>
 

--- a/addons/udes_stock/views/stock_picking_type.xml
+++ b/addons/udes_stock/views/stock_picking_type.xml
@@ -75,10 +75,17 @@
                 </group>
             </xpath>
 
+            <field name="show_operations" position="after">
+                <field name="u_show_transfer_count"/>
+                <field name="u_show_package_count"/>
+            </field>
             <xpath expr="//field[@name='default_location_dest_id']" position="after">
                 <field name="u_damaged_location_id" options="{'no_create': True}"/>
                 <field name="u_good_location_id" options="{'no_create': True}"/>
             </xpath>
+            <field name="warehouse_id" position="after">
+                <field name="u_package_count_button_name" attrs="{'required':[('u_show_package_count', '=', True)]}"/>
+            </field>
         </field>
     </record>
 

--- a/addons/udes_stock/views/stock_quant_views.xml
+++ b/addons/udes_stock/views/stock_quant_views.xml
@@ -25,4 +25,10 @@
         </field>
     </record>
 
+    <!--Open default list view of quants-->
+    <record model="ir.actions.act_window" id="location_open_quants">
+        <field name="name">Package Stock</field>
+        <field name="res_model">stock.quant</field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
- New button on the inventory dashboard shows the number of packages at a location for a picking type
- Existing "Transfers" button can be shown/ hidden based upon config for the picking type. This should be shown for all picking types

