### PR TITLE
User-story: 12162 

### DIFF
--- a/addons/udes_stock/models/stock_move.py
+++ b/addons/udes_stock/models/stock_move.py
@@ -329,6 +329,21 @@ class StockMove(models.Model):
         post_refactor_done_moves.push_from_drop()
         return post_refactor_done_moves
 
+    def _get_new_picking_values(self):
+        values = super()._get_new_picking_values()
+
+        previous_pickings = self.mapped('move_orig_ids.picking_id')
+        if not values.get('origin'):
+            previous_origin = list(set(previous_pickings.mapped('origin')))
+            if len(previous_origin) == 1:
+                values['origin'] = previous_origin[0]
+        if not values.get('partner_id'):
+            previous_partner = previous_pickings.mapped('partner_id')
+            if len(previous_partner) == 1:
+                values['partner_id'] = previous_partner.id
+
+        return values
+
     def push_from_drop(self):
         Move = self.env["stock.move"]
         MoveLine = self.env["stock.move.line"]

--- a/addons/udes_stock/tests/test_push_from_drop.py
+++ b/addons/udes_stock/tests/test_push_from_drop.py
@@ -235,3 +235,18 @@ class TestPushFromDrop(PushFromDropBase):
                       'location_dest_id': self.location_qc_01.id})
         putaway.action_done()
         self.assertEqual(putaway.state, 'done')
+
+    def test05_picking_info_propagated(self):
+        """Test that when a picking is created by push_from_drop it contains
+        the origin and partner of the source picking."""
+        for ml in self.move_lines:
+            ml.write({'qty_done': ml.product_uom_qty,
+                      'location_dest_id': self.received_damaged_location.id})
+        new_partner = self.create_partner('Test partner')
+        self.goods_in.partner_id = new_partner
+        new_origin = 'Test origin'
+        self.goods_in.origin = new_origin
+        self.goods_in.action_done()
+        putaway = self.goods_in.u_next_picking_ids
+        self.assertEqual(putaway.origin, new_origin)
+        self.assertEqual(putaway.partner_id, new_partner)


### PR DESCRIPTION
Propagate origin and partner_id from picking

In case the moves do not propagate it, propagate it from the picking
since some times they are empty at the moves but not at the picking.

