### PR TITLE
[ADD] udes_sale_stock: Implement manual cancellation of sale order lines

### DIFF
--- a/addons/udes_sale_stock/models/sale_order.py
+++ b/addons/udes_sale_stock/models/sale_order.py
@@ -56,6 +56,10 @@ class SaleOrder(models.Model):
     client_order_ref = fields.Char(required=True, copy=True)
     requested_date = fields.Datetime(required=True, copy=True)
 
+    u_allow_manual_sale_order_line_cancellation = fields.Boolean(
+        readonly=True, related="warehouse_id.u_allow_manual_sale_order_line_cancellation",
+    )
+
     @api.depends("order_line.move_ids.picking_id")
     def _compute_picking_ids_by_line(self):
         self.mapped("order_line.move_ids.picking_id")

--- a/addons/udes_sale_stock/models/sale_order_line.py
+++ b/addons/udes_sale_stock/models/sale_order_line.py
@@ -2,13 +2,17 @@
 
 from datetime import datetime
 
-from odoo import api, models, fields
+from odoo import api, models, fields, _
+from odoo.exceptions import ValidationError
 
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
     is_cancelled = fields.Boolean(string="Cancelled", readonly=True, default=False, index=True)
+    ui_is_cancelled = fields.Boolean(
+        string="Cancelled", compute="_get_ui_is_cancelled", inverse="_set_ui_is_cancelled"
+    )
     cancel_date = fields.Datetime(
         string="Cancel Date", help="Time of cancellation", readonly=True, index=True
     )
@@ -49,3 +53,85 @@ class SaleOrderLine(models.Model):
     def _action_launch_procurement_rule(self):
         not_cancelled_lines = self.filtered(lambda l: not l.is_cancelled)
         super(SaleOrderLine, not_cancelled_lines)._action_launch_procurement_rule()
+
+    @api.depends("is_cancelled")
+    def _get_ui_is_cancelled(self):
+        """Populates the `ui_is_cancelled` field"""
+        for line in self:
+            line.ui_is_cancelled = line.is_cancelled
+
+    @api.multi
+    def _set_ui_is_cancelled(self):
+        """Triggers cancellation of sale order lines from the UI"""
+        lines_to_uncancel = self.filtered(lambda l: l.is_cancelled and not l.ui_is_cancelled)
+        lines_to_cancel = self.filtered(lambda l: not l.is_cancelled and l.ui_is_cancelled)
+
+        # Check if the warehouse config allow manual cancellation
+        if lines_to_cancel and False in self.mapped(
+            "order_id.warehouse_id.u_allow_manual_sale_order_line_cancellation"
+        ):
+            raise ValidationError(
+                _(
+                    "Manual cancellation of individual order lines is not "
+                    "allowed by the warehouse config"
+                )
+            )
+
+        # Forbid uncancellation of sale order lines
+        if lines_to_uncancel:
+            raise ValidationError(
+                _("Cannot uncancel order lines: %s")
+                % (", ".join(lines_to_uncancel.mapped("name")),)
+            )
+
+        # Forbid cancellation of completed sale order lines
+        lines_done = lines_to_cancel.filtered(lambda l: l.state == "done")
+        if lines_done:
+            raise ValidationError(
+                _("Cannot cancel completed order lines: %s")
+                % (", ".join(lines_done.mapped("name")),)
+            )
+
+        # Forbid cancellation of sale order lines with stock.pickings in progress
+        # Cancellation of sale order lines with the part of the outbound
+        # process completed and the next part unstarted is intentionally
+        # allowed. In this case it is up to the users to stock move products
+        # back into stock.
+        moves = lines_to_cancel.mapped("move_ids")
+        in_progress_moves = moves.filtered(
+            # Sale order lines are in progress if any of their pickings in the route are in progress
+            lambda m: m.state not in ("done", "cancel")
+            and (
+                m.picking_id.batch_id.state == "in_progress"
+                # NB: `picking_id.move_lines` is not necessarily a subset of `moves`
+                or m.picking_id.move_lines.filtered(lambda m2: m2.quantity_done > 0)
+            )
+        )
+        in_progress_lines = in_progress_moves.mapped("sale_line_id")
+        if in_progress_lines:
+            raise ValidationError(
+                _("Cannot cancel order lines with pickings in progress: %s")
+                % (", ".join(in_progress_lines.mapped("name")),)
+            )
+
+        # Disallow cancellation at certain stages in the outbound process
+        # NB: If half of a sale order line has left the warehouse and the other
+        #     half has not been picked yet, cancellation should be allowed.
+        uncancellable_moves = moves.filtered(
+            lambda m: m.state in ("partially_available", "assigned")
+            and m.picking_id.picking_type_id
+            in m.sale_line_id.order_id.warehouse_id.u_disallow_manual_sale_order_line_cancellation_at_picking_type_ids
+            # move.warehouse_id can't be used as it is not populated
+        )
+
+        uncancellable_lines = uncancellable_moves.mapped("sale_line_id")
+        if uncancellable_lines:
+            raise ValidationError(
+                _("Cannot cancel order lines with pickings at the %s stage: %s")
+                % (
+                    "/".join(uncancellable_moves.mapped("picking_type_id.name")),
+                    ", ".join(uncancellable_lines.mapped("name")),
+                )
+            )
+
+        lines_to_cancel.action_cancel()

--- a/addons/udes_sale_stock/models/stock_warehouse.py
+++ b/addons/udes_sale_stock/models/stock_warehouse.py
@@ -9,3 +9,14 @@ class StockWarehouse(models.Model):
         default=1,
         help="Days ahead to auto confirm sales orders for. " "0 = Today, 1 = Tomorrow, -1 = All",
     )
+
+    u_allow_manual_sale_order_line_cancellation = fields.Boolean(
+        "Allow manual cancellation of individual sale order lines",
+        default=False,
+    )
+
+    u_disallow_manual_sale_order_line_cancellation_at_picking_type_ids = fields.Many2many(
+        comodel_name="stock.picking.type",
+        relation="stock_warehouse_disallow_so_line_cancel_at_picking_types_rel",
+        string="Disallow manual cancellation of sale order lines at these picking stages",
+    )

--- a/addons/udes_sale_stock/tests/__init__.py
+++ b/addons/udes_sale_stock/tests/__init__.py
@@ -3,5 +3,6 @@
 from . import common
 from . import test_cancel_unfulfillable
 from . import test_get_current_demand
+from . import test_manual_sale_order_line_cancellation
 from . import test_sale_order_state
 from . import test_stock_picking

--- a/addons/udes_sale_stock/tests/test_manual_sale_order_line_cancellation.py
+++ b/addons/udes_sale_stock/tests/test_manual_sale_order_line_cancellation.py
@@ -1,0 +1,203 @@
+"""Tests for manual sale order line cancellation"""
+from odoo.exceptions import ValidationError
+
+from . import common
+
+
+class TestManualSaleOrderLineCancellation(common.BaseSaleUDES):
+    """Tests for manual sale order line cancellation"""
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestManualSaleOrderLineCancellation, cls).setUpClass()
+
+        cls.apple_quant = cls.create_quant(
+            cls.apple.id, cls.test_location_01.id, 30, package_id=cls.create_package().id,
+        )
+        cls.banana_quant = cls.create_quant(
+            cls.banana.id, cls.test_location_02.id, 30, package_id=cls.create_package().id,
+        )
+
+        # Create sale order
+        sale = cls.create_sale(cls.customer)
+        cls.apple_sale_line = cls.create_sale_line(sale, cls.apple, 15, route_id=cls.route_out.id)
+        cls.banana_sale_line = cls.create_sale_line(sale, cls.banana, 15, route_id=cls.route_out.id)
+        sale.action_confirm()
+        cls.sale = sale
+        cls.sale.warehouse_id.u_allow_manual_sale_order_line_cancellation = True
+
+        cls.first_picking = sale.picking_ids.filtered(lambda p: p.state == "assigned")
+        cls.last_picking = cls.first_picking.u_next_picking_ids
+        assert not cls.last_picking.u_next_picking_ids
+
+    def complete_picking_partially(self, picking, product, quantity=None, dest_location=None):
+        """Completes a single move line of a picking and backorders the rest"""
+        move_line = picking.move_line_ids.filtered(lambda ml: ml.product_id == product)
+        vals = {"qty_done": quantity if quantity is not None else move_line.product_uom_qty}
+        if dest_location is not None:
+            vals["location_dest_id"] = dest_location.id
+        move_line.write(vals)
+        picking.action_done()
+        self.assertEqual(self.first_picking.state, "done")
+        self.assertTrue(self.first_picking.u_created_back_orders)
+
+    def test01_not_allowed_by_warehouse_config(self):
+        """Test that cancellation is rejected if the warehouse config does not allow it"""
+        self.sale.warehouse_id.u_allow_manual_sale_order_line_cancellation = False
+        with self.assertRaises(ValidationError) as e:
+            self.apple_sale_line.ui_is_cancelled = True
+        self.assertEqual(
+            e.exception.name,
+            "Manual cancellation of individual order lines is not "
+            "allowed by the warehouse config",
+        )
+
+    def test02_cancellation(self):
+        """Test cancellation of a sale order line"""
+        self.apple_sale_line.ui_is_cancelled = True
+
+        # The apple sale order line should be cancelled
+        self.assertTrue(self.apple_sale_line.is_cancelled)
+        self.assertEqual({"cancel"}, set(self.apple_sale_line.move_ids.mapped("state")))
+
+        # The banana sale order line should still be processable
+        self.assertEqual(self.sale.state, "sale")
+        self.assertFalse(self.banana_sale_line.is_cancelled)
+        self.assertEqual(
+            {"assigned", "waiting"}, set(self.banana_sale_line.move_ids.mapped("state"))
+        )
+        self.assertEqual(
+            {"assigned", "waiting"}, set(self.banana_sale_line.move_ids.mapped("picking_id.state"))
+        )
+
+    def test03_cannot_uncancel(self):
+        """Test that uncancellation of a sale order line is not allowed"""
+        self.apple_sale_line.ui_is_cancelled = True
+        with self.assertRaises(ValidationError) as e:
+            self.apple_sale_line.ui_is_cancelled = False
+        self.assertEqual(
+            e.exception.name, "Cannot uncancel order lines: %s" % (self.apple.name,),
+        )
+
+    def test04_can_cancel_with_completed_picking(self):
+        """Test that a sale order line with its first picking completed can be cancelled"""
+        for move_line in self.first_picking.move_line_ids:
+            move_line.write(
+                {
+                    "qty_done": move_line.product_uom_qty,
+                    "location_dest_id": self.test_output_location_01.id,
+                }
+            )
+        self.first_picking.action_done()
+        self.assertEqual(self.first_picking.state, "done")
+
+        self.apple_sale_line.ui_is_cancelled = True
+
+    def test05_cannot_cancel_with_assigned_batch(self):
+        """Test that a sale order line with an in progress batch cannot be cancelled"""
+        Batch = self.env["stock.picking.batch"]
+
+        # Put the first picking in a batch and assign it to a user
+        batch = Batch.create({})
+        self.first_picking.batch_id = batch
+        batch.mark_as_todo()
+        batch.user_id = self.outbound_user
+        self.assertEqual(batch.state, "in_progress")
+
+        with self.assertRaises(ValidationError) as e:
+            self.apple_sale_line.ui_is_cancelled = True
+        self.assertEqual(
+            e.exception.name,
+            "Cannot cancel order lines with pickings in progress: %s" % (self.apple.name,),
+        )
+
+    def test06_cannot_cancel_with_quantity_done(self):
+        """Test that a sale order line with an in progress picking cannot be cancelled
+
+        Pickings are considered in progress if any of their move lines have been
+        partially or fully picked.
+        """
+        move_lines = self.first_picking.move_line_ids
+        banana_move_line = move_lines.filtered(lambda ml: ml.product_id == self.banana)
+        banana_move_line.qty_done = 1
+
+        with self.assertRaises(ValidationError) as e:
+            self.apple_sale_line.ui_is_cancelled = True
+        self.assertEqual(
+            e.exception.name,
+            "Cannot cancel order lines with pickings in progress: %s" % (self.apple.name,),
+        )
+
+    def test07_can_cancel_full_line_backorder(self):
+        """Test that a sale order line fully in a backorder picking can be cancelled"""
+        # Pick only bananas and backorder all the apples for the first picking
+        self.complete_picking_partially(
+            self.first_picking, self.banana, dest_location=self.test_output_location_01
+        )
+
+        # No ValidationError should be raised
+        self.apple_sale_line.ui_is_cancelled = True
+        self.assertTrue(self.apple_sale_line.is_cancelled)
+
+    def test08_can_cancel_split_line_backorder(self):
+        """Test that a sale order line partially in a backorder picking can be cancelled"""
+        # Pick a single apple for the first picking and backorder the rest
+        self.complete_picking_partially(
+            self.first_picking, self.apple, 1, dest_location=self.test_output_location_01
+        )
+
+        self.apple_sale_line.ui_is_cancelled = True
+
+    def test09_cannot_cancel_full_line_at_disallowed_picking_stage(self):
+        """Test that a sale order line at a disallowed picking stage cannot be cancelled"""
+        self.sale.warehouse_id.u_disallow_manual_sale_order_line_cancellation_at_picking_type_ids = [
+            (6, 0, [self.last_picking.picking_type_id.id])
+        ]
+
+        # Pick the entire line of apples
+        self.complete_picking_partially(
+            self.first_picking, self.apple, dest_location=self.test_output_location_01
+        )
+
+        with self.assertRaises(ValidationError) as e:
+            self.apple_sale_line.ui_is_cancelled = True
+        self.assertEqual(
+            e.exception.name,
+            "Cannot cancel order lines with pickings at the %s stage: %s"
+            % (self.last_picking.picking_type_id.name, self.apple.name,),
+        )
+
+    def test10_cannot_cancel_partial_line_at_disallowed_picking_stage(self):
+        """Test that a sale order line partly at a disallowed picking stage cannot be cancelled"""
+        self.sale.warehouse_id.u_disallow_manual_sale_order_line_cancellation_at_picking_type_ids = [
+            (6, 0, [self.last_picking.picking_type_id.id])
+        ]
+
+        # Pick only a single apple
+        self.complete_picking_partially(
+            self.first_picking, self.apple, 1, dest_location=self.test_output_location_01
+        )
+
+        with self.assertRaises(ValidationError) as e:
+            self.apple_sale_line.ui_is_cancelled = True
+        self.assertEqual(
+            e.exception.name,
+            "Cannot cancel order lines with pickings at the %s stage: %s"
+            % (self.last_picking.picking_type_id.name, self.apple.name,),
+        )
+
+    def test11_can_cancel_after_disallowed_picking_stage(self):
+        """Test that a sale order line that has partly left the warehouse can be cancelled again"""
+        self.sale.warehouse_id.u_disallow_manual_sale_order_line_cancellation_at_picking_type_ids = [
+            (6, 0, [self.last_picking.picking_type_id.id])
+        ]
+
+        # Pick and dispatch a single apple
+        self.complete_picking_partially(
+            self.first_picking, self.apple, 1, dest_location=self.test_output_location_01
+        )
+        self.complete_picking_partially(self.last_picking, self.apple, 1)
+
+        self.assertEqual(self.apple_sale_line.state, "sale")
+        self.assertEqual(self.apple_sale_line.qty_delivered, 1)
+        self.apple_sale_line.ui_is_cancelled = True

--- a/addons/udes_sale_stock/views/sale_order_views.xml
+++ b/addons/udes_sale_stock/views/sale_order_views.xml
@@ -11,10 +11,18 @@
         <xpath expr="//field[@name='payment_term_id']" position="after">
           <field name="priority"/>
         </xpath>
+        <xpath expr="//field[@name='order_line']" position="before">
+          <field name="u_allow_manual_sale_order_line_cancellation" invisible="1"/>
+        </xpath>
         <xpath expr="//field[@name='order_line']/tree/field[@name='price_unit']"
                position="before">
           <field name="product_packaging"/>
-          <field name="is_cancelled"/>
+          <field name="is_cancelled" invisible="1"/>
+          <field name="ui_is_cancelled"
+                 attrs="{'readonly': ['|', '|',
+                                      ('parent.u_allow_manual_sale_order_line_cancellation', '=', False),
+                                      ('is_cancelled', '=', True),
+                                      ('state', '=', 'done')]}"/>
         </xpath>
 
         <xpath expr="//field[@name='client_order_ref']" position="replace"/>

--- a/addons/udes_sale_stock/views/stock_warehouse.xml
+++ b/addons/udes_sale_stock/views/stock_warehouse.xml
@@ -8,6 +8,8 @@
             <xpath expr="//group[@name='print_picking_type']" position="after">
                 <group name="udes_sale_stock_config" string="Sale Stock Config">
                     <field name="u_so_auto_confirm_ahead_days" />
+                    <field name="u_allow_manual_sale_order_line_cancellation" />
+                    <field name="u_disallow_manual_sale_order_line_cancellation_at_picking_type_ids" />
                 </group>
             </xpath>
         </field>


### PR DESCRIPTION
Replaces https://github.com/unipartdigital/udes-open/pull/460

The previous PR disallowed cancellation if the outbound process was in progress. 
This PR allows it as long as no picking in the outbound process is in progress:


Sale order lines may be manually cancelled if there are no pickings in
progress. Note that this is not the same as the outbound process being
in progress: sale order lines may be cancelled midway through the outbound
process as long as no one is working on a picking related to it.

Sale order lines may not be cancelled once their products have progressed
to a certain stage of the outbound process, controlled by the
u_disallow_manual_sale_order_line_cancellation_at_picking_type_ids setting
on the warehouse. Eg. cancellation can be disallowed once products are about
to be dispatched. However once those products have left the warehouse and
are considered delivered, the remaining quantity in the sale order line
may be cancelled again.
