### PR TITLE
[FIX] udes_priorities: Ensure pickings are not checked if installing

### DIFF
--- a/addons/udes_priorities/models/priority.py
+++ b/addons/udes_priorities/models/priority.py
@@ -96,6 +96,12 @@ class UdesPriority(models.Model):
 
     @api.multi
     def _check_for_oustanding_pickings(self):
+
+        install_mode = self.env.context.get("install_mode", False)
+
+        if install_mode:
+            return
+
         priorities_with_outstanding_picks = self.browse()
         for priority in self:
             if priority._number_of_oustanding_pickings() > 0:


### PR DESCRIPTION
Checks for install_mode flag and bypasses the check for outstanding pickings if True.

Signed-off-by: Adam Patrick <adam.patrick@unipart.io>