### PR TITLE
[ADD] udes_stock: Add option to only reserve full lines

### DIFF
--- a/addons/udes_stock/README.md
+++ b/addons/udes_stock/README.md
@@ -122,6 +122,7 @@ A lot of custom UDES functionality is specfied at the picking type level. This i
 | u_drop_location_preprocess | boolean | Selects if suggestions u_drop_location_policy should be added on assignment. If this is set will apply the u_drop_location_policy and the first location is set as location_dest_id for the set of move_lines. This can only be used with polcies decorated with allow_preprocess, usage on other polcies will result in an ValidationError.|
 | u_display_summary          | string  | How to display the Source Document and a summary of all Package Names associated with that Source Document number at Goods-Out (enum: 'none', 'list', 'list_contents'). |
 | u_handle_partials          | boolean | If the picking type is allowed to handle partially available pickings. If True, then pickings of this type will report their u_pending value. If False, prevents the state of a picking to be ready until the previous pickings are resolved.|
+| u_handle_partial_lines     | boolean | If the picking type can partially reserve move lines. Requires u_handle_partials to be enabled. |
 | u_create_procurement_group | boolean | Indicate if a procurement group should be created on confirmation of the picking if one does not already exist. |
 | u_enable_unpickable_items  | boolean | When not enabled only an error is shown to the user instead of the usual unpickable items behaviour. |
 | u_enable_exception_handling| boolean | Flag to indicate if exception handling options (exceptions that raise a stock investigation) will be shown. |

--- a/addons/udes_stock/models/stock_picking_type.py
+++ b/addons/udes_stock/models/stock_picking_type.py
@@ -120,6 +120,13 @@ class StockPickingType(models.Model):
         help="Allow processing a transfer when the preceding transfers are not all completed.",
     )
 
+    u_handle_partial_lines = fields.Boolean(
+        string="Handle Partial Move Lines",
+        default=True,
+        help="Allow handling partial move lines. "
+        "Only applicable if handling partial transfers is enabled.",
+    )
+
     u_create_procurement_group = fields.Boolean(
         string="Create Procurement Group",
         default=False,
@@ -561,6 +568,7 @@ class StockPickingType(models.Model):
             "u_display_summary": self.u_display_summary,
             "u_reserve_as_packages": self.u_reserve_as_packages,
             "u_handle_partials": self.u_handle_partials,
+            "u_handle_partial_lines": self.u_handle_partial_lines,
             "u_create_procurement_group": self.u_create_procurement_group,
             "u_scan_tracking": self.u_scan_tracking,
             "u_confirm_expiry_date": self.u_confirm_expiry_date,

--- a/addons/udes_stock/views/stock_picking_type.xml
+++ b/addons/udes_stock/views/stock_picking_type.xml
@@ -32,6 +32,7 @@
                     <field name="u_validate_real_time" />
                     <field name="u_reserve_as_packages" />
                     <field name="u_handle_partials" />
+                    <field name="u_handle_partial_lines" />
                     <field name="u_create_procurement_group"/>
                     <field name="u_drop_criterion" />
                     <field name="u_drop_location_constraint" />


### PR DESCRIPTION
- When partial reservation of a picking is enabled there is
now the option to only allow this by entire move lines rather
than partial move lines

User-story: 12840
Signed-off-by: Anthony Williams <anthony.williams@unipart.io>