### PR TITLE
[FIX] udes_stock: Fix for merged quants in raise stock inv

### DIFF
--- a/addons/udes_stock/models/stock_picking.py
+++ b/addons/udes_stock/models/stock_picking.py
@@ -2198,7 +2198,7 @@ class StockPicking(models.Model):
 
         # create new "investigation pick"
         Picking.create_picking(
-            quant_ids=quants.ids,
+            quant_ids=quants.exists().ids,
             location_id=location.id,
             picking_type_id=stock_inv_pick_type.id,
             group_id=group.id,


### PR DESCRIPTION
When raising a stock investigation we should only consider quants
that still exist, as merging of quants may happen due to removal
of additional information when unreserving.