### PR TITLE
[IMP] udes_sale_stock: Cancelled Due to Stock Shortage now set on action_cancel on Sale Order Line

### DIFF
--- a/addons/udes_sale_stock/models/sale_order.py
+++ b/addons/udes_sale_stock/models/sale_order.py
@@ -121,8 +121,7 @@ class SaleOrder(models.Model):
         if unfulfillable_lines:
             # Cancel these lines
             with self.statistics() as stats:
-                unfulfillable_lines.action_cancel()
-                unfulfillable_lines.write({"is_cancelled_due_shortage": True})
+                unfulfillable_lines.with_context(cancelled_stock_shortage=True).action_cancel()
 
             _logger.info(
                 "Sale lines on orders %s cancelled in %.2fs, %d queries, due to" " stock shortage,",

--- a/addons/udes_sale_stock/models/sale_order_line.py
+++ b/addons/udes_sale_stock/models/sale_order_line.py
@@ -34,7 +34,13 @@ class SaleOrderLine(models.Model):
             return False
 
         now_date = datetime.now()
-        to_cancel.write({"is_cancelled": True, "cancel_date": fields.Datetime.to_string(now_date)})
+        cancel_vals = {
+            "is_cancelled": True,
+            "cancel_date": fields.Datetime.to_string(now_date),
+            "is_cancelled_due_shortage": self.env.context.get("cancelled_stock_shortage", False),
+        }
+        to_cancel.write(cancel_vals)
+
         to_cancel.mapped("move_ids").filtered(
             lambda m: m.state not in ("done", "cancel")
         )._action_cancel()


### PR DESCRIPTION
If "cancelled_stock_shortage" is set in context, the Cancelled Due to Stock Shortage flag will now be written to the Order Line in action_cancel. This saves a write on the lines after they have been cancelled in "cancel_orders_without_availability"

Story/11984

Signed-off-by: Peter Clark <peter.clark@unipart.io>