### PR TITLE
[FIX] udes-open: restrict ability to add picking types to priorities

### DIFF
--- a/addons/udes_priorities/__manifest__.py
+++ b/addons/udes_priorities/__manifest__.py
@@ -7,7 +7,7 @@
     "website": "http://unipart.io",
     "category": "Warehouse",
     "version": "0.1",
-    "depends": ["udes_stock"],
+    "depends": ["udes_stock", "udes_security"],
     "data": [
         "data/default_priority_groups.xml",
         "data/default_priorities.xml",

--- a/addons/udes_priorities/models/priority.py
+++ b/addons/udes_priorities/models/priority.py
@@ -1,15 +1,19 @@
 # -*- coding: utf-8 -*-
 
-from odoo import models, fields, api, _
+from odoo import models, fields, api, SUPERUSER_ID, _
 from odoo.exceptions import UserError
 from uuid import uuid4
 
+
+""" Cannot be edited by anyone, including admin"""
+FORBIDDEN_FIELDS = {"reference"}
+
+""" Cannot be edited by anyone else than trusted or admin"""
 PROTECTED_FIELDS = {
     "name",
-    "reference",
     "sequence",
     "picking_type_ids",
-    "group_ids",
+    "priority_group_ids",
     "active",
 }
 
@@ -26,16 +30,37 @@ class UdesPriority(models.Model):
         default=lambda self: uuid4(),
     )
 
+    @api.multi
+    @api.depends("reference")
+    def _compute_pickings_count(self):
+        """
+        Count the number of transfers assigned to each priority.
+        """
+        for priority in self:
+            Picking = self.env["stock.picking"]
+            priority.picking_count = Picking.search_count(
+                [
+                    ("priority", "=", priority.reference),
+                ]
+            )
+
     def _default_sequence(self):
         max_rec = self.search([], order="sequence desc, id desc", limit=1)
         return max_rec.sequence + 1 if max_rec else 1
 
-    sequence = fields.Integer(default=_default_sequence, help="Used to order the priorities")
+    sequence = fields.Integer(
+        default=_default_sequence, help="Used to order the priorities"
+    )
     description = fields.Text(help="A description about the purpose of the priority")
     picking_type_ids = fields.Many2many(
         "stock.picking.type",
         string="Stock Transfer Types",
-        help="The stock picking types this priority is visible on. No picking types means all picking types",
+        help="The stock transfer types this priority is visible on. No transfer types means all transfer types",
+    )
+    picking_count = fields.Integer(
+        string="Affected Stock Transfers",
+        compute="_compute_pickings_count",
+        help="Stock transfers that would be affected by changes in the current priority.",
     )
     priority_group_ids = fields.Many2many(
         "udes_priorities.priority_group",
@@ -84,45 +109,86 @@ class UdesPriority(models.Model):
     @api.one
     def _check_for_duplicate_names_for_same_pick_type(self):
         if self._has_duplicate_names_for_same_pick_type() > 0:
-            raise UserError("Name must be unique for the picking types it is shown on")
+            raise UserError("Name must be unique for the transfer types it is shown on")
 
-    @api.multi
-    def _number_of_oustanding_pickings(self):
-        Picking = self.env["stock.picking"]
-        self.ensure_one()
-        return Picking.search_count(
-            [("priority", "=", self.reference), ("state", "not in", ("cancel", "done")),]
+    @api.constrains("active")
+    def _check_existing_transfers(self):
+        """Constrain active field
+
+        Allow only priorities with no existing stock transfers set to this priority to be archived.
+        """
+        inactive_priorities = self.filtered(lambda p: not p.active)
+        for priority in inactive_priorities:
+            if priority.picking_count:
+                raise UserError(
+                    "Cannot archive a priority that is set on existing transfers."
+                )
+
+    def _is_user_trusted_or_admin(self):
+        return self.env.uid == SUPERUSER_ID or self.env.user.has_group(
+            "udes_security.group_trusted_user"
         )
 
+    def _is_install_mode(self):
+        """Return true if Odoo is installing the module"""
+        return self.env.context.get("install_mode", False)
+
     @api.multi
-    def _check_for_oustanding_pickings(self):
+    def _validate_transfer_types_changes(self, values):
+        """Validate changes to transfer types
 
-        install_mode = self.env.context.get("install_mode", False)
-
-        if install_mode:
+        Allow addition of any transfer type but no removal of transfer types when
+        there are existing transfers of this type with the current priority set.
+        """
+        if self._is_install_mode():
             return
 
-        priorities_with_outstanding_picks = self.browse()
-        for priority in self:
-            if priority._number_of_oustanding_pickings() > 0:
-                priorities_with_outstanding_picks |= priority
-
-        if priorities_with_outstanding_picks:
-            raise UserError(
-                _("There are outstanding pickings for priorities: {}").format(
-                    ", ".join(priorities_with_outstanding_picks.mapped("name"))
-                )
+        if "picking_type_ids" in values:
+            Picking = self.env["stock.picking"]
+            message = (
+                "Invalid changes, you cannot remove the following transfer types as there are existing"
+                " transfers from this type assigned to the current priority:\n"
             )
+            invalid = False
+            new_ids = values["picking_type_ids"][0][2]
+
+            for old_pick_type in self.picking_type_ids:
+                if old_pick_type.id not in new_ids:
+                    assigned_pickings = Picking.search_count(
+                        [
+                            ("priority", "=", self.reference),
+                            ("picking_type_id", "=", old_pick_type.id),
+                        ]
+                    )
+                    if assigned_pickings:
+                        invalid = True
+                        message += "\n" + old_pick_type.name
+            if invalid:
+                raise UserError(message)
 
     @api.multi
     def write(self, values):
-        if values and any(k in PROTECTED_FIELDS for k in values):
-            self._check_for_oustanding_pickings()
+        if any(k in FORBIDDEN_FIELDS for k in values):
+            if self._is_install_mode():
+                return
+            raise UserError("Cannot change protected fields.")
+
+        if self._is_user_trusted_or_admin():
+            self._validate_transfer_types_changes(values)
+        else:
+            if any(k in PROTECTED_FIELDS for k in values):
+                raise UserError("You do not have the rights for making changes.")
         return super().write(values)
 
     @api.multi
     def unlink(self):
-        self._check_for_oustanding_pickings()
+        if self._is_user_trusted_or_admin() is False:
+            raise UserError("You do not have the rights for making changes.")
+        for priority in self:
+            if priority.picking_count:
+                raise UserError(
+                    "Changes cannot be applied as there are transfers assigned to selected priorities."
+                )
         return super().unlink()
 
     @api.multi

--- a/addons/udes_priorities/tests/common.py
+++ b/addons/udes_priorities/tests/common.py
@@ -9,7 +9,9 @@ class BasePriorities(common.BaseUDES):
         super().setUpClass()
 
         Priorities = cls.env["udes_priorities.priority"]
-        (Priorities.search([]) - cls.env.ref("udes_priorities.normal")).write({"active": False})
+        (Priorities.search([]) - cls.env.ref("udes_priorities.normal")).write(
+            {"active": False}
+        )
 
         cls.urgent = Priorities.create(
             {
@@ -39,3 +41,28 @@ class BasePriorities(common.BaseUDES):
         )
 
         cls.test_priorities = cls.urgent | cls.normal | cls.not_urgent
+
+        User = cls.env["res.users"]
+
+        cls.group_stock_user = cls.env.ref(
+            "stock.group_stock_user"
+        )  # Necessary to access stock.picking
+        cls.group_trusted_user = cls.env.ref("udes_security.group_trusted_user")
+
+        cls.trusted_usr = User.create(
+            {
+                "name": "test_priority_usr_1",
+                "login": "test_priority_usr_1",
+                "groups_id": [
+                    (6, 0, [cls.group_stock_user.id, cls.group_trusted_user.id])
+                ],
+            }
+        )
+
+        cls.simple_stock_usr = User.create(
+            {
+                "name": "test_priority_usr_2",
+                "login": "test_priority_usr_2",
+                "groups_id": [(6, 0, [cls.group_stock_user.id])],
+            }
+        )

--- a/addons/udes_priorities/tests/test_priority.py
+++ b/addons/udes_priorities/tests/test_priority.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-
 from . import common
-from odoo.exceptions import UserError
+from odoo.exceptions import AccessError, UserError, ValidationError
 
 
 class TestPriorities(common.BasePriorities):
@@ -28,21 +27,65 @@ class TestPriorities(common.BasePriorities):
 
         actual_order_2 = Priorities.search([("id", "in", self.test_priorities.ids)])
         for retrieved, ordered in zip(actual_order_2, new_order):
-            self.assertEqual(retrieved, ordered, "Incorrect ordering after being modified")
+            self.assertEqual(
+                retrieved, ordered, "Incorrect ordering after being modified"
+            )
 
-    def test_outstanding_picking(self):
-        self.urgent.reference = "This is allowed"
+    def test_check_other_user_rights_for_priorities(self):
+        """
+        Check that non trusted or non admin users cannot modify priorities.
+        """
+        with self.assertRaises(UserError):
+            self.urgent.sudo(self.simple_stock_usr).reference = "This is not allowed"
 
-        picking = self.create_picking(self.picking_type_pick)
-        picking.priority = self.urgent.reference
-        with self.assertRaises(
-            UserError, msg="Allowed to change reference while there is outstanding an picking"
-        ):
+        with self.assertRaises(AccessError):
+            self.urgent.sudo(self.simple_stock_usr).description = "This is not allowed"
+
+        with self.assertRaises(UserError):
+            self.urgent.sudo(self.simple_stock_usr).active = False
+
+        with self.assertRaises(UserError):
+            self.urgent.sudo(self.simple_stock_usr).unlink()
+
+    def test_check_editable_fields_for_priorities(self):
+        """
+        Check that the correct users can modify specific fields.
+        """
+        self.urgent.name = "This is allowed1"
+        self.urgent.sudo(self.trusted_usr).name = "This is allowed2"
+
+        self.urgent.description = "This is allowed1"
+        self.urgent.sudo(self.trusted_usr).description = "This is allowed2"
+
+        with self.assertRaises(UserError):
             self.urgent.reference = "This is not allowed"
+        with self.assertRaises(UserError):
+            self.urgent.sudo(self.trusted_usr).reference = "This is not allowed"
 
-        self.urgent.description = "This is still allowed"
+        self.urgent.sudo(self.trusted_usr).sequence = "3"
 
-        with self.assertRaises(
-            UserError, msg="Allowed to unlink while there is outstanding an picking"
-        ):
+        self.urgent.sudo(self.trusted_usr).active = False
+        self.urgent.sudo(self.trusted_usr).active = True
+
+        self.urgent.sudo(self.trusted_usr).picking_type_ids += self.picking_type_pick
+
+    def test_cannot_remove_picking_type_with_assigned_transfers(self):
+        picking1 = self.create_picking(self.picking_type_pick)
+        picking1.priority = self.urgent.reference
+
+        with self.assertRaises(UserError):
+            self.urgent.picking_type_ids -= self.picking_type_pick
+
+    def test_cannot_archive_picking_type_with_assigned_transfers(self):
+        picking1 = self.create_picking(self.picking_type_pick)
+        picking1.priority = self.urgent.reference
+
+        with self.assertRaises(ValidationError):
+            self.urgent.active = False
+
+    def test_cannot_remove_priority_with_assigned_transfers(self):
+        picking1 = self.create_picking(self.picking_type_pick)
+        picking1.priority = self.urgent.reference
+
+        with self.assertRaises(UserError):
             self.urgent.unlink()

--- a/addons/udes_priorities/views/priorities.xml
+++ b/addons/udes_priorities/views/priorities.xml
@@ -37,6 +37,7 @@
                 <field name="reference"/>
                 <field name="description"/>
                 <field name="picking_type_ids"/>
+                <field name="picking_count"/>
                 <field name="priority_group_ids"/>
               </group>
             </group>


### PR DESCRIPTION
When adding a new stock transfer type to a priority if there was a
picking that is not yet completed then UDES would complain of this
and not let any user modify the list of assigned stock transfer types.

This change adds the ability for sysadmin, debug and trusted users
to modify the list of stock transfer types for priorities and also
see the outstanding pickings for the priority in question.

User-story: 20

Signed-off-by: Lorenzo Cucurachi <lorenzo.cucurachi@unipart.io>