### PR TITLE
[FIX] udes_stock: Change error to show only duplicate serials

### DIFF
--- a/addons/udes_stock/models/product_product.py
+++ b/addons/udes_stock/models/product_product.py
@@ -24,7 +24,7 @@ class ProductProduct(models.Model):
             if lots:
                 raise ValidationError(
                     _("Serial numbers %s already in use for product %s")
-                    % (" ".join(serial_numbers), self.name)
+                    % (" ".join(lots.mapped("name")), self.name)
                 )
 
     def _prepare_info(self, fields_to_fetch=None):


### PR DESCRIPTION
Instead of showing all of the serials used in the search we want
to show only the result of all serials in use already

User-story: 11395

Signed-off-by: Peter Alabaster <peter.alabaster@unipart.io>