### PR TITLE
[FIX] udes_stock: MissingError when raising stock investigation

### DIFF
--- a/addons/udes_stock/models/stock_picking_batch.py
+++ b/addons/udes_stock/models/stock_picking_batch.py
@@ -1094,7 +1094,7 @@ class StockPickingBatch(models.Model):
             # in a different picking
             # No unlinking of the empty pickings is done - this relies on the cron
             # to do the clean up
-            refactored_moves = to_investigate.mapped("move_lines")._action_refactor(stage="confirm")
+            refactored_moves = to_investigate.exists().mapped("move_lines")._action_refactor(stage="confirm")
             pickings_to_investigate = refactored_moves.mapped("picking_id")
             if not bypass_reassignment:
                 for picking in pickings_to_investigate:


### PR DESCRIPTION
Sometimes, due to refactoring, `to_investigate` can exist in cache
but not in the database. Check it exists before operating on it

Signed-off-by: Peter Alabaster <peter.alabaster@unipart.io>

User-story: 14596