### PR TITLE
[FIX] udes_priorities: Extend depends on groups pick type computation

### DIFF
--- a/addons/udes_priorities/models/priority_groups.py
+++ b/addons/udes_priorities/models/priority_groups.py
@@ -19,8 +19,8 @@ class UdesPriorityGroup(models.Model):
         store=True,
     )
 
-    @api.depends("priority_ids")
     @api.multi
+    @api.depends("priority_ids", "priority_ids.picking_type_ids")
     def _compute_picking_types(self):
         for group in self:
             group.picking_type_ids = group.mapped("priority_ids.picking_type_ids")


### PR DESCRIPTION
So that changes to a priorities picking type are also propogated to the group

Signed-off-by: Michele Costa <michele.costa@unipart.io>