### PR TITLE
Story/11767 - Lock pickings once confirmed/completed

### DIFF
--- a/addons/udes_stock/views/stock_picking.xml
+++ b/addons/udes_stock/views/stock_picking.xml
@@ -83,8 +83,18 @@
                 <field name="u_location_category_id"/>
             </xpath>
 
-            <!--Hide unlock/lock button-->
-            <xpath expr="//button[@name='action_toggle_is_locked']" position="attributes">
+            <!-- 
+                Both unlock and lock buttons use the "action_toggle_is_locked" method,
+                so each button needs to be hidden individually 
+            -->
+
+            <!--Hide unlock button-->
+            <xpath expr="//button[@name='action_toggle_is_locked'][1]" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+
+            <!--Hide lock button-->
+            <xpath expr="//button[@name='action_toggle_is_locked'][2]" position="attributes">
                 <attribute name="invisible">1</attribute>
             </xpath>
 


### PR DESCRIPTION
Unlocked pickings (e.g. Goods In Pickings generated from completed Delivery Control pickings) are now locked once marked as todo or as an extra safety check, when the picking is completed.

Fixed issue with Stock Picking form override that was only hiding the Unlock button and not Lock.

Added Unit Test to ensure unlocked pickings are locked once confirmed or completed.