### PR TITLE
[FIX] udes-open Adds a limit to empty locations returned.

### DIFF
--- a/addons/udes_stock/models/stock_picking.py
+++ b/addons/udes_stock/models/stock_picking.py
@@ -1316,7 +1316,7 @@ class StockPicking(models.Model):
 
         domains.append(("id", "child_of", self.location_dest_id.id))
 
-        return Location.search(domains)
+        return Location.search(domains, limit=50)
 
     def is_valid_location_dest_id(self, location=None, location_ref=None):
         """ Whether the specified location or location reference


### PR DESCRIPTION
To fix slowness of the sorting when fetching many empty locations. We limit the returned empty locations to the 50 before we sort them by name.