### PR TITLE
[IMP] udes_open: Adding last reserved pallet name on batch info

### DIFF
--- a/addons/udes_stock/models/stock_picking_batch.py
+++ b/addons/udes_stock/models/stock_picking_batch.py
@@ -575,6 +575,7 @@ class StockPickingBatch(models.Model):
             "result_package_names": pickings.get_result_packages_names(),
             "u_original_name": self.u_original_name,
             "has_done_pickings": has_done_pickings,
+            "u_last_reserved_pallet_name": pickings.get_result_packages_names() and self.u_last_reserved_pallet_name or False,
         }
 
     def get_info(self, allowed_picking_states):

--- a/addons/udes_stock/models/stock_picking_batch.py
+++ b/addons/udes_stock/models/stock_picking_batch.py
@@ -575,7 +575,7 @@ class StockPickingBatch(models.Model):
             "result_package_names": pickings.get_result_packages_names(),
             "u_original_name": self.u_original_name,
             "has_done_pickings": has_done_pickings,
-            "u_last_reserved_pallet_name": pickings.get_result_packages_names() and self.u_last_reserved_pallet_name or False,
+            "u_last_reserved_pallet_name": pickings.get_result_packages_names() and self.u_last_reserved_pallet_name or None,
         }
 
     def get_info(self, allowed_picking_states):


### PR DESCRIPTION
Field is needed for an improvement to guide the user if has interrrupted
the process and picked some already with a pallet , so that user
goes and scanns last pallet
Story: 13659
Signed-off-by: Armand Cela <armand.cela@unipart.io>