### PR TITLE
[FIX] edi_sale_notifier: Fix failing tests

### DIFF
--- a/addons/edi_sale_notifier/tests/test_sale_notifier.py
+++ b/addons/edi_sale_notifier/tests/test_sale_notifier.py
@@ -1,6 +1,7 @@
 from odoo.addons.edi_sale.tests.common import EdiSaleCase
+from odoo import fields
 
-from mock import patch
+from unittest.mock import patch
 
 
 class TestSaleNotifier(EdiSaleCase):
@@ -17,6 +18,23 @@ class TestSaleNotifier(EdiSaleCase):
         cls.doc_type_tutorial.fail_fast = fail_fast
         return cls.create_input_document(cls.doc_type_tutorial, *filenames)
 
+    def prepare_document(self, doc):
+        """Actions taken when preparing document"""
+        SaleRequestTutorialRecord = self.env["edi.sale.request.tutorial.record"]
+
+        res = doc.action_prepare()
+        # Find related records and fill in client_order_ref and requested_date
+        # (These are fields that are made required in other addons that are not in the manifest
+        # so these need to be populated when running tests with both addons installed)
+        records = SaleRequestTutorialRecord.search([("doc_id", "=", doc.id)])
+        records.write(
+            {
+                "client_order_ref": "test_reference",
+                "requested_date": fields.Datetime.now()
+            }
+        )
+        return res
+
     def mock_invalid_partner_updates(self):
         """Patch function that checks partners to allow fail_fast=False to be used"""
         return patch.object(
@@ -28,6 +46,7 @@ class TestSaleNotifier(EdiSaleCase):
     def test_suffix_no_errors(self):
         """Test that no warning suffix is generated when there are no errors"""
         doc = self.create_tutorial("order01.csv", fail_fast=False)
+        self.assertTrue(self.prepare_document(doc))
         with self.mock_invalid_partner_updates():
             self.assertTrue(doc.action_execute())
         self.assertFalse(doc.notifier_subject_suffix)
@@ -35,6 +54,7 @@ class TestSaleNotifier(EdiSaleCase):
     def test_suffix_invalid_orderline(self):
         """Test that a suffix is generated when an orderline has an error"""
         doc = self.create_tutorial("order02.csv", fail_fast=False)
+        self.assertTrue(self.prepare_document(doc))
         with self.mock_invalid_partner_updates():
             self.assertTrue(doc.action_execute())
         self.assertTrue(doc.notifier_subject_suffix)
@@ -42,7 +62,7 @@ class TestSaleNotifier(EdiSaleCase):
     def test_suffix_invalid_partner(self):
         """Test that a suffix is generated when a partner has an error"""
         doc = self.create_tutorial("order01.csv", fail_fast=False)
-        self.assertTrue(doc.action_prepare())
+        self.assertTrue(self.prepare_document(doc))
         doc.partner_ids[0].error = True
         with self.mock_invalid_partner_updates():
             self.assertTrue(doc.action_execute())


### PR DESCRIPTION
- Tests fail as some fields are made required by addons not in the
manifest of edi_sale_notifier
- These fields will be now populated in these tests

User-story: 14441
Signed-off-by: Anthony Williams <anthony.williams@unipart.io>

CI bump?