### PR TITLE
[IMP] udes_stock: _get_inventory_lines_values refactored

### DIFF
--- a/addons/udes_stock/tests/test_stock_inventory.py
+++ b/addons/udes_stock/tests/test_stock_inventory.py
@@ -148,3 +148,239 @@ class TestStockInventoryLine(common.BaseUDES):
 
         self.test_stock_inventory.line_ids._compute_reserved_qty()
         self.assertEqual(self.test_stock_inventory.line_ids.reserved_qty, 2)
+
+
+class TestStockInventoryFilters(common.BaseUDES):
+    @classmethod
+    def setUpClass(cls):
+        """Setup products and create a Inventory Adjustment record"""
+        super(TestStockInventoryFilters, cls).setUpClass()
+
+        cls._setup_product_categories()
+        cls._setup_products_in_categories()
+
+        cls.test_stock_inventory = cls.create_stock_inventory(
+            name="Test Stock Check", location_id=cls.test_location_01.id
+        )
+
+    @classmethod
+    def create_product_category(cls, name, parent_category=None, **kwargs):
+        """Create and return a Product Category record"""
+        ProductCategory = cls.env["product.category"]
+
+        vals = {"name": name, "parent_id": parent_category.id if parent_category else False}
+        vals.update(kwargs)
+        return ProductCategory.create(vals)
+
+    @classmethod
+    def create_product_in_category(cls, name, product_category, **kwargs):
+        """Create and return a Product record in the supplied category"""
+        kwargs["categ_id"] = product_category.id
+        return cls.create_product(name, **kwargs)
+
+    @classmethod
+    def _setup_product_categories(cls):
+        """Create product categories for testing"""
+        cls.category_a = cls.create_product_category("A")
+        cls.category_b = cls.create_product_category("B")
+
+    @classmethod
+    def _setup_products_in_categories(cls):
+        """Create products in test categories, with a quant created for each product"""
+        cls.product_a_1 = cls.create_product_in_category("Product A1", cls.category_a)
+        cls.product_a_2 = cls.create_product_in_category("Product A2", cls.category_a)
+        cls.product_b_1 = cls.create_product_in_category("Product B1", cls.category_b)
+
+        cls.a_products = cls.product_a_1 | cls.product_a_2
+        cls.b_products = cls.product_b_1
+
+        cls.product_qty = 5
+        for product in cls.a_products | cls.b_products:
+            package = cls.create_package()
+            cls.create_quant(
+                product.id, cls.test_location_01.id, cls.product_qty, package_id=package.id
+            )
+
+    def _assert_inventory_lines_have_products(self, inventory_lines, products, expected=True):
+        """
+        Assert that each supplied Product is/isn't present in the supplied Inventory Lines.
+
+        Optionally set `expected` (default True) to specify whether the products should or shouldn't
+        be in the Inventory Lines.
+        """
+        inventory_lines_products = inventory_lines.mapped("product_id")
+
+        for product in products:
+            if expected:
+                self.assertIn(
+                    product,
+                    inventory_lines_products,
+                    f"{product.name} should be in Inventory Lines",
+                )
+            else:
+                self.assertNotIn(
+                    product,
+                    inventory_lines_products,
+                    f"{product.name} should not be in Inventory Lines",
+                )
+
+    def _assert_line_counts_equal(self, expected_line_count, actual_line_count):
+        """Assert that expected line count matches actual line count"""
+        self.assertEqual(
+            expected_line_count,
+            actual_line_count,
+            f"{expected_line_count} lines should have been created, got: {actual_line_count}",
+        )
+
+    def test_assert_no_filter(self):
+        """
+        Assert that Inventory Adjustment record with no filter set returns all products with
+        quants within specified location
+        """
+        Quant = self.env["stock.quant"]
+
+        # Create product with quant in Test Location 2
+        test_loc_2_product = self.create_product("Test Loc 2 Product")
+        package = self.create_package()
+        self.create_quant(
+            test_loc_2_product.id,
+            self.test_location_02.id,
+            self.product_qty,
+            package_id=package.id,
+        )
+
+        # Set inventory adjustment filter to none and start inventory
+        self.test_stock_inventory.filter = "none"
+        self.test_stock_inventory.action_start()
+
+        # Get products with quants that are inside Test Location 1
+        test_loc_1_quants = Quant.search([("location_id", "child_of", self.test_location_01.id)])
+        test_loc_1_products = test_loc_1_quants.mapped("product_id")
+
+        # Assert that one line was created for each product in Test Location 1
+        inventory_lines = self.test_stock_inventory.line_ids
+        expected_line_count = len(test_loc_1_products)
+        actual_line_count = len(inventory_lines)
+
+        self._assert_line_counts_equal(expected_line_count, actual_line_count)
+
+        # Assert that Test Loc 1 products are in the Inventory Lines, but not Test Loc 2 Products
+        self._assert_inventory_lines_have_products(inventory_lines, test_loc_1_products)
+        self._assert_inventory_lines_have_products(
+            inventory_lines, test_loc_2_product, expected=False
+        )
+
+    def test_assert_product_category_filter(self):
+        """
+        Assert that product category filter only creates lines for products
+        within specified category
+        """
+        # Set inventory adjustment product category to A and start inventory
+        self.test_stock_inventory.filter = "category"
+        self.test_stock_inventory.category_id = self.category_a
+        self.test_stock_inventory.action_start()
+
+        # Assert that one line was created for each product in Category A
+        inventory_lines = self.test_stock_inventory.line_ids
+        expected_line_count = self.category_a.product_count
+        actual_line_count = len(inventory_lines)
+
+        self._assert_line_counts_equal(expected_line_count, actual_line_count)
+
+        # Assert that A products are in the Inventory Lines, but not B products
+        self._assert_inventory_lines_have_products(inventory_lines, self.a_products)
+        self._assert_inventory_lines_have_products(inventory_lines, self.b_products, expected=False)
+
+    def test_assert_product_filter(self):
+        """Assert that product filter only creates lines for specified product"""
+        # Create additional quants for product A1
+        new_quant_count = 2
+        for _ in range(0, new_quant_count):
+            package = self.create_package()
+            self.create_quant(
+                self.product_a_1.id,
+                self.test_location_01.id,
+                self.product_qty,
+                package_id=package.id,
+            )
+
+        # Set inventory adjustment product to A1 and start inventory
+        self.test_stock_inventory.filter = "product"
+        self.test_stock_inventory.product_id = self.product_a_1
+        self.test_stock_inventory.action_start()
+
+        # Assert that one line was created for each product in Category A
+        inventory_lines = self.test_stock_inventory.line_ids
+        expected_line_count = len(self.product_a_1) + new_quant_count
+        actual_line_count = len(inventory_lines)
+
+        self._assert_line_counts_equal(expected_line_count, actual_line_count)
+
+        # Assert that A1 product is in the Inventory Lines
+        self._assert_inventory_lines_have_products(inventory_lines, self.product_a_1)
+
+    def test_assert_lot_filter(self):
+        """Assert that lot filter only creates lines for specified lot"""
+        # Set A1 to be tracked by Lot
+        self.product_a_1.tracking = "lot"
+
+        # Create lot and set it against A1 quant
+        product_a_1_quant = self.product_a_1.stock_quant_ids[0]
+        a1_lot = self.create_lot(self.product_a_1.id, self.product_a_1.name)
+        product_a_1_quant.lot_id = a1_lot
+
+        # Set inventory adjustment lot to A1 lot and start inventory
+        self.test_stock_inventory.filter = "lot"
+        self.test_stock_inventory.lot_id = a1_lot
+        self.test_stock_inventory.action_start()
+
+        # Assert that one line was created for A1 lot
+        inventory_lines = self.test_stock_inventory.line_ids
+        expected_line_count = len(product_a_1_quant)
+        actual_line_count = len(inventory_lines)
+
+        self._assert_line_counts_equal(expected_line_count, actual_line_count)
+
+        # Assert that A1 product is in the Inventory Lines
+        self._assert_inventory_lines_have_products(inventory_lines, self.product_a_1)
+
+        # Assert that A1 lot is in the Inventory Lines
+        inventory_lines_lots = inventory_lines.mapped("prod_lot_id")
+        self.assertEqual(
+            inventory_lines_lots, a1_lot, f"Inventory Lines should only contain Lot {a1_lot.name}"
+        )
+
+    def test_assert_package_filter(self):
+        """Assert that package filter only creates lines for specified package"""
+        # Put product B1 quant into the same package as A1
+        product_a_1_quant = self.product_a_1.stock_quant_ids[0]
+        product_b_1_quant = self.product_b_1.stock_quant_ids[0]
+
+        a1_package = product_a_1_quant.package_id
+        a1_package.name = self.product_a_1.name
+        product_b_1_quant.package_id = a1_package
+
+        # Set inventory adjustment package to A1 package and start inventory
+        self.test_stock_inventory.filter = "pack"
+        self.test_stock_inventory.package_id = a1_package
+        self.test_stock_inventory.action_start()
+
+        # Assert that lines were created for product A1 and B1
+        inventory_lines = self.test_stock_inventory.line_ids
+        expected_line_count = len(product_a_1_quant | product_b_1_quant)
+        actual_line_count = len(inventory_lines)
+
+        self._assert_line_counts_equal(expected_line_count, actual_line_count)
+
+        # Assert that A1 and B1 products are in the Inventory Lines
+        self._assert_inventory_lines_have_products(
+            inventory_lines, self.product_a_1 | self.product_b_1
+        )
+
+        # Assert that A1 package is in the Inventory Lines
+        inventory_lines_packages = inventory_lines.mapped("package_id")
+        self.assertEqual(
+            inventory_lines_packages,
+            a1_package,
+            f"Inventory Lines should only contain Package {a1_package.name}",
+        )


### PR DESCRIPTION
Refactored _get_inventory_lines_values from core Odoo, with logic for filtering and retrieving line values split out into separate functions which can be easily overridden in other modules if needed.

Rather than using SQL to retreive the values to use for Inventory Lines, a search with the appropriate filter is now carried out on Quants, with a key used to identify unique quants in a dictionary of values. If the key is already found, the quantity is updated.

Story/11983

Signed-off-by: Peter Clark <peter.clark@unipart.io>