### PR TITLE
[ADD] udes_stock: Improve skip functionality

### DIFF
--- a/addons/udes_stock/README.md
+++ b/addons/udes_stock/README.md
@@ -108,6 +108,8 @@ A lot of custom UDES functionality is specfied at the picking type level. This i
 | sequence                   | int     | Used for ordering picking types in a display. |
 | u_allow_swapping_packages  | boolean | During a specified pick, this field determines whether we can we swap one package for another if they contain exactly the same. |
 | u_skip_allowed             | boolean | Is the user allowed to skip to the next item to pick? |
+| u_skip_item_by             | boolean | When an item is skipped, determine what is skipped by the given criteria. |
+| u_return_to_skipped        | boolean | Can the user return to a skipped item when picking a batch? |
 | u_split_on_drop_off        | boolean | |
 | u_suggest_qty              | boolean | Do we display the suggested quantity, or get the user to enter it without any vision of what is expected. When we suggest it, the risk is that users will be automatically confirming it without a thorough check. |
 | u_over_receive             | boolean | Is the system able to receive more than is expected. |

--- a/addons/udes_stock/controllers/stock_picking_batch.py
+++ b/addons/udes_stock/controllers/stock_picking_batch.py
@@ -86,7 +86,12 @@ class PickingBatchApi(UdesApi):
 
     @http.route('/api/stock-picking-batch/<ident>/next',
                 type='json', methods=['GET'], auth='user')
-    def get_next_task(self, ident, skipped_product_ids=None):
+    def get_next_task(
+        self,
+        ident,
+        skipped_product_ids=None,
+        skipped_move_line_ids=None
+    ):
         """
         Returns the next pick task from the picking batch in
         progress for the current user.
@@ -104,7 +109,10 @@ class PickingBatchApi(UdesApi):
         batch = _get_batch(request.env, ident)
 
         with batch.statistics() as stats:
-            task = batch.get_next_task(skipped_product_ids=skipped_product_ids)
+            task = batch.get_next_task(
+                skipped_product_ids=skipped_product_ids,
+                skipped_move_line_ids=skipped_move_line_ids
+            )
         _logger.info("Get next task (user %s) in %.2fs, %d queries",
                      request.env.uid, stats.elapsed, stats.count)
 

--- a/addons/udes_stock/models/stock_picking_type.py
+++ b/addons/udes_stock/models/stock_picking_type.py
@@ -23,6 +23,19 @@ class StockPickingType(models.Model):
         help="Flag to indicate if the skip button will be shown.",
     )
 
+    u_skip_item_by = fields.Selection(
+        [("product", "Product"), ("move_line_id", "Move Line")],
+        string="Skip Item By",
+        default="product",
+        help="When an item is skipped, determine what is skipped by the given criteria.",
+    )
+
+    u_return_to_skipped = fields.Boolean(
+        string="Return to Skipped Items",
+        default=False,
+        help="Flag to indicate if the skipped items will be returned to in the same batch.",
+    )
+
     u_split_on_drop_off_picked = fields.Boolean("Split on drop off picked")
 
     u_suggest_qty = fields.Boolean(
@@ -387,7 +400,7 @@ class StockPickingType(models.Model):
         help="If set, the user may be asked to confirm the type of the package they are scanning"
         " during the picking workflow",
     )
-    
+
     u_default_package_type_id = fields.Many2one(
         comodel_name="product.packaging",
         string="Default Package Type (For Check)",
@@ -458,6 +471,8 @@ class StockPickingType(models.Model):
             - default_location_src_id: int
             - u_allow_swapping_packages: boolean
             - u_skip_allowed: boolean
+            - u_return_to_skipped: boolean
+            - u_skip_item_by: string
             - u_split_on_drop_off_picked: boolean
             - u_suggest_qty: boolean
             - u_under_receive: boolean
@@ -510,6 +525,8 @@ class StockPickingType(models.Model):
             "default_location_src_id": self.default_location_src_id.id,
             "u_allow_swapping_packages": self.u_allow_swapping_packages,
             "u_skip_allowed": self.u_skip_allowed,
+            "u_return_to_skipped": self.u_return_to_skipped,
+            "u_skip_item_by": self.u_skip_item_by,
             "u_split_on_drop_off_picked": self.u_split_on_drop_off_picked,
             "u_suggest_qty": self.u_suggest_qty,
             "u_under_receive": self.u_under_receive,

--- a/addons/udes_stock/views/stock_picking_type.xml
+++ b/addons/udes_stock/views/stock_picking_type.xml
@@ -22,6 +22,8 @@
                     <field name="u_scan_parent_package_end" />
                     <field name="u_allow_swapping_packages" />
                     <field name="u_skip_allowed" />
+                    <field name="u_skip_item_by" />
+                    <field name="u_return_to_skipped" />
                     <field name="u_split_on_drop_off_picked" />
                     <field name="u_suggest_qty" />
                     <field name="u_under_receive"/>


### PR DESCRIPTION
- Added config to allow user to skip based on move_lines
in addition to products
- Added config to allow the user to return to skipped items
- Added unit tests for skipping

User-story: 11993
Signed-off-by: ajrwilliams <anthony.williams@unipart.io>

Changed get_next_task to allow it to return to skipped tasks. In the process of doing this I refactored it to improve the flow and allow some of the functionality to be used for future purposes (returning list of all remaining tasks)