### PR TITLE
[ADD] udes_stock: Added u_show_scanned_pallets to picking types

### DIFF
--- a/addons/udes_stock/README.md
+++ b/addons/udes_stock/README.md
@@ -133,7 +133,7 @@ A lot of custom UDES functionality is specfied at the picking type level. This i
 | u_max_reservable_pallets   | int     | The maximum number of pallets that may be simultaneously reserved in a batch, if `u_reserve_pallets_per_picking` is `True`. |
 | u_warn_picking_precondition     | string  |  | Display a warning messsage when trying to validate a picking when a given precondition is not met. |
 | u_show_all_tasks | boolean | Flag to indicate whether all tasks are shown to the user during the picking flow. |
-
+| u_show_scanned_pallets | boolean | Flag to show a list of scanned pallets at the scan pallet screen |
 
 More on the enumeration fields below.
 

--- a/addons/udes_stock/models/stock_picking_type.py
+++ b/addons/udes_stock/models/stock_picking_type.py
@@ -435,6 +435,13 @@ class StockPickingType(models.Model):
         help="Enable/Disable Transfer count button on kanban view",
     )
 
+    # Pallet count options
+    u_show_scanned_pallets = fields.Boolean(
+        string="Show Scanned Pallets",
+        default=False,
+        help="Show a list of scanned pallets at the scan pallet screen",
+    )
+
     def _compute_package_count(self):
         """Counts number of packages at parent and child locations"""
         StockQuantPackage = self.env["stock.quant.package"]
@@ -513,6 +520,7 @@ class StockPickingType(models.Model):
             - u_check_package_type: boolean
             - u_default_package_type_id: int
             - u_show_all_tasks: boolean
+            - u_show_scanned_pallets: boolean
         """
         self.ensure_one()
         Batch = self.env["stock.picking.batch"]
@@ -576,6 +584,7 @@ class StockPickingType(models.Model):
             "u_check_package_type": self.u_check_package_type,
             "u_default_package_type_id": self.u_default_package_type_id.id,
             "u_show_all_tasks": self.u_show_all_tasks,
+            "u_show_scanned_pallets": self.u_show_scanned_pallets,
         }
 
     def get_info(self):

--- a/addons/udes_stock/views/stock_picking_type.xml
+++ b/addons/udes_stock/views/stock_picking_type.xml
@@ -81,6 +81,7 @@
             <field name="show_operations" position="after">
                 <field name="u_show_transfer_count"/>
                 <field name="u_show_package_count"/>
+                <field name="u_show_scanned_pallets"/>
             </field>
             <xpath expr="//field[@name='default_location_dest_id']" position="after">
                 <field name="u_damaged_location_id" options="{'no_create': True}"/>


### PR DESCRIPTION
Added `u_show_scanned_pallets` option. Original implementation is at goods in when changing a pallet.

Story/12709

Signed-off-by: Adam Patrick <adam.patrick@unipart.io>