### PR TITLE
[IMP] udes_security: Removed groups set directly on main Settings menu item

### DIFF
--- a/addons/udes_security/__manifest__.py
+++ b/addons/udes_security/__manifest__.py
@@ -11,6 +11,8 @@ Security enhancements used by UDES
     "category": "Authentication",
     "data": [
         "security/ir.model.access.csv",
+        "views/base_language_install_view.xml",
+        "views/base_menu.xml",
         "views/blocked_file_type_views.xml",
         "views/res_users_views.xml",
         "views/webclient_templates.xml",

--- a/addons/udes_security/views/base_language_install_view.xml
+++ b/addons/udes_security/views/base_language_install_view.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <!-- Hide Tranlsations menu for users without administration settings permission -->
+    <record model="ir.ui.menu" id="base.menu_translation">
+        <field name="groups_id" eval="[(4, ref('base.group_system'))]"/>
+    </record>
+</odoo>

--- a/addons/udes_security/views/base_menu.xml
+++ b/addons/udes_security/views/base_menu.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <!-- Remove groups from top Settings menu so that it will show if user has access to any sub-menus -->
+    <record model="ir.ui.menu" id="base.menu_administration">
+        <field name="groups_id" eval="[(6, 0, [])]"/>
+    </record>
+
+    <!-- Hide Users and Companies menu for users without administration settings or access rights permission -->
+    <record model="ir.ui.menu" id="base.menu_users">
+        <field name="groups_id" eval="[(6, 0, [ref('base.group_system'), ref('base.group_erp_manager')])]"/>
+    </record>
+</odoo>


### PR DESCRIPTION
In order to accommodate the scenario where users without system administration/access rights permissions still need access to certain menus in settings, the groups set directly against the top Settings menu item have been removed.

The settings menu will now show if the user has access to any sub menu items. Because of this, appropriate security groups have been added to User/Companies and Translation menus.

Story/12629

Signed-off-by: Peter Clark <peter.clark@unipart.io>