### PR TITLE
[ADD] udes-open: Added move details to PI count moves

### DIFF
--- a/addons/udes_stock/models/stock_location.py
+++ b/addons/udes_stock/models/stock_location.py
@@ -392,6 +392,13 @@ class StockLocation(models.Model):
         if result_parent_package:
             picking.move_line_ids.write({"u_result_parent_package_id": result_parent_package.id})
         picking.move_line_ids.mark_as_done()
+
+        picking_details = Picking.get_stock_investigation_message(quants)
+
+        if picking_details:
+            picking_header = "PI Count Move created with: <br>"
+            picking.message_post(body=_(picking_header + picking_details))
+
         return picking
 
     # PI Inventory Adjustments

--- a/addons/udes_stock/models/stock_picking.py
+++ b/addons/udes_stock/models/stock_picking.py
@@ -2330,7 +2330,8 @@ class StockPicking(models.Model):
         picking_details = self.get_stock_investigation_message(quants.exists())
 
         if picking_details:
-            picking.message_post(body=_(picking_details))
+            picking_header = "Stock Investigation created with: <br>"
+            picking.message_post(body=_(picking_header + picking_details))
 
         # Try to re-assign the picking after, by creating the
         # investigation, we've reserved the problematic stock


### PR DESCRIPTION
Added the ability to provide details of the moves to the picking's mail.thread for PI count moves e.g. when additional packages are present in the location.

Story/12762

Signed-off-by: Adam Patrick <adam.patrick@unipart.io>