### PR TITLE
[IMP] udes_delivery_control: Only set default supplier on backload record if the picking supplier does not already have a backload record

### DIFF
--- a/addons/udes_delivery_control/models/stock_picking.py
+++ b/addons/udes_delivery_control/models/stock_picking.py
@@ -114,6 +114,11 @@ class StockPicking(models.Model):
     # Backloading Fields
     u_is_backload = fields.Boolean(related="u_extras_id.is_backload")
     u_backload_ids = fields.One2many(related="u_extras_id.backload_ids")
+    u_backload_added = fields.Boolean(
+        compute="_compute_backload_added",
+        string="Backload Added",
+        help="True if a backload record exists on the picking",
+    )
 
     u_delivery_control_picking_id = fields.Many2one(
         "stock.picking",
@@ -205,6 +210,12 @@ class StockPicking(models.Model):
 
         for picking in self.filtered("u_is_delivery_control"):
             picking.show_mark_as_todo = picking.state == "draft"
+
+    @api.depends("u_backload_ids")
+    def _compute_backload_added(self):
+        """Set to True if Backload record has been added to Picking"""
+        for picking in self.filtered(lambda p: p.u_is_backload and p.u_backload_ids):
+            picking.u_backload_added = True
 
     @api.onchange("picking_type_id")
     def _onchange_picking_type_id(self):

--- a/addons/udes_delivery_control/views/stock_picking.xml
+++ b/addons/udes_delivery_control/views/stock_picking.xml
@@ -35,6 +35,7 @@
                         <group name="loading_visible">
                             <field name="u_is_backload" invisible="1"/>
                             <field name="u_is_unload" invisible="1"/>
+                            <field name="u_backload_added" invisible="1"/>
                         </group>
                         <group name="extra_info" string="Extra Info">
                             <field name="u_user_id"/>
@@ -64,7 +65,7 @@
                         </group>
                     </group>
                     <group string="Backloading" name="back_loading" attrs="{'invisible': [('u_is_backload', '=', False)]}">
-                        <field name="u_backload_ids" nolabel="1" context="{'supplier': partner_id}">
+                        <field name="u_backload_ids" nolabel="1" context="{'picking_supplier_id': partner_id, 'u_backload_added': u_backload_added}">
                             <tree editable="bottom">
                                 <field name="supplier_id" context="{'default_supplier': 1, 'default_customer': 0}" required="1"/>
                                 <field name="start_date"/>


### PR DESCRIPTION
Story/12482

Signed-off-by: Peter Clark <peter.clark@unipart.io>