### PR TITLE
[IMP] udes_stock: Remove smart merging at _create_moves()

### DIFF
--- a/addons/udes_stock/models/stock_picking.py
+++ b/addons/udes_stock/models/stock_picking.py
@@ -552,20 +552,15 @@ class StockPicking(models.Model):
         for product_id, qty in products_info.items():
             if product_quantity:
                 qty = product_quantity
-
-            product_move = self.move_lines.filtered(lambda m: m.product_id.id == product_id)
-            if product_move:
-                product_move.product_uom_qty += qty
-            else:
-                move_vals = {
-                    "name": "{} {}".format(qty, Product.browse(product_id).display_name),
-                    "product_id": product_id,
-                    "product_uom_qty": qty,
-                }
-                move_vals.update(values)
-                move = Move.create(move_vals)
-                if unexpected:
-                    move.ordered_qty = 0
+            move_vals = {
+                "name": "{} {}".format(qty, Product.browse(product_id).display_name),
+                "product_id": product_id,
+                "product_uom_qty": qty,
+            }
+            move_vals.update(values)
+            move = Move.create(move_vals)
+            if unexpected:
+                move.ordered_qty = 0
 
         if confirm:
             # Use picking.action_confirm, which will merge moves of the same


### PR DESCRIPTION
Rely on the code inside action_confirm() to do so, since it uses
a list of fields to take into account instead of just product.

User-story: 12377

Signed-off-by: Miquel PS <miquel.palahi.sitges@unipart.io>