### PR TITLE
[IMP] udes_stock: Create date added to Stock Quant list view, hidden by default

### DIFF
--- a/addons/udes_stock/models/stock_picking_type.py
+++ b/addons/udes_stock/models/stock_picking_type.py
@@ -599,11 +599,21 @@ class StockPickingType(models.Model):
         return self._get_action("udes_stock.action_picking_tree_draft")
 
     def get_action_package_tree(self):
+        """
+        Return action to show quants for the picking type source location.
+
+        Add context to display quant create date in the tree view.
+        """
         location_ids = self.default_location_src_id.ids
         action = self._get_action("udes_stock.location_open_quants")
         # Check if context exists and is of type dictionary
         if not isinstance(action.get("context", 0), dict):
             action["context"] = {}
-        action["context"]["active_ids"] = location_ids
+
+        action["context"].update({
+            "active_ids": location_ids,
+            "hide_create_date": False,
+        })
         action["domain"] = [("location_id", "child_of", location_ids)]
+
         return action

--- a/addons/udes_stock/views/stock_quant_views.xml
+++ b/addons/udes_stock/views/stock_quant_views.xml
@@ -31,4 +31,16 @@
         <field name="res_model">stock.quant</field>
     </record>
 
+    <!-- Add create date to the quant list -->
+    <record id="stock_view_stock_quant_tree" model="ir.ui.view">
+        <field name="name">stock.view_stock_quant_tree.udes_stock</field>
+        <field name="model">stock.quant</field>
+        <field name="inherit_id" ref="stock.view_stock_quant_tree"/>
+        <field name="arch" type="xml">
+          <xpath expr="//field[@name='quantity']" position="after">
+            <field name="create_date" string="Last Move Date" invisible="context.get('hide_create_date', True)"/>
+          </xpath>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
Added create date field to Stock Quant list view to show the date the quant was last moved. Field is hidden by default but is shown when viewing package counts via the Inventory Dashboard.

Story/12608

Signed-off-by: Peter Clark <peter.clark@unipart.io>