### PR TITLE
[IMP] udes_open: Handle UoM in udes_stock

### DIFF
--- a/addons/udes_stock/README.md
+++ b/addons/udes_stock/README.md
@@ -85,6 +85,8 @@ Additional Details:
 ### Quants (model: stock.quant)
 
 Physical instances of products at a location are modelled as quants. Short of "quantities of stock", these are used to record stock levels are various parts of the warehouse. Using the analogy of object-orientated programming, products = classes, quants = objects.
+Note that quants are stored in their unit of measure, so if screws come in boxes of 1000 and we have 5000 in a location,
+then we would have `available_quantity = 5`.
 
 Additional Details:
 - Change _description to 'Quant'
@@ -128,8 +130,8 @@ This is essentially a collection of products that are to be moved from one locat
 | u_prev_picking_ids | one2many (stock.picking) | Shows the previous pickings in the chain |
 | u_next_picking_ids | one2many (stock.picking) | Shows the next pickings in the chain |
 | u_created_backorder_ids | one2many (stock.picking) | Shows backorders created from this picking |
-| u_quantity_done | float | Sums all done move quantities for the picking |
-| u_total_quantity | float | Sums all move quantities for the picking |
+| u_quantity_done | float | Sums all done move quantities for the picking (in the UoM of the moves) |
+| u_total_quantity | float | Sums all move quantities for the picking (in the UoM of the moves) |
 | u_has_discrepancies | boolean | Flags when u_quantity_done doesn't match u_total_quantity |
 | u_num_pallets | int | Sums all unique destination packages found in the picking's move lines |
 
@@ -158,6 +160,17 @@ The type of stock.picking can is defined by this type. It can represent a goods 
 ### Stock Move (model: stock.move)
 
 A move of an item of stock from one location to another.
+Note:
+* `product_qty`: the quantity of the product in the move in the UoM of the product (computed field)
+* `product_uom_qty`: the quantity of the product in the move in the UoM of the move
+Example, screws come in a box of 1000. The UoM of the product is 1000.
+If you wanted a move to always move 6 boxes at a time, the UoM of the move is 6000.
+If you wanted to move 12 boxes in one move, then:
+* product_qty = 12
+* product_uom_qty = 2
+so the full/real/absolute quantity (whatever we refer to the 12000 screws as) is never considered in the move.
+
+When using/creating/splitting moves, we use the UoM of the move. 
 
 | Helpers | Description |
 | ------- | ----------- |

--- a/addons/udes_stock/models/stock_move.py
+++ b/addons/udes_stock/models/stock_move.py
@@ -130,9 +130,7 @@ class StockMove(models.Model):
                 "do_not_unreserve": True,
             }
             self.with_context(**context_vars).write(
-                {
-                    "product_uom_qty": self.product_uom_qty - total_initial_qty,
-                }
+                {"product_uom_qty": self.product_uom_qty - total_initial_qty}
             )
 
             # When not complete, splitting a move may change its state,

--- a/addons/udes_stock/models/stock_move_line.py
+++ b/addons/udes_stock/models/stock_move_line.py
@@ -74,9 +74,7 @@ class StockMoveLine(models.Model):
         package = self.package_id
         owner = self.owner_id
         location = self.location_id
-        domain = [
-            ("product_id", "=", product.id),
-        ]
+        domain = [("product_id", "=", product.id)]
         if not strict:
             if lot:
                 domain = expression.AND([[("lot_id", "=", lot.id)], domain])
@@ -122,9 +120,7 @@ class StockMoveLine(models.Model):
 
     def _round_qty(self, value):
         return float_round(
-            value,
-            precision_rounding=self.product_uom_id.rounding,
-            rounding_method="UP",
+            value, precision_rounding=self.product_uom_id.rounding, rounding_method="UP"
         )
 
     def _split(self, qty=None):
@@ -175,10 +171,7 @@ class StockMoveLine(models.Model):
             # - bypass_reservation_update:
             #   avoids to execute code specific for Odoo UI at stock.move.line.write()
             self.with_context(bypass_reservation_update=True).write(
-                {
-                    "product_uom_qty": qty_to_keep,
-                    "qty_done": qty_done,
-                }
+                {"product_uom_qty": qty_to_keep, "qty_done": qty_done}
             )
             res = new_ml
         return res

--- a/addons/udes_stock/models/stock_quant.py
+++ b/addons/udes_stock/models/stock_quant.py
@@ -51,8 +51,11 @@ class StockQuant(models.Model):
         return products
 
     def create_picking(self, picking_type, **kwargs):
-        """Create a picking from quants
-        Uses stock.picking create_picking functionality
+        """
+        Create a picking from quants
+        Uses stock.picking create_picking functionality to create the picking.
+        Note that the quants are stored in the product uom.
+
         :args:
             - picking_type
         :kwargs:
@@ -69,7 +72,9 @@ class StockQuant(models.Model):
                 kwargs.update({"location_id": location.id})
 
         product_quantities = self.get_quantities_by_key()
-        products_info = [{"product": key, "qty": val} for key, val in product_quantities.items()]
+        products_info = [
+            {"product": key, "uom_qty": val} for key, val in product_quantities.items()
+        ]
         return Picking.with_context(quant_ids=self.ids).create_picking(
             picking_type, products_info, **kwargs
         )

--- a/addons/udes_stock/tests/common.py
+++ b/addons/udes_stock/tests/common.py
@@ -82,11 +82,7 @@ class BaseUDES(common.SavepointCase):
     def create_quant(cls, product_id, location_id, qty, lot_name=None, **kwargs):
         """Create and return a quant of a product at location"""
         Quant = cls.env["stock.quant"]
-        vals = {
-            "product_id": product_id,
-            "location_id": location_id,
-            "quantity": qty,
-        }
+        vals = {"product_id": product_id, "location_id": location_id, "quantity": qty}
         if lot_name:
             lot = cls.create_lot(product_id, lot_name)
             vals["lot_id"] = lot.id
@@ -97,10 +93,7 @@ class BaseUDES(common.SavepointCase):
     def create_lot(cls, product_id, lot_name, **kwargs):
         Lot = cls.env["stock.production.lot"]
 
-        vals = {
-            "name": lot_name,
-            "product_id": product_id,
-        }
+        vals = {"name": lot_name, "product_id": product_id}
         if "company_id" not in kwargs:
             vals["company_id"] = cls.company.id
         vals.update(kwargs)
@@ -175,11 +168,7 @@ class BaseUDES(common.SavepointCase):
         cls.test_goodsout_location_01, cls.test_goodsout_location_02 = cls.test_goodsout_locations
 
         cls.trailer_location = cls.picking_type_goods_out.default_location_dest_id.copy(
-            {
-                "name": "TEST_OUT_TRAILER",
-                "active": True,
-                "location_id": cls.warehouse_location.id,
-            }
+            {"name": "TEST_OUT_TRAILER", "active": True, "location_id": cls.warehouse_location.id}
         )
         cls.test_trailer_locations = Location.create(
             [
@@ -305,17 +294,10 @@ class BaseUDES(common.SavepointCase):
         cls.route_out = Route.create(route_vals)
 
         # Goods out
-        sequence_vals = {
-            "name": "TestGoodsOut",
-            "prefix": "TESTGOODSOUT",
-            "padding": 5,
-        }
+        sequence_vals = {"name": "TestGoodsOut", "prefix": "TESTGOODSOUT", "padding": 5}
         sequence_goodsout = Sequence.create(sequence_vals)
 
-        out_vals = {
-            "sequence_id": sequence_goodsout.id,
-            "sequence": 13,
-        }
+        out_vals = {"sequence_id": sequence_goodsout.id, "sequence": 13}
         picking_type_out.write(out_vals)
 
         # set goods-out source location = pick dest location
@@ -363,10 +345,7 @@ class BaseUDES(common.SavepointCase):
     def _setup_check_location(cls):
         Location = cls.env["stock.location"]
         cls.check_location = cls.picking_type_pick.default_location_dest_id.copy(
-            {
-                "name": "TEST_CHECK",
-                "active": True,
-            }
+            {"name": "TEST_CHECK", "active": True}
         )
         cls.test_check_location_01 = Location.create(
             {
@@ -451,10 +430,7 @@ class BaseUDES(common.SavepointCase):
         User = cls.env["res.users"]
         # Creating user without company
         # takes company from current user
-        vals = {
-            "name": name,
-            "login": login,
-        }
+        vals = {"name": name, "login": login}
         vals.update(kwargs)
         user = User.create(vals)
 
@@ -466,9 +442,7 @@ class BaseUDES(common.SavepointCase):
     @classmethod
     def update_move(cls, move, qty_done, **kwargs):
         """Update a move with qty done"""
-        vals = {
-            "quantity_done": qty_done + move["quantity_done"],
-        }
+        vals = {"quantity_done": qty_done + move["quantity_done"]}
         vals.update(kwargs)
         return move.update(vals)
 

--- a/addons/udes_stock/tests/test_stock_location.py
+++ b/addons/udes_stock/tests/test_stock_location.py
@@ -16,34 +16,16 @@ class TestStockLocation(BaseUDES):
         # Stock > Zone 02 > Loc 02-02
         cls.zone_01, cls.zone_02 = Location.create(
             [
-                {
-                    "name": "Zone 01",
-                    "location_id": cls.stock_location.id,
-                },
-                {
-                    "name": "Zone 02",
-                    "location_id": cls.stock_location.id,
-                },
+                {"name": "Zone 01", "location_id": cls.stock_location.id},
+                {"name": "Zone 02", "location_id": cls.stock_location.id},
             ]
         )
         cls.loc_01_01, cls.loc_01_02, cls.loc_02_01, cls.loc_02_02 = Location.create(
             [
-                {
-                    "name": "Loc 01-01",
-                    "location_id": cls.zone_01.id,
-                },
-                {
-                    "name": "Loc 01-02",
-                    "location_id": cls.zone_01.id,
-                },
-                {
-                    "name": "Loc 02-01",
-                    "location_id": cls.zone_02.id,
-                },
-                {
-                    "name": "Loc 02-02",
-                    "location_id": cls.zone_02.id,
-                },
+                {"name": "Loc 01-01", "location_id": cls.zone_01.id},
+                {"name": "Loc 01-02", "location_id": cls.zone_01.id},
+                {"name": "Loc 02-01", "location_id": cls.zone_02.id},
+                {"name": "Loc 02-02", "location_id": cls.zone_02.id},
             ]
         )
 

--- a/addons/udes_stock/tests/test_stock_move.py
+++ b/addons/udes_stock/tests/test_stock_move.py
@@ -12,7 +12,7 @@ class TestStockMove(common.BaseUDES):
         cls.Move = cls.env["stock.move"]
 
         # Create a picking
-        cls._pick_info = [{"product": cls.banana, "qty": 6}]
+        cls._pick_info = [{"product": cls.banana, "uom_qty": 6}]
         cls.quant1 = cls.create_quant(cls.banana.id, cls.test_stock_location_01.id, 5)
         cls.quant2 = cls.create_quant(cls.banana.id, cls.test_stock_location_02.id, 3)
         cls.pick = cls.create_picking(
@@ -36,7 +36,7 @@ class TestStockMove(common.BaseUDES):
     def test01_split_out_move_lines_raise_error(self):
         """Raise a value error when try to split out move lines from another move"""
         # Create another picking
-        new_pick_info = [{"product": self.apple, "qty": 20}]
+        new_pick_info = [{"product": self.apple, "uom_qty": 20}]
         self.create_quant(self.banana.id, self.test_stock_location_01.id, 5)
         self.create_quant(self.apple.id, self.test_stock_location_02.id, 10)
         new_pick = self.create_picking(
@@ -102,7 +102,7 @@ class TestStockMove(common.BaseUDES):
         self.create_quant(self.fig.id, self.test_stock_location_01.id, 2, package_id=pack2.id)
         picking = self.create_picking(
             self.picking_type_pick,
-            products_info=[{"product": self.fig, "qty": 5}],
+            products_info=[{"product": self.fig, "uom_qty": 5}],
             location_dest_id=self.test_received_location_01.id,
             location_id=self.test_stock_location_01.id,
             assign=True,
@@ -159,8 +159,8 @@ class TestStockMove(common.BaseUDES):
         self.create_quant(self.apple.id, self.test_stock_location_01.id, apple_uom_qty)
 
         products_info = [
-            {"product": self.apple, "qty": apple_uom_qty},
-            {"product": self.banana, "qty": banana_uom_qty},
+            {"product": self.apple, "uom_qty": apple_uom_qty},
+            {"product": self.banana, "uom_qty": banana_uom_qty},
         ]
 
         move_values = self.Picking._prepare_move(self.pick, [products_info])

--- a/addons/udes_stock/tests/test_stock_move.py
+++ b/addons/udes_stock/tests/test_stock_move.py
@@ -170,10 +170,7 @@ class TestStockMove(common.BaseUDES):
         banana_move = moves.filtered(lambda m: m.product_id == self.banana)
 
         # Check the prepared move_line_values are correct
-        moves_info = {
-            apple_move: apple_uom_qty,
-            banana_move: banana_uom_qty,
-        }
+        moves_info = {apple_move: apple_uom_qty, banana_move: banana_uom_qty}
         move_line_values = self.Move._prepare_move_lines(moves_info)
 
         self.assertEqual(

--- a/addons/udes_stock/tests/test_stock_move_line.py
+++ b/addons/udes_stock/tests/test_stock_move_line.py
@@ -8,7 +8,10 @@ class TestStockMoveLine(common.BaseUDES):
     def setUpClass(cls):
         super(TestStockMoveLine, cls).setUpClass()
         # Order the banana first to allow for sorting checks later on
-        cls._pick_info = [{"product": cls.banana, "qty": 5}, {"product": cls.apple, "qty": 4}]
+        cls._pick_info = [
+            {"product": cls.banana, "uom_qty": 5},
+            {"product": cls.apple, "uom_qty": 4},
+        ]
         cls.picking = cls.create_picking(
             cls.picking_type_goods_in, products_info=cls._pick_info, confirm=True, assign=True
         )
@@ -46,7 +49,10 @@ class TestStockMoveLine(common.BaseUDES):
         # Create pick to reserve the quants
         pick = self.create_picking(
             self.picking_type_pick,
-            products_info=[{"product": self.apple, "qty": 12}, {"product": self.banana, "qty": 5}],
+            products_info=[
+                {"product": self.apple, "uom_qty": 12},
+                {"product": self.banana, "uom_qty": 5},
+            ],
             assign=True,
             confirm=True,
         )
@@ -78,9 +84,9 @@ class TestStockMoveLine(common.BaseUDES):
     def test04_sort_by_key_custom(self):
         """Get the move lines sorted by product qty then product id"""
         pick_info = [
-            {"product": self.banana, "qty": 5},
-            {"product": self.fig, "qty": 4},
-            {"product": self.apple, "qty": 5},
+            {"product": self.banana, "uom_qty": 5},
+            {"product": self.fig, "uom_qty": 4},
+            {"product": self.apple, "uom_qty": 5},
         ]
         # Create picking
         picking = self.create_picking(
@@ -219,7 +225,10 @@ class TestStockMoveLine(common.BaseUDES):
         # Create pick to reserve the quants
         pick = self.create_picking(
             self.picking_type_pick,
-            products_info=[{"product": self.apple, "qty": 12}, {"product": self.banana, "qty": 8}],
+            products_info=[
+                {"product": self.apple, "uom_qty": 12},
+                {"product": self.banana, "uom_qty": 8},
+            ],
             assign=True,
             confirm=True,
         )
@@ -272,7 +281,7 @@ class TestStockMoveLine(common.BaseUDES):
         Uses the default sorting
         """
         # Create additional move lines in a new picking
-        pick_info = [{"product": self.banana, "qty": 17}]
+        pick_info = [{"product": self.banana, "uom_qty": 17}]
         new_picking = self.create_picking(
             self.picking_type_goods_in, products_info=pick_info, confirm=True, assign=True
         )
@@ -292,7 +301,7 @@ class TestStockMoveLine(common.BaseUDES):
         Does not use the default sorting, sort = False
         """
         # Create additional move lines
-        pick_info = [{"product": self.banana, "qty": 17}]
+        pick_info = [{"product": self.banana, "uom_qty": 17}]
         new_picking = self.create_picking(
             self.picking_type_goods_in, products_info=pick_info, confirm=True, assign=True
         )  # Sort the move lines in this case to ensure the smallest is first
@@ -328,7 +337,7 @@ class TestStockMoveLine(common.BaseUDES):
         # Create pick to reserve the quant
         pick = self.create_picking(
             self.picking_type_pick,
-            products_info=[{"product": self.banana, "qty": 8}],
+            products_info=[{"product": self.banana, "uom_qty": 8}],
             assign=True,
             confirm=True,
         )
@@ -355,7 +364,7 @@ class TestStockMoveLine(common.BaseUDES):
         # Create pick to reserve the quant
         pick = self.create_picking(
             self.picking_type_pick,
-            products_info=[{"product": self.banana, "qty": 8}],
+            products_info=[{"product": self.banana, "uom_qty": 8}],
             assign=True,
             confirm=True,
         )

--- a/addons/udes_stock/tests/test_stock_move_line.py
+++ b/addons/udes_stock/tests/test_stock_move_line.py
@@ -35,19 +35,13 @@ class TestStockMoveLine(common.BaseUDES):
         test_package_1 = self.create_package()
         test_package_2 = self.create_package()
         self.create_quant(
-            self.apple.id,
-            self.test_stock_location_01.id,
-            10,
-            package_id=test_package_1.id,
+            self.apple.id, self.test_stock_location_01.id, 10, package_id=test_package_1.id
         )
         self.create_quant(
             self.banana.id, self.test_stock_location_01.id, 5, package_id=test_package_1.id
         )
         self.create_quant(
-            self.apple.id,
-            self.test_stock_location_02.id,
-            10,
-            package_id=test_package_2.id,
+            self.apple.id, self.test_stock_location_02.id, 10, package_id=test_package_2.id
         )
         # Create pick to reserve the quants
         pick = self.create_picking(
@@ -214,19 +208,13 @@ class TestStockMoveLine(common.BaseUDES):
         test_package_1 = self.create_package()
         test_package_2 = self.create_package()
         self.create_quant(
-            self.apple.id,
-            self.test_stock_location_01.id,
-            10,
-            package_id=test_package_1.id,
+            self.apple.id, self.test_stock_location_01.id, 10, package_id=test_package_1.id
         )
         self.create_quant(
             self.banana.id, self.test_stock_location_01.id, 5, package_id=test_package_1.id
         )
         self.create_quant(
-            self.apple.id,
-            self.test_stock_location_02.id,
-            10,
-            package_id=test_package_2.id,
+            self.apple.id, self.test_stock_location_02.id, 10, package_id=test_package_2.id
         )
         # Create pick to reserve the quants
         pick = self.create_picking(

--- a/addons/udes_stock/tests/test_stock_picking.py
+++ b/addons/udes_stock/tests/test_stock_picking.py
@@ -68,16 +68,9 @@ class TestStockPicking(common.BaseUDES):
 
     def test_get_empty_locations(self):
         """Get empty locations - for goods in"""
-        self.assertEqual(
-            self.test_picking_in.get_empty_locations(),
-            self.test_received_location_01,
-        )
+        self.assertEqual(self.test_picking_in.get_empty_locations(), self.test_received_location_01)
         # Add stock to a location - to check empty locations obtained
-        self.create_quant(
-            self.apple.id,
-            self.test_received_location_01.id,
-            5,
-        )
+        self.create_quant(self.apple.id, self.test_received_location_01.id, 5)
         self.assertFalse(self.test_picking_in.get_empty_locations())
 
     def test_get_empty_locations_sorted(self):
@@ -85,19 +78,8 @@ class TestStockPicking(common.BaseUDES):
         # Create location 'A' in zone 'Z'
         # When sorted by location name directly 'A' will appear first,
         # but in default location ordering it will be last
-        zone_z = self.Location.create(
-            {
-                "name": "Zone Z",
-                "location_id": self.received_location.id,
-            }
-        )
-        loc_a = self.Location.create(
-            {
-                "name": "A",
-                "barcode": "LRTESTA",
-                "location_id": zone_z.id,
-            }
-        )
+        zone_z = self.Location.create({"name": "Zone Z", "location_id": self.received_location.id})
+        loc_a = self.Location.create({"name": "A", "barcode": "LRTESTA", "location_id": zone_z.id})
 
         # Set destination location of the test Goods In picking to the received zone
         self.test_picking_in.location_dest_id = self.received_location
@@ -156,10 +138,7 @@ class TestStockPicking(common.BaseUDES):
         products = self.apple | self.banana
         pick = self.Picking.create_picking(
             picking_type=self.picking_type_pick,
-            products_info=[
-                {"product": self.apple, "qty": 2},
-                {"product": self.banana, "qty": 4},
-            ],
+            products_info=[{"product": self.apple, "qty": 2}, {"product": self.banana, "qty": 4}],
         )
         # Check default pick locations
         self.assertEqual(pick.location_id, self.stock_location)
@@ -176,10 +155,7 @@ class TestStockPicking(common.BaseUDES):
         products = self.apple | self.banana
         pick = self.Picking.create_picking(
             picking_type=self.picking_type_pick,
-            products_info=[
-                {"product": self.apple, "qty": 2},
-                {"product": self.banana, "qty": 4},
-            ],
+            products_info=[{"product": self.apple, "qty": 2}, {"product": self.banana, "qty": 4}],
             location_id=self.test_stock_location_01.id,
             location_dest_id=self.test_goodsout_location_01.id,
             confirm=True,
@@ -205,14 +181,8 @@ class TestStockPicking(common.BaseUDES):
         picks = self.Picking.create_picking(
             picking_type=self.picking_type_pick,
             products_info=[
-                [
-                    {"product": self.apple, "qty": 2},
-                    {"product": self.banana, "qty": 4},
-                ],
-                [
-                    {"product": self.apple, "qty": 1},
-                    {"product": self.banana, "qty": 1},
-                ],
+                [{"product": self.apple, "qty": 2}, {"product": self.banana, "qty": 4}],
+                [{"product": self.apple, "qty": 1}, {"product": self.banana, "qty": 1}],
             ],
             location_id=self.test_stock_location_01.id,
             location_dest_id=self.test_goodsout_location_01.id,
@@ -237,12 +207,7 @@ class TestStockPicking(common.BaseUDES):
     def test_pepare_and_create_move(self):
         """Prepare and create a single move"""
         pick = self.create_picking(self.picking_type_goods_in)
-        move_values = self.Picking._prepare_move(
-            pick,
-            [
-                [{"product": self.elderberry, "qty": 10}],
-            ],
-        )
+        move_values = self.Picking._prepare_move(pick, [[{"product": self.elderberry, "qty": 10}]])
         # Check the prepared move_values are correct
         self.assertEqual(len(move_values), 1)
         self.assertEqual(move_values[0], self._get_expected_move_values(pick, self.elderberry, 10))
@@ -499,12 +464,7 @@ class TestStockPicking(common.BaseUDES):
                 pick_c: False,
                 pick_d: (pick_b | pick_c),
             },
-            "u_next_picking_ids": {
-                pick_a: pick_b,
-                pick_b: pick_d,
-                pick_c: pick_d,
-                pick_d: False,
-            },
+            "u_next_picking_ids": {pick_a: pick_b, pick_b: pick_d, pick_c: pick_d, pick_d: False},
         }
 
         # Assert that each computed picking field returns the expected result for all picks

--- a/addons/udes_stock/tests/test_stock_quant.py
+++ b/addons/udes_stock/tests/test_stock_quant.py
@@ -203,9 +203,9 @@ class TestStockQuantFIFO(BaseUDES):
         cls.Quant = cls.env["stock.quant"]
 
         # Create packages
-        cls.pack1 = cls.create_package(name="test_package_one")
-        cls.pack2 = cls.create_package(name="test_package_two")
-        cls.pack3 = cls.create_package(name="test_package_three")
+        cls.pack1 = cls.create_package(name="1001")
+        cls.pack2 = cls.create_package(name="1002")
+        cls.pack3 = cls.create_package(name="1003")
 
         # Create three quants in the same location
         cls.quant1 = cls.create_quant(cls.apple.id, cls.test_stock_location_01.id, 1.0)

--- a/addons/udes_stock/tests/test_stock_quant_package.py
+++ b/addons/udes_stock/tests/test_stock_quant_package.py
@@ -9,10 +9,7 @@ class TestStockQuantPackageModel(BaseUDES):
         cls.Package = cls.env["stock.quant.package"]
         cls.test_package = cls.Package.get_or_create("test_package_01", create=True)
         cls.apple_quant = cls.create_quant(
-            cls.apple.id,
-            cls.test_stock_location_01.id,
-            10,
-            package_id=cls.test_package.id,
+            cls.apple.id, cls.test_stock_location_01.id, 10, package_id=cls.test_package.id
         )
         cls.create_quant(
             cls.banana.id, cls.test_stock_location_01.id, 5, package_id=cls.test_package.id
@@ -241,16 +238,10 @@ class TestCreatePicking(BaseUDES):
 
         cls.test_package = Package.get_or_create("test_package_01", create=True)
         cls.create_quant(
-            cls.apple.id,
-            cls.test_stock_location_01.id,
-            10,
-            package_id=cls.test_package.id,
+            cls.apple.id, cls.test_stock_location_01.id, 10, package_id=cls.test_package.id
         )
         cls.create_quant(
-            cls.banana.id,
-            cls.test_stock_location_01.id,
-            5,
-            package_id=cls.test_package.id,
+            cls.banana.id, cls.test_stock_location_01.id, 5, package_id=cls.test_package.id
         )
         cls.test_user = cls.create_user("test_user", "test_user_login")
 

--- a/addons/udes_stock/tests/test_stock_quant_package.py
+++ b/addons/udes_stock/tests/test_stock_quant_package.py
@@ -122,7 +122,10 @@ class TestStockQuantPackageModel(BaseUDES):
         # Create a picking from test package
         pick = self.create_picking(
             self.picking_type_pick,
-            products_info=[{"product": self.apple, "qty": 12}, {"product": self.banana, "qty": 5}],
+            products_info=[
+                {"product": self.apple, "uom_qty": 12},
+                {"product": self.banana, "uom_qty": 5},
+            ],
             assign=True,
             confirm=True,
         )
@@ -135,7 +138,10 @@ class TestStockQuantPackageModel(BaseUDES):
         # Create a picking from test package
         pick = self.create_picking(
             self.picking_type_pick,
-            products_info=[{"product": self.apple, "qty": 12}, {"product": self.banana, "qty": 5}],
+            products_info=[
+                {"product": self.apple, "uom_qty": 12},
+                {"product": self.banana, "uom_qty": 5},
+            ],
             assign=True,
             confirm=True,
         )
@@ -149,7 +155,10 @@ class TestStockQuantPackageModel(BaseUDES):
         self.create_quant(self.apple.id, self.test_stock_location_02.id, 10)
         self.create_quant(self.banana.id, self.test_stock_location_02.id, 10)
         # Create a new pick
-        product_info = [{"product": self.banana, "qty": 2}, {"product": self.apple, "qty": 10}]
+        product_info = [
+            {"product": self.banana, "uom_qty": 2},
+            {"product": self.apple, "uom_qty": 10},
+        ]
         pick = self.create_picking(
             self.picking_type_pick,
             products_info=product_info,
@@ -172,7 +181,7 @@ class TestStockQuantPackageModel(BaseUDES):
         self.create_quant(self.apple.id, self.test_stock_location_02.id, 20)
         pick = self.create_picking(
             self.picking_type_pick,
-            products_info=[{"product": self.apple, "qty": 18}],
+            products_info=[{"product": self.apple, "uom_qty": 18}],
             assign=True,
             confirm=True,
             location_id=self.test_stock_location_02.id,
@@ -200,9 +209,9 @@ class TestStockQuantPackageModel(BaseUDES):
         self.create_quant(self.fig.id, self.test_stock_location_02.id, 15)
         # Create pick
         product_info = [
-            {"product": self.banana, "qty": 17},
-            {"product": self.fig, "qty": 15},
-            {"product": self.apple, "qty": 18},
+            {"product": self.banana, "uom_qty": 17},
+            {"product": self.fig, "uom_qty": 15},
+            {"product": self.apple, "uom_qty": 18},
         ]
         pick = self.create_picking(
             self.picking_type_pick,

--- a/addons/udes_stock/tests/test_stock_quant_package.py
+++ b/addons/udes_stock/tests/test_stock_quant_package.py
@@ -7,7 +7,11 @@ class TestStockQuantPackageModel(BaseUDES):
     def setUpClass(cls):
         super(TestStockQuantPackageModel, cls).setUpClass()
         cls.Package = cls.env["stock.quant.package"]
-        cls.test_package = cls.Package.get_or_create("test_package_01", create=True)
+        User = cls.env["res.users"]
+
+        warehouse = User.get_user_warehouse()
+        # package
+        cls.test_package = cls.Package.get_or_create("1001", create=True)
         cls.apple_quant = cls.create_quant(
             cls.apple.id, cls.test_stock_location_01.id, 10, package_id=cls.test_package.id
         )
@@ -32,11 +36,11 @@ class TestStockQuantPackageModel(BaseUDES):
     def test03_has_same_content(self):
         """Test has same content of three packages, two are the same and one is not"""
         # Create two new packages with same content but different content than default package
-        test_package_2 = self.Package.get_or_create("test_package_2", create=True)
+        test_package_2 = self.Package.get_or_create("1002", create=True)
         self.create_quant(
             self.banana.id, self.test_stock_location_01.id, 5, package_id=test_package_2.id
         )
-        test_package_3 = self.Package.get_or_create("test_package_3", create=True)
+        test_package_3 = self.Package.get_or_create("1003", create=True)
         self.create_quant(
             self.banana.id, self.test_stock_location_01.id, 5, package_id=test_package_3.id
         )
@@ -58,10 +62,10 @@ class TestStockQuantPackageModel(BaseUDES):
             "qty": 5,
         }
         # Create two new packages with two quants with lot each
-        test_package_1 = self.Package.get_or_create("test_package_1", create=True)
+        test_package_1 = self.Package.get_or_create("1001", create=True)
         self.create_quant(**apple_quant_info, package_id=test_package_1.id, lot_name="LOT001")
         self.create_quant(**banana_quant_info, package_id=test_package_1.id, lot_name="LOT001")
-        test_package_2 = self.Package.get_or_create("test_package_2", create=True)
+        test_package_2 = self.Package.get_or_create("1002", create=True)
         self.create_quant(**apple_quant_info, package_id=test_package_2.id, lot_name="LOT002")
         self.create_quant(**banana_quant_info, package_id=test_package_2.id, lot_name="LOT002")
         # Check they should have the same content by product
@@ -86,15 +90,15 @@ class TestStockQuantPackageModel(BaseUDES):
             "qty": 5,
         }
         # Create new packages with 10, 5, 5, 5, 5 apples each
-        test_package_1 = self.Package.get_or_create("test_package_1", create=True)
+        test_package_1 = self.Package.get_or_create("2001", create=True)
         self.create_quant(**quant_info_10, package_id=test_package_1.id)
-        test_package_2 = self.Package.get_or_create("test_package_2", create=True)
+        test_package_2 = self.Package.get_or_create("2002", create=True)
         self.create_quant(**quant_info_5, package_id=test_package_2.id)
-        test_package_3 = self.Package.get_or_create("test_package_3", create=True)
+        test_package_3 = self.Package.get_or_create("2003", create=True)
         self.create_quant(**quant_info_5, package_id=test_package_3.id)
-        test_package_4 = self.Package.get_or_create("test_package_4", create=True)
+        test_package_4 = self.Package.get_or_create("2004", create=True)
         self.create_quant(**quant_info_5, package_id=test_package_4.id)
-        test_package_5 = self.Package.get_or_create("test_package_5", create=True)
+        test_package_5 = self.Package.get_or_create("2005", create=True)
         self.create_quant(**quant_info_5, package_id=test_package_5.id)
         # Split all packages in two groups
         group_1 = test_package_1 | test_package_2
@@ -245,7 +249,7 @@ class TestCreatePicking(BaseUDES):
 
         Package = cls.env["stock.quant.package"]
 
-        cls.test_package = Package.get_or_create("test_package_01", create=True)
+        cls.test_package = Package.get_or_create("1001", create=True)
         cls.create_quant(
             cls.apple.id, cls.test_stock_location_01.id, 10, package_id=cls.test_package.id
         )


### PR DESCRIPTION
Use product_uom_qty throughout as product_qty is a computed
field. This is a backend change, and further changes need
to be done to handle different UoMs in both the frontend
and in Odoo.

User-story: 462

Signed-off-by: Pete Pratt <peter.pratt@unipart.io>