### PR TITLE
[FIX] udes_stock: Add optional limit and sort to suggested locations

### DIFF
--- a/addons/udes_stock/controllers/stock_move_line.py
+++ b/addons/udes_stock/controllers/stock_move_line.py
@@ -15,7 +15,6 @@ class StockMoveLineApi(UdesApi):
         Search suggested locations - refer to the API specs for details.
         """
         MoveLine = request.env['stock.move.line']
-
         if not move_line_ids:
             raise ValidationError(_("Must specify the 'move_line_ids' entry"))
 
@@ -26,12 +25,13 @@ class StockMoveLineApi(UdesApi):
 
         for pick in mls.mapped('picking_id'):
             pick_mls = mls.filtered(lambda ml: ml.picking_id == pick)
-            pick_locs = pick.get_suggested_locations(pick_mls)
+            pick_locs = pick.get_suggested_locations(pick_mls, limit=50)
+
             locations = pick_locs if locations is None \
                         else locations & pick_locs
 
             if pick.picking_type_id.u_drop_location_constraint == "enforce_with_empty":
-                pick_empty_locs = pick.get_empty_locations()
+                pick_empty_locs = pick.get_empty_locations(limit=50)
                 empty_locations = pick_empty_locs if empty_locations is None \
                                   else empty_locations & pick_empty_locs
 

--- a/addons/udes_stock/controllers/stock_move_line.py
+++ b/addons/udes_stock/controllers/stock_move_line.py
@@ -6,7 +6,32 @@ from odoo.exceptions import ValidationError
 
 from .main import UdesApi
 
+
 class StockMoveLineApi(UdesApi):
+
+    @staticmethod
+    def get_suggested_locations(move_line_ids, limit=None, sort=False):
+        MoveLine = request.env['stock.move.line']
+        if not move_line_ids:
+            raise ValidationError(_("Must specify the 'move_line_ids' entry"))
+
+        locations = None
+        empty_locations = None
+        mls = MoveLine.browse(move_line_ids)
+
+        for pick in mls.mapped('picking_id'):
+            pick_mls = mls.filtered(lambda ml: ml.picking_id == pick)
+            pick_locs = pick.get_suggested_locations(pick_mls, limit=limit, sort=sort)
+
+            locations = pick_locs if locations is None \
+                else locations & pick_locs
+
+            if pick.picking_type_id.u_drop_location_constraint == "enforce_with_empty":
+                pick_empty_locs = pick.get_empty_locations(limit=limit, sort=sort)
+                empty_locations = pick_empty_locs if empty_locations is None \
+                    else empty_locations & pick_empty_locs
+
+        return locations, empty_locations
 
     @http.route('/api/stock-move-line/suggested-locations',
                 type='json', methods=['POST'], auth='user')
@@ -14,26 +39,8 @@ class StockMoveLineApi(UdesApi):
         """
         Search suggested locations - refer to the API specs for details.
         """
-        MoveLine = request.env['stock.move.line']
-        if not move_line_ids:
-            raise ValidationError(_("Must specify the 'move_line_ids' entry"))
-
         response = []
-        locations = None
-        empty_locations = None
-        mls = MoveLine.browse(move_line_ids)
-
-        for pick in mls.mapped('picking_id'):
-            pick_mls = mls.filtered(lambda ml: ml.picking_id == pick)
-            pick_locs = pick.get_suggested_locations(pick_mls, limit=50)
-
-            locations = pick_locs if locations is None \
-                        else locations & pick_locs
-
-            if pick.picking_type_id.u_drop_location_constraint == "enforce_with_empty":
-                pick_empty_locs = pick.get_empty_locations(limit=50)
-                empty_locations = pick_empty_locs if empty_locations is None \
-                                  else empty_locations & pick_empty_locs
+        locations, empty_locations = self.get_suggested_locations(move_line_ids, limit=50, sort=True)
 
         if locations:
             response.append({"title": "",
@@ -48,3 +55,21 @@ class StockMoveLineApi(UdesApi):
                              "locations": empty_locations.get_info()})
 
         return response
+
+    @http.route('/api/stock-move-line/validate-location',
+                type='json', methods=['POST'], auth='user')
+    def validate_location(self, move_line_ids, location_barcode):
+        """
+        Validate Suggested Locations
+        """
+        Location = request.env['stock.location']
+        location = Location.search([('barcode', '=', location_barcode)])
+        location.ensure_one()
+        if not location:
+            raise ValidationError(_("Location not found"))
+        locations, empty_locations = self.get_suggested_locations(move_line_ids, limit=None, sort=False)
+        all_locations = locations | empty_locations
+        if location not in all_locations:
+            raise ValidationError(_("This is not an expected location"))
+        info = location.get_info()[0]
+        return info

--- a/addons/udes_stock/models/stock_move_line.py
+++ b/addons/udes_stock/models/stock_move_line.py
@@ -987,11 +987,11 @@ class StockMoveLine(models.Model):
                     continue
 
                 # location should be one of the suggested locations
-                locations = picking.get_suggested_locations(mls)
+                locations = picking.get_suggested_locations(mls, sort=False)
 
                 # or an empty location
                 if constraint == "enforce_with_empty":
-                    locations = locations | picking.get_empty_locations()
+                    locations = locations | picking.get_empty_locations(sort=False)
 
                 # or the damaged stock location if the picking type is set up
                 # to handle damages

--- a/addons/udes_stock/models/stock_picking.py
+++ b/addons/udes_stock/models/stock_picking.py
@@ -2162,14 +2162,14 @@ class StockPicking(models.Model):
 
         return location
 
-    def _get_suggested_location_empty_location(self, limit=None):
+    def _get_suggested_location_empty_location(self, limit=None, sort=False):
         """Get suggested locations by finding locations which are empty.
         """
-        return self.get_empty_locations(limit=limit)
+        return self.get_empty_locations(limit=limit, sort=sort)
 
-    def _get_suggested_location_by_products(self, move_line_ids, limit=None, products=None):
+    def _get_suggested_location_by_products(self, move_line_ids, limit=None, products=None, sort=False):
         """Get suggested locations by matching product."""
-        return self._suggest_locations_products(move_line_ids, products, limit=limit)
+        return self._suggest_locations_products(move_line_ids, products, limit=limit, sort=sort)
 
     def _get_suggested_location_by_product_lot(self, move_line_ids, products=None):
         """Get suggested locations by matching both product and lot number.
@@ -2179,7 +2179,7 @@ class StockPicking(models.Model):
         """
         return self._suggest_locations_products(move_line_ids, products, match_lots=True)
 
-    def _suggest_locations_products(self, move_line_ids, products=None, match_lots=False, limit=None):
+    def _suggest_locations_products(self, move_line_ids, products=None, match_lots=False, limit=None, sort=False):
         """Get suggested locations by matching product and optionally lot number.
 
         If used on a product that is not tracked by lot then locations will be suggested
@@ -2229,7 +2229,7 @@ class StockPicking(models.Model):
         if not suggested_locations:
             # No drop locations currently used for this product;
             # gather the empty ones
-            suggested_locations = self.get_empty_locations(limit=limit)
+            suggested_locations = self.get_empty_locations(limit=limit, sort=sort)
 
         return suggested_locations
 

--- a/addons/udes_stock/models/stock_picking.py
+++ b/addons/udes_stock/models/stock_picking.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+import inspect
 from collections import OrderedDict, defaultdict
 from lxml import etree
 
@@ -1301,7 +1301,7 @@ class StockPicking(models.Model):
 
         return move_lines.filtered(lambda o: o.qty_done > 0)
 
-    def _get_child_dest_locations(self, domains=None):
+    def _get_child_dest_locations(self, domains=None, limit=None):
         """ Return the child locations of the instance dest location.
             Extra domains are added to the child locations search query,
             when specified.
@@ -1314,8 +1314,7 @@ class StockPicking(models.Model):
             domains = []
 
         domains.append(("id", "child_of", self.location_dest_id.id))
-
-        return Location.search(domains, limit=50)
+        return Location.search(domains, limit=limit)
 
     def is_valid_location_dest_id(self, location=None, location_ref=None):
         """ Whether the specified location or location reference
@@ -2080,7 +2079,7 @@ class StockPicking(models.Model):
                 if locs:
                     mls.write({"location_dest_id": locs[0].id})
 
-    def get_suggested_locations(self, move_line_ids):
+    def get_suggested_locations(self, move_line_ids, limit=None, sort=True):
         """ Dispatch the configured suggestion location policy to
             retrieve the suggested locations
         """
@@ -2111,20 +2110,35 @@ class StockPicking(models.Model):
                 # If the pre-selected value is blocked
                 if not result:
                     func = getattr(self, "_get_suggested_location_" + policy, None)
-
                     if func:
-                        result = func(move_line_ids)
+                        # The signature of each "get suggested location" method may not
+                        # match, so inspect the method and only pass in the expected args
+                        expected_args = inspect.getfullargspec(func)[0]
+                        keys = ["move_line_ids", "limit", "sort"]
+                        local_vars = locals()
+                        kwargs = {x: local_vars[x] for x in keys if x in expected_args}
+                        result = func(**kwargs)
+                        # If result is sorted by the suggest method, don't re-sort it
+                        if "sort" in expected_args:
+                            sort = False
+        if sort:
+            return result.sorted(lambda l: l.name)
+        else:
+            return result
 
-        return result.sorted(lambda l: l.name)
-
-    def get_empty_locations(self):
+    def get_empty_locations(self, limit=None, sort=True):
         """ Returns the recordset of locations that are child of the
             instance dest location, are not blocked, and are empty.
             Expects a singleton instance.
         """
-        return self._get_child_dest_locations(
-            [("u_blocked", "=", False), ("barcode", "!=", False), ("quant_ids", "=", False)]
-        ).sorted(lambda l: l.name)
+        locations = self._get_child_dest_locations(
+            [("u_blocked", "=", False), ("barcode", "!=", False), ("quant_ids", "=", False)],
+            limit=limit
+        )
+        if sort:
+            return locations.sorted(lambda l: l.name)
+        else:
+            return locations
 
     def _check_picking_move_lines_suggest_location(self, move_line_ids):
         pick_move_lines = self.mapped("move_line_ids").filtered(lambda ml: ml in move_line_ids)
@@ -2148,14 +2162,14 @@ class StockPicking(models.Model):
 
         return location
 
-    def _get_suggested_location_empty_location(self, move_line_ids):
+    def _get_suggested_location_empty_location(self, limit=None):
         """Get suggested locations by finding locations which are empty.
         """
-        return self.get_empty_locations()
+        return self.get_empty_locations(limit=limit)
 
-    def _get_suggested_location_by_products(self, move_line_ids, products=None):
+    def _get_suggested_location_by_products(self, move_line_ids, limit=None, products=None):
         """Get suggested locations by matching product."""
-        return self._suggest_locations_products(move_line_ids, products)
+        return self._suggest_locations_products(move_line_ids, products, limit=limit)
 
     def _get_suggested_location_by_product_lot(self, move_line_ids, products=None):
         """Get suggested locations by matching both product and lot number.
@@ -2165,7 +2179,7 @@ class StockPicking(models.Model):
         """
         return self._suggest_locations_products(move_line_ids, products, match_lots=True)
 
-    def _suggest_locations_products(self, move_line_ids, products=None, match_lots=False):
+    def _suggest_locations_products(self, move_line_ids, products=None, match_lots=False, limit=None):
         """Get suggested locations by matching product and optionally lot number.
 
         If used on a product that is not tracked by lot then locations will be suggested
@@ -2174,7 +2188,9 @@ class StockPicking(models.Model):
         Assumption: match_lots not used for goods in process, i.e. based on lots with ids.
         During goods in, lots of quants on movelines won't be committed to the database so won't
         have ids, only names. To allow this to work for goods in the search would have to be on
-        the name instead which would be less efficicent.
+        the name instead which would be less efficient.
+
+        Limit only limits the number of empty locs to suggest
         """
         Quant = self.env["stock.quant"]
 
@@ -2213,7 +2229,7 @@ class StockPicking(models.Model):
         if not suggested_locations:
             # No drop locations currently used for this product;
             # gather the empty ones
-            suggested_locations = self.get_empty_locations()
+            suggested_locations = self.get_empty_locations(limit=limit)
 
         return suggested_locations
 


### PR DESCRIPTION
Allowing sorting and limit optionally in suggested_locations, sorting
is for all policies, limit only for those that accept it (story/14394)