### PR TITLE
[FIX] udes_stock: Disable name translation

### DIFF
--- a/addons/udes_stock/models/__init__.py
+++ b/addons/udes_stock/models/__init__.py
@@ -13,6 +13,7 @@ from . import stock_inventory
 from . import stock_location
 from . import stock_location_category
 from . import stock_location_path
+from . import stock_location_route
 from . import stock_move
 from . import stock_move_line
 from . import stock_picking
@@ -23,3 +24,4 @@ from . import stock_production_lot
 from . import stock_quant
 from . import stock_quant_package
 from . import stock_warehouse
+from . import stock_warehouse_orderpoint

--- a/addons/udes_stock/models/stock_location.py
+++ b/addons/udes_stock/models/stock_location.py
@@ -852,37 +852,3 @@ class StockLocation(models.Model):
         """Method to be override in other modules"""
         self.ensure_one()
         return None
-
-
-class Orderpoint(models.Model):
-
-    _inherit = "stock.warehouse.orderpoint"
-
-    @api.onchange("location_id")
-    @api.constrains("location_id")
-    def _is_limited(self):
-        """Prevents creating a second order point on a location.
-
-        If the location or an ancestor is configured to only allow a single
-        order point.
-
-        Raises a ValidationError if the constraint is breached.
-        """
-        self.ensure_one()
-        Orderpoint = self.env["stock.warehouse.orderpoint"]
-        orderpoints = Orderpoint.search(
-            [
-                ("location_id", "=", self.location_id.id),
-            ]
-        )
-        orderpoints -= self
-        if not orderpoints:
-            return
-        if not self.location_id.limits_orderpoints():
-            return
-        names = ", ".join(orderpoints.mapped("product_id.name"))
-        raise ValidationError(
-            _("An order point for location {} already exists on " "{}.").format(
-                self.location_id.name, names
-            )
-        )

--- a/addons/udes_stock/models/stock_location_route.py
+++ b/addons/udes_stock/models/stock_location_route.py
@@ -1,0 +1,8 @@
+from odoo import fields, models
+
+
+class Route(models.Model):
+    _inherit = "stock.location.route"
+
+    # Disable translation instead of renaming.
+    name = fields.Char(translate=False)

--- a/addons/udes_stock/models/stock_picking_type.py
+++ b/addons/udes_stock/models/stock_picking_type.py
@@ -20,6 +20,8 @@ TARGET_STORAGE_FORMAT_OPTIONS = [
 class StockPickingType(models.Model):
     _inherit = "stock.picking.type"
 
+    name = fields.Char(translate=False)
+
     show_operations = fields.Boolean(default=True)
 
     # Pick workflow options

--- a/addons/udes_stock/models/stock_warehouse_orderpoint.py
+++ b/addons/udes_stock/models/stock_warehouse_orderpoint.py
@@ -1,0 +1,35 @@
+from odoo import fields, models, _, api
+from odoo.exceptions import ValidationError
+
+
+class Orderpoint(models.Model):
+    _inherit = "stock.warehouse.orderpoint"
+
+    @api.onchange("location_id")
+    @api.constrains("location_id")
+    def _is_limited(self):
+        """Prevents creating a second order point on a location.
+
+        If the location or an ancestor is configured to only allow a single
+        order point.
+
+        Raises a ValidationError if the constraint is breached.
+        """
+        self.ensure_one()
+        Orderpoint = self.env["stock.warehouse.orderpoint"]
+        orderpoints = Orderpoint.search(
+            [
+                ("location_id", "=", self.location_id.id),
+            ]
+        )
+        orderpoints -= self
+        if not orderpoints:
+            return
+        if not self.location_id.limits_orderpoints():
+            return
+        names = ", ".join(orderpoints.mapped("product_id.name"))
+        raise ValidationError(
+            _("An order point for location {} already exists on " "{}.").format(
+                self.location_id.name, names
+            )
+        )


### PR DESCRIPTION
Disable name translation for picking types and routes,
this avoids complications when duplicating, where the
new duplicated name was not being saved and was being
treated as a translation.

User-story: 621

Signed-off-by: Caleb Shelton <caleb.shelton@unipart.io>