### PR TITLE
[FIX] udes_open: Changing the error message

### DIFF
--- a/addons/udes_stock/models/stock_picking.py
+++ b/addons/udes_stock/models/stock_picking.py
@@ -1775,8 +1775,8 @@ class StockPicking(models.Model):
 
         if not scanned_package.has_same_content(expected_package):
             raise ValidationError(
-                _("The contents of %s does not match what you have been asked " "to pick.")
-                % expected_package.name
+                _("The contents of %s does not match what you have been asked to pick.")
+                % scanned_package.name
             )
 
         if not scanned_package.is_reserved():


### PR DESCRIPTION
with scanned package instead of expected package

Story: 12656
Signed-off-by: Armand Cela <armand.cela@unipart.io>