### PR TITLE
Story/12266 - Parent Package added to Inventory Adjustment screen

### DIFF
--- a/addons/udes_stock/models/stock_inventory.py
+++ b/addons/udes_stock/models/stock_inventory.py
@@ -69,6 +69,13 @@ class StockInventory(models.Model):
         else:
             return self.action_done()
 
+    def action_check(self):
+        """Override to update Parent Package on Package if needed."""
+        inventories_to_check = self.filtered(lambda i: i.state not in ("done", "cancel"))
+        for inventory in inventories_to_check:
+            inventory.line_ids._update_package_parent()
+        return super(StockInventory, self).action_check()
+
     def _is_adjusting_reserved(self):
         """Check if a user is adjusting reserved stock."""
         self.ensure_one()
@@ -188,6 +195,17 @@ class StockInventoryLine(models.Model):
         store=False
     )
 
+    u_result_parent_package_id = fields.Many2one(
+        'stock.quant.package', 'Parent Destination Package'
+    )
+
+    u_package_parent_package_id = fields.Many2one(
+        'stock.quant.package',
+        'Current Parent Package',
+        help='The current parent package, used to determine if the parent package '
+        'on the Inventory Line has been updated'
+    )
+
     @api.one
     @api.depends(
         'location_id',
@@ -207,6 +225,16 @@ class StockInventoryLine(models.Model):
                 self.product_uom_id
             )
         self.reserved_qty = reserved_qty
+
+    @api.onchange('package_id')
+    def onchange_package_id(self):
+        """
+        Set values for u_result_parent_package_id and u_package_parent_package_id
+        when package is changed
+        """
+        parent_package = self.package_id.package_id
+        self.u_result_parent_package_id = parent_package
+        self.u_package_parent_package_id = parent_package
 
     def _get_quants_domain(self):
         """Returns a domain used for retrieving relevant Quant records"""
@@ -240,6 +268,8 @@ class StockInventoryLine(models.Model):
             "prod_lot_id": quant.lot_id.id,
             "package_id": quant.package_id.id,
             "partner_id": quant.owner_id.id,
+            "u_result_parent_package_id": quant.package_id.package_id.id,
+            "u_package_parent_package_id": quant.package_id.package_id.id,
         }
         return quant_line_vals
 
@@ -253,3 +283,27 @@ class StockInventoryLine(models.Model):
             quant_line_vals["partner_id"],
         )
         return quant_key
+
+    def _get_move_values(self, qty, location_id, location_dest_id, out):
+        """Override to include Parent Package, if set"""
+        move_values = super(StockInventoryLine, self)._get_move_values(
+            qty, location_id, location_dest_id, out
+        )
+        move_line_vals = move_values["move_line_ids"][0][2]
+
+        result_parent_package_id = (not out) and self.u_result_parent_package_id.id
+        move_line_vals["u_result_parent_package_id"] = result_parent_package_id
+        return move_values
+
+    def _update_package_parent(self):
+        """Update Package's Parent Package if it has been updated on the Inventory Line"""
+        for line in self.filtered(
+            lambda l: l.package_id and l.u_result_parent_package_id != l.u_package_parent_package_id
+        ):
+            line.package_id.sudo().write({"package_id": line.u_result_parent_package_id.id})
+
+    @api.constrains("package_id", "u_result_parent_package_id")
+    def _parent_package_check(self):
+        """Remove `u_result_parent_package_id` if `package_id` not set"""
+        lines_to_update = self.filtered(lambda l: not l.package_id and l.u_result_parent_package_id)
+        lines_to_update.write({"u_result_parent_package_id": False})

--- a/addons/udes_stock/models/stock_quant_package.py
+++ b/addons/udes_stock/models/stock_quant_package.py
@@ -306,3 +306,12 @@ class StockQuantPackage(models.Model):
         if aux_domain is not None:
             domain.extend(aux_domain)
         return MoveLine.search(domain)
+
+    @api.depends("package_id")
+    def _compute_display_name(self):
+        """Override to hide parent package if context set"""
+        if self.env.context.get("display_package_name_only", False):
+            for package in self:
+                package.display_name = package.name
+        else:
+            super(StockQuantPackage, self)._compute_display_name()

--- a/addons/udes_stock/views/stock_inventory.xml
+++ b/addons/udes_stock/views/stock_inventory.xml
@@ -59,5 +59,9 @@
                 </form>
             </field>
         </record>
+
+        <record id="stock.action_inventory_form" model="ir.actions.act_window">
+            <field name="context">{'display_package_name_only': True}</field>
+        </record>
     </data>
 </odoo>

--- a/addons/udes_stock/views/stock_inventory.xml
+++ b/addons/udes_stock/views/stock_inventory.xml
@@ -27,6 +27,8 @@
                 </xpath>
                 <xpath expr="//sheet/notebook/page/field/tree" position="attributes">
                     <attribute name="decoration-danger">reserved_qty or theoretical_qty &lt; 0</attribute>
+                    <attribute name="decoration-info">u_line_updated</attribute>
+                </xpath>
                 <xpath expr="//sheet/notebook/page/field/tree/field[@name='package_id']" position="after">
                     <field name="u_result_parent_package_id" attrs="{'readonly': [('package_id', '=', False)]}"/>
                     <field name="u_package_parent_package_id" invisible="1"/>

--- a/addons/udes_stock/views/stock_inventory.xml
+++ b/addons/udes_stock/views/stock_inventory.xml
@@ -27,6 +27,10 @@
                 </xpath>
                 <xpath expr="//sheet/notebook/page/field/tree" position="attributes">
                     <attribute name="decoration-danger">reserved_qty or theoretical_qty &lt; 0</attribute>
+                <xpath expr="//sheet/notebook/page/field/tree/field[@name='package_id']" position="after">
+                    <field name="u_result_parent_package_id" attrs="{'readonly': [('package_id', '=', False)]}"/>
+                    <field name="u_package_parent_package_id" invisible="1"/>
+                    <field name="u_line_updated" invisible="1"/>
                 </xpath>
                 <xpath expr="//sheet/notebook/page/field/tree/field[@name='theoretical_qty']" position="before">
                     <field name="reserved_qty" readonly="1"/>


### PR DESCRIPTION
Parent Package field added to Stock Inventory Line. This means the parent package will be retained when a Quant is adjusted. The parent package can also be updated in the Inventory Adjustment screen.