### PR TITLE
[ADD] udes_stock_cron: Migrated over the reserve_stock method in stoc…

### DIFF
--- a/addons/udes_stock/models/stock_move.py
+++ b/addons/udes_stock/models/stock_move.py
@@ -45,7 +45,7 @@ class StockMove(models.Model):
 
         """
         move_line_values = []
-
+        
         for move, qty in moves_info.items():
             vals = self._prepare_move_line(move, qty, **kwargs)
             move_line_values.append(vals)

--- a/addons/udes_stock_cron/__init__.py
+++ b/addons/udes_stock_cron/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/udes_stock_cron/__manifest__.py
+++ b/addons/udes_stock_cron/__manifest__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "UDES Stock Cron",
+    "summary": "udes stock cron",
+    "description": "Core models and configuration for UDES Stock cron - Odoo 14",
+    "author": "Unipart digital",
+    "website": "http://github/unipartdigital/udes-open",
+    "category": "UDES",
+    "version": "0.1",
+    "depends": ["base", "stock", "stock_picking_batch", "udes_common", "udes_cron", "udes_stock"],
+    "data": [
+        "data/ir_cron.xml",
+        "views/stock_picking_type.xml",
+    ],
+}

--- a/addons/udes_stock_cron/data/ir_cron.xml
+++ b/addons/udes_stock_cron/data/ir_cron.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+
+        <record id="reserve_stock_action" model="ir.cron">
+        <field name="name">Reserve stock</field>
+        <field name="active" eval="True" />
+        <field name="user_id" ref="base.user_root" />
+        <field name="interval_number">5</field>
+        <field name="interval_type">minutes</field>
+        <field name="numbercall">-1</field>
+        <field name="doall">0</field>
+        <field name="model_id" ref="stock.model_stock_picking" />
+        <field name="state">code</field>
+        <field name="code">model.reserve_stock()</field>
+        </record>
+        
+    </data>
+</odoo>

--- a/addons/udes_stock_cron/models/__init__.py
+++ b/addons/udes_stock_cron/models/__init__.py
@@ -1,0 +1,5 @@
+from . import stock_move_line
+from . import stock_move 
+from . import stock_picking_batch
+from . import stock_picking_type
+from . import stock_picking

--- a/addons/udes_stock_cron/models/stock_move.py
+++ b/addons/udes_stock_cron/models/stock_move.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+from odoo import models, api, _
+
+import logging
+_logger = logging.getLogger(__name__)
+
+# Map move state to the refactor stage.
+STAGES = {
+    "confirmed": "confirm",
+    "waiting": "confirm",
+    "assigned": "assign",
+    "partially_available": "assign",
+    "done": "validate",
+}
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _action_assign(self):
+        """Extend _action_assign to trigger refactor action and preprocess
+        location suggestions.
+        n.b. _action_assign does not return anything in core Odoo, so we
+        don't return any extra moves that may have been created
+        by refactoring.
+        """
+        res = super(StockMove, self)._action_assign()
+
+        self.exists().unreserve_partial_lines()
+        assign_moves = self.exists()._action_refactor(stage="assign")
+
+        for picking_type, moves in assign_moves.groupby("picking_type_id"):
+            # location suggestions
+            if picking_type.u_drop_location_preprocess:
+                moves.mapped("picking_id").apply_drop_location_policy()
+
+        assign_moves.mapped("picking_id")._reserve_full_packages()
+        return res
+
+    def unreserve_partial_lines(self):
+        """Unreserve any partially reserved lines if not allowed by the picking type."""
+        # Override to prevent assigning partial lines via the check
+        # availability button when u_handle_partial_lines is False,
+        pass
+
+    def _unreserve_partial_lines(self):
+        """Unreserve any partially reserved lines if not allowed by the picking type."""
+        Move = self.env["stock.move"]
+
+        moves_to_unreserve = Move.browse()
+        partial_moves = self.filtered(lambda m: m.state == "partially_available")
+        for picking_type, grouped_moves in partial_moves.groupby("picking_type_id"):
+            if picking_type.u_handle_partials and not picking_type.u_handle_partial_lines:
+                moves_to_unreserve += grouped_moves
+        moves_to_unreserve._do_unreserve()
+        return None
+
+
+    def _action_refactor(self, stage=None):
+        """Refactor moves in self.
+        :param stage: One of confirm|assign|done, if set, filters the moves
+            which will be refactored to only the state(s) that match:
+                - 'confirm': confirmed, waiting
+                - 'assign': assigned, partially_available
+                - 'done': done
+           Methods doing a refactor are expected to take a single recordset of
+           moves on which they will act, and to return the recordset of
+           equivalent moves after they have been transformed.
+           The output moves may be identical to the input, may contain none
+           of the input moves, or anywhere in between.
+           The output should contain a functionally similar set of moves.
+        """
+        if stage is not None and stage not in STAGES.values():
+            raise UserError(_("Unknown stage for move refactor: %s") % stage)
+        moves = self
+
+        if self._context.get("disable_move_refactor"):
+            return moves
+
+        rf_moves = moves.filtered(
+            lambda m: m.picking_type_id and m.state not in ["draft", "cancel"]
+        )
+        if stage is not None:
+            rf_moves = rf_moves.filtered(lambda m: STAGES[m.state] == stage)
+
+        for picking_type, pt_moves in rf_moves.groupby("picking_type_id"):
+            for stage, st_moves in pt_moves.groupby(lambda m: STAGES[m.state]):
+                if stage == "confirm":
+                    action = picking_type.u_post_confirm_action
+                elif stage == "assign":
+                    action = picking_type.u_post_assign_action
+                elif stage == "validate":
+                    action = picking_type.u_post_validate_action
+                else:
+                    continue  # Don't refactor cancel or draft moves.
+                
+                if action:
+                    _logger.info(
+                        "Refactoring %s at %s using %s: %s",
+                        picking_type.name,
+                        stage,
+                        action,
+                        st_moves.ids,
+                    )
+                    func = getattr(st_moves.with_context(refactor_stage=stage), "refactor_action_" + action)
+                    new_moves = func()
+                    if new_moves is not None:
+                        moves -= st_moves
+                        moves |= new_moves
+
+        return moves
+

--- a/addons/udes_stock_cron/models/stock_move_line.py
+++ b/addons/udes_stock_cron/models/stock_move_line.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from odoo import models, fields, _
+from collections import defaultdict
+
+class StockMoveLine(models.Model):
+    _inherit = "stock.move.line"
+
+    def any_destination_locations_default(self):
+        """Checks if all location_dest_id's are the picks default
+           location_dest_id of the picking.
+        """
+        default_dest = self.mapped("picking_id.location_dest_id")
+        default_dest.ensure_one()
+        return any(ml.location_dest_id == default_dest for ml in self)
+    
+    def _get_all_products_quantities(self):
+        """This function computes the different product quantities for the given move_lines
+        """
+        res = defaultdict(int)
+        for move_line in self:
+            res[move_line.product_id] += move_line.product_uom_qty
+        return res

--- a/addons/udes_stock_cron/models/stock_picking.py
+++ b/addons/udes_stock_cron/models/stock_picking.py
@@ -1,0 +1,387 @@
+# -*- coding: utf-8 -*-
+from odoo import fields, models, _, api
+from collections import defaultdict
+from odoo.exceptions import UserError, ValidationError
+from psycopg2 import OperationalError, errorcodes
+
+import logging
+_logger = logging.getLogger(__name__)
+
+
+PG_CONCURRENCY_ERRORS_TO_RETRY = (
+    errorcodes.LOCK_NOT_AVAILABLE,
+    errorcodes.SERIALIZATION_FAILURE,
+    errorcodes.DEADLOCK_DETECTED,
+)
+MAX_TRIES_ON_CONCURRENCY_FAILURE = 5
+
+class StockPicking(models.Model):
+    _inherit = 'stock.picking'
+
+    batch_id = fields.Many2one("stock.picking.batch", copy=True)
+
+    def _reserve_stock_assign(self):
+        """Perform assign of the pickings at the move level because refactoring
+        may change the pickings.
+        This is a function so it can be extended and/or overriden.
+        """
+        # Assign at the move level disabling refactoring
+        moves = self.mapped("move_lines")
+        moves.with_context(lock_batch_state=True, disable_move_refactor=True)._action_assign()
+
+        # Unreserve any partially reserved lines if not allowed by the picking type
+        moves._unreserve_partial_lines()
+
+        # Refactor after unreserving
+        refactored_moves = moves._action_refactor(stage="assign")
+
+        return refactored_moves.mapped("picking_id")
+
+    def reserve_stock(self):
+        """
+        Reserve stock according to the number of reservable pickings.
+        If this method is called on an empty recordset it will attempt to
+        reserve stock for all eligible picking types.  If the recordset is not
+        empty, it will reserve stock for the picks in the recordset. If the
+        recordset is not empty, it is the callers responsibility to make sure
+        that the pickings belong to at most one batch, otherwise this method
+        cannot respect the priority order of pickings, in this case the
+        behaviour of this method is undefined.
+        In either scenario the picking type flags for reserving complete
+        batches and handling partial batches are respected.
+        The number of reservable pickings is defined on the picking type.
+        0 reservable pickings means this function should not reserve stock
+        -1 reservable picking means all reservable stock should be reserved.
+        """
+
+        Picking = self.env["stock.picking"]
+        PickingType = self.env["stock.picking.type"]
+
+        if self:
+            picking_types = self.mapped("picking_type_id")
+        else:
+            picking_types = PickingType.search(
+                [("active", "=", True), ("u_num_reservable_pickings", "!=", 0)]
+            )
+
+        # We will either reserve up to the reservation limit or until all
+        # available picks have been reserved, depending on the value of
+        # u_num_reservable_pickings.
+        # However we must also take into account the atomic batch reservation
+        # flag (u_reserve_batches) and the handle partial flag
+        # (u_handle_partials).
+
+        for picking_type in picking_types:
+            _logger.info("Reserving stock for picking type %r.", picking_type)
+
+            # We want to reserve batches atomically, that is we will
+            # reserve pickings until all pickings in a batch have been
+            # assigned, even if we exceed the number of reservable pickings.
+            # However, the value of the handle partial flag is false we
+            # should not reserve stock if the batch cannot be completely
+            # reserved.
+            to_reserve = picking_type.u_num_reservable_pickings
+            reserve_all = to_reserve == -1
+            base_domain = [("picking_type_id", "=", picking_type.id), ("state", "=", "confirmed")]
+            limit = 1
+            processed = Picking.browse()
+            by_type = lambda x: x.picking_type_id == picking_type
+
+            while reserve_all or to_reserve > 0:
+
+                if self:
+                    # Removed processed pickings from self
+                    pickings = self.filtered(by_type) - processed
+                else:
+                    domain = base_domain[:]
+                    if processed:
+                        domain.append(("id", "not in", processed.ids))
+                    pickings = Picking.search(domain, limit=limit)
+
+                if not pickings:
+                    # No pickings left to process.
+                    # If u_num_reservable_pickings is -1, or there are
+                    # fewer available pickings that the limit, the loop must
+                    # terminate here.
+                    break
+
+                batch = pickings.mapped("batch_id")
+                if batch and batch.state == "draft":
+                    # Add to seen pickings so that we don't try to process
+                    # this batch again.
+                    processed |= batch.picking_ids
+                    continue
+
+                if batch and picking_type.u_reserve_batches:
+                    pickings = batch.picking_ids
+
+
+                # MPS: mimic Odoo's retry behaviour
+                tries = 0
+                while True:
+
+                    try:
+                        with self.env.cr.savepoint():
+                            pickings = pickings._reserve_stock_assign()
+                            batch._compute_state()
+
+                            processed |= pickings
+
+                            unsatisfied = pickings.filtered(
+                                lambda x: x.state not in ["assigned", "cancel", "done"]
+                            )
+                            mls = pickings.mapped("move_line_ids")
+                            if unsatisfied:
+                                # Unreserve if the picking type cannot handle partials or it
+                                # can but there is nothing allocated (no stock.move.lines)
+                                if not picking_type.u_handle_partials or not mls:
+                                    # construct error message, report only products
+                                    # that are unreservable.
+                                    not_done = lambda x: x.state not in (
+                                        "done",
+                                        "assigned",
+                                        "cancel",
+                                    )
+                                    moves = unsatisfied.mapped("move_lines").filtered(not_done)
+                                    products = moves.mapped("product_id.default_code")
+                                    picks = moves.mapped("picking_id.name")
+                                    msg = (
+                                        f"Unable to reserve stock for products {products} "
+                                        f"for pickings {picks}."
+                                    )
+                                    raise UserError(msg)
+                            break
+                    except UserError as e:
+                        self.invalidate_cache()
+                        # Only propagate the error if the function has been
+                        # manually triggered
+                        if self:
+                            raise e
+                        tries = -1
+                        break
+                    except OperationalError as e:
+                        self.invalidate_cache()
+                        if e.pgcode not in PG_CONCURRENCY_ERRORS_TO_RETRY:
+                            raise
+                        if tries >= MAX_TRIES_ON_CONCURRENCY_FAILURE:
+                            _logger.info(
+                                "%s, maximum number of tries reached" % errorcodes.lookup(e.pgcode)
+                            )
+                            break
+                        tries += 1
+                        wait_time = 1
+                        _logger.info(
+                            "%s, retry %d/%d in %.04f sec..."
+                            % (
+                                errorcodes.lookup(e.pgcode),
+                                tries,
+                                MAX_TRIES_ON_CONCURRENCY_FAILURE,
+                                wait_time,
+                            )
+                        )
+                        time.sleep(wait_time)
+                if tries == -1:
+                    continue
+                if tries >= MAX_TRIES_ON_CONCURRENCY_FAILURE:
+                    break
+                
+                # Incrementally commit to release picks as soon as possible and
+                # allow serialisation error to propagate to respect priority
+                # order
+                self.env.cr.commit()
+                # Only count as reserved the number of pickings at mls
+                to_reserve -= len(mls.mapped("picking_id"))
+
+                if self:
+                    # Only process the specified pickings
+                    break
+            _logger.info("Reserving stock for picking type %r completed.", picking_type)
+        return
+    
+    def apply_drop_location_policy(self):
+        """Apply suggested locations to move lines
+        raise ValidationError: if the policy set does not have
+                               _allow_preprocess set
+        """
+        by_pack_or_single = lambda ml: ml.package_id.package_id or ml.package_id or ml.id
+
+        for pick in self:
+            self.check_policy_for_preprocessing(pick.picking_type_id.u_drop_location_policy)
+            # Group by pallet or package
+            for _pack, mls in pick.move_line_ids.groupby(by_pack_or_single):
+                locs = pick.get_suggested_locations(mls)
+                if locs:
+                    mls.write({"location_dest_id": locs[0].id})
+
+    def check_policy_for_preprocessing(self, policy):
+        """ "Check policy allows pre processing as not all polices
+        can be used in this way
+        """
+        func = getattr(self, "_get_suggested_location_" + policy, None)
+
+        if not hasattr(func, "_allow_preprocess"):
+            raise ValidationError(
+                _("This policy(%s) is not meant to be used in " "preprocessing") % policy
+            )
+    
+    def get_suggested_locations(self, move_line_ids, limit=None, sort=True):
+        """Dispatch the configured suggestion location policy to
+        retrieve the suggested locations
+        """
+        result = self.env["stock.location"]
+
+        # WS-MPS: use self.ensure_one() and don't loop (self is used in all but
+        # one place), or suggest locations for the move lines of the picking,
+        # use picking instead of self inside the loop and ?intersect? result.
+        for picking in self:
+            policy = picking.picking_type_id.u_drop_location_policy
+
+            if policy:
+                if (
+                    move_line_ids
+                    and picking.picking_type_id.u_drop_location_preprocess
+                    and not move_line_ids.any_destination_locations_default()
+                ):
+                    # The policy has been preprocessed this assumes the
+                    # the policy is able to provide a sensible value (this is
+                    # not the case for every policy)
+                    # Use the preselected value
+                    result = self._get_suggested_location_exactly_match_move_line(move_line_ids)
+
+                    # Just to prevent running it twice
+                    if not result and policy == "exactly_match_move_line":
+                        return result
+
+                # If the pre-selected value is blocked
+                if not result:
+                    func = getattr(self, "_get_suggested_location_" + policy, None)
+                    if func:
+                        # The signature of each "get suggested location" method may not
+                        # match, so inspect the method and only pass in the expected args
+                        expected_args = inspect.getfullargspec(func)[0]
+                        keys = ["move_line_ids", "limit", "sort"]
+                        local_vars = locals()
+                        kwargs = {x: local_vars[x] for x in keys if x in expected_args}
+                        result = func(**kwargs)
+                        # If result is sorted by the suggest method, don't re-sort it
+                        if "sort" in expected_args:
+                            sort = False
+        if sort:
+            return result.sorted(lambda l: l.name)
+        else:
+            return result
+    
+    def _get_suggested_location_exactly_match_move_line(self, move_line_ids):
+        self._check_picking_move_lines_suggest_location(move_line_ids)
+        location = move_line_ids.mapped("location_dest_id")
+
+        location.ensure_one()
+
+        if location.u_blocked or location.usage == "view":
+            return self.env["stock.location"]
+
+        return location
+
+    def _check_picking_move_lines_suggest_location(self, move_line_ids):
+        pick_move_lines = self.mapped("move_line_ids").filtered(lambda ml: ml in move_line_ids)
+
+        if len(pick_move_lines) != len(move_line_ids):
+            raise ValidationError(
+                _(
+                    "Some move lines not found in picking %s to suggest "
+                    "drop off locations for them." % self.name
+                )
+            )
+
+    def _should_reserve_full_packages(self):
+        """Method to determine if picking should reserve entire packages"""
+        self.ensure_one()
+        return self.picking_type_id.u_reserve_as_packages
+
+    def _reserve_full_packages(self):
+        """
+        If the picking type of the picking in self has full package
+        reservation enabled, partially reserved packages are
+        completed.
+        """
+        Quant = self.env["stock.quant"]
+        MoveLine = self.env["stock.move.line"]
+
+        # do not reserve full packages when bypass_reserve_full packages
+        # is set in the context as True
+        if not self.env.context.get("bypass_reserve_full_packages"):
+            for picking in self.filtered(lambda p: p._should_reserve_full_packages()):
+                all_quants = Quant.browse()
+                remaining_qtys = defaultdict(int)
+
+                # get all packages
+                packages = picking.mapped("move_line_ids.package_id")
+                for package in packages:
+                    move_lines = picking.mapped("move_line_ids").filtered(
+                        lambda ml: ml.package_id == package
+                    )
+                    # TODO: merge with assert_reserved_full_package
+                    pack_products = frozenset(package._get_all_products_quantities().items())
+                    mls_products = frozenset(move_lines._get_all_products_quantities().items())
+                    if pack_products != mls_products:
+                        # move_lines do not match the quants
+                        pack_mls = MoveLine.search(
+                            [
+                                ("package_id", "child_of", package.id),
+                                ("state", "not in", ["done", "cancel"]),
+                            ]
+                        )
+                        other_pickings = pack_mls.mapped("picking_id") - picking
+                        if other_pickings:
+                            raise ValidationError(
+                                _("The package is reserved in other pickings: %s")
+                                % ",".join(other_pickings.mapped("name"))
+                            )
+
+                        quants = package._get_contained_quants()
+                        all_quants |= quants
+                        for product, qty in quants.group_quantity_by_product(
+                            only_available=True
+                        ).items():
+                            remaining_qtys[product] += qty
+                if remaining_qtys:
+                    # Context variables:
+                    # - filter the quants used in _create_moves() to be
+                    # the ones of the packages to be completed
+                    # - add bypass_reserve_full_packages at the context
+                    # to avoid to be called again inside _create_moves()
+                    picking.with_context(
+                        bypass_reserve_full_packages=True, quant_ids=all_quants.ids
+                    )._create_moves(
+                        remaining_qtys,
+                        values={"priority": picking.priority},
+                        confirm=True,
+                        assign=True,
+                    )
+
+    def can_handle_partials(self, **kwargs):
+        self.ensure_one()
+        return self.picking_type_id.u_handle_partials
+    
+    @api.depends("move_type", "move_lines.state", "move_lines.picking_id")
+    def _compute_state(self):
+        """Prevent pickings to be in state assigned when not able to handle
+        partials, so they should remain in state waiting or confirmed until
+        they are fully assigned.
+
+        Add the flag 'computing_state' when we call can_handle_partials here to
+        distinguish it from other calls.
+        """
+        move_lines = self.move_lines.filtered(lambda move: move.state not in ["cancel", "done"])
+        if move_lines and not self.can_handle_partials(computing_state=True):
+            relevant_move_state = move_lines._get_relevant_state_among_moves()
+            if relevant_move_state == "partially_available":
+                if self.u_prev_picking_ids:
+                    self.state = "waiting"
+                else:
+                    self.state = "confirmed"
+                return
+
+        super()._compute_state()
+
+

--- a/addons/udes_stock_cron/models/stock_picking_batch.py
+++ b/addons/udes_stock_cron/models/stock_picking_batch.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+from odoo import models, api
+import logging
+_logger = logging.getLogger(__name__)
+
+class StockPickingBatch(models.Model):
+    _inherit = "stock.picking.batch"
+
+    @api.constrains("user_id")
+    def _compute_state(self):
+        """ Compute the state of a batch post confirm
+            waiting     : At least some picks are not ready
+            ready       : All picks are in ready state (assigned)
+            in_progress : All picks are ready and a user has been assigned
+            done        : All picks are complete (in state done or cancel)
+            the other two states are draft and cancel are manual
+            to transitions from or to the respective state.
+        """
+        if self.env.context.get("lock_batch_state"):
+            # State is locked so don't do anything
+            return
+
+        for batch in self:
+            if batch.state in ["draft", "cancel"]:
+                # Can not do anything with them don't bother trying
+                continue
+
+            if batch.picking_ids:
+
+                ready_picks = batch.ready_picks()
+                done_picks = batch.done_picks()
+                unready_picks = batch.unready_picks()
+
+                # Figure out state
+                if ready_picks and not unready_picks:
+                    if batch.user_id:
+                        batch.state = "in_progress"
+                    else:
+                        batch.state = "ready"
+
+                if ready_picks and unready_picks:
+                    if batch.user_id:
+                        batch.state = "in_progress"
+                    else:
+                        batch.state = "waiting"
+
+                if done_picks and not ready_picks and not unready_picks:
+                    batch.state = "done"
+            else:
+                batch.state = "done"

--- a/addons/udes_stock_cron/models/stock_picking_type.py
+++ b/addons/udes_stock_cron/models/stock_picking_type.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+from odoo import fields, models 
+
+import logging
+_logger = logging.getLogger(__name__)
+
+CORE_LIFECYCLE_ACTIONS = [
+    ("group_by_move_line_key", "Group by Move Line Key"),
+    ("group_by_move_key", "Group by Move Key"),
+]
+
+POST_ASSIGN_ACTIONS = CORE_LIFECYCLE_ACTIONS + [
+    ("by_maximum_quantity", "Maximum Quantity")
+]
+
+class StockPickingType(models.Model):
+    _inherit = 'stock.picking.type'
+   
+    u_num_reservable_pickings = fields.Integer(
+        string='Number of pickings to reserve',
+        default=-1,
+        help='The number of pickings in the queue to reserve stock for. '
+             'If batch reservation is enabled, entire picking batches are '
+             'reserved in the order of their earliest picking in the queue '
+             'until at least this number of pickings are reserved. '
+             '0 indicates no pickings should be reserved. '
+             '-1 indicates all pickings should be reserved.'
+    )  
+
+    u_reserve_batches = fields.Boolean(
+        string="Reserve picking batches atomically",
+        default=False,
+        help="Flag to indicate whether to reserve pickings by batches. "
+        "This is ignored if the number of pickings to reserve is 0.",
+    )
+
+    u_handle_partials = fields.Boolean(
+        string="Process Partial Transfers",
+        default=False,
+        help="Allow processing a transfer when the preceding transfers are not all completed.",
+    ) 
+
+    u_handle_partial_lines = fields.Boolean(
+        string="Handle Partial Move Lines",
+        default=False,
+        help="Allow handling partial move lines. "
+        "Only applicable if handling partial transfers is enabled.",
+    )
+
+    u_drop_location_policy = fields.Selection(
+        [
+            ("exactly_match_move_line", "Exactly Match The Move Line Destination Location",),
+            ("by_products", "By Products"),
+            ("by_product_lot", "By Product and Lot Number"),
+            ("by_packages", "By Products in Packages"),
+            ("by_height_speed", "By Height and Speed Category"),
+            ("by_orderpoint", "By Order Point"),
+            ("empty_location", "Only Empty Locations"),
+        ],
+        string="Suggest Locations Policy",
+        default="exactly_match_move_line",
+        help="Indicate the policy for suggesting drop locations.",
+    )
+
+    u_drop_location_preprocess = fields.Boolean(
+        string="Add destination location on pick assignment",
+        default=False,
+        help="Flag to indicate if picking assignment should select destination locations",
+    )
+
+    u_reserve_as_packages = fields.Boolean(
+        string="Reserve entire packages",
+        default=False,
+        help="Flag to indicate reservations should be rounded up to entire packages.",
+    )
+
+    u_post_confirm_action = fields.Selection(
+        selection=[
+            ("group_by_move_key", "Group by Move Key"),
+            ("batch_pickings_by_date", "Batch pickings by date"),
+            ("batch_pickings_by_date_priority", "Batch pickings by date and priority"),
+        ],
+        string="Post Confirm Action",
+        help="Choose the action to be taken after confirming a picking.",
+    )
+
+    u_post_assign_action = fields.Selection(
+        selection=POST_ASSIGN_ACTIONS,
+        string="Post Assign Action",
+        help="Choose the action to be taken after reserving a picking.",
+    )
+
+    u_post_validate_action = fields.Selection(
+        selection=CORE_LIFECYCLE_ACTIONS,
+        string="Post Validate Action",
+        help="Choose the action to be taken after validating a picking.",
+    )

--- a/addons/udes_stock_cron/tests/__init__.py
+++ b/addons/udes_stock_cron/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_stock_picking

--- a/addons/udes_stock_cron/tests/test_stock_picking.py
+++ b/addons/udes_stock_cron/tests/test_stock_picking.py
@@ -1,0 +1,190 @@
+# -*- coding: utf-8 -*-
+from odoo.tests import common
+from odoo.addons.udes_stock.tests.common import BaseUDES
+from odoo.exceptions import UserError
+
+class TestStockPicking(BaseUDES):
+    
+    @classmethod
+    def setUpClass(cls):
+        super(TestStockPicking, cls).setUpClass()
+
+        products_info = [{"product" : cls.apple, "qty" : 10.0}]
+        
+        # Create a picking with a move
+        cls.test_picking_pick = cls.create_picking(
+            cls.picking_type_pick,
+            products_info=products_info,
+            confirm=True,
+            location_dest_id=cls.test_received_location_01.id,)
+        
+        # Create an available quantity of apples
+        cls.test_quant_apple = cls.create_quant(
+            product_id = cls.apple.id,
+            location_id = cls.picking_type_pick.default_location_src_id.id,
+            quantity = 10.0
+        )
+
+    # Want to inherit the methods from BaseUDES but do not want the database to 
+    # rollback after each test, as the method in test: reserve_stock, commits to  
+    # the database via the cursor - so will not be able to rollback
+    def setUp(cls):
+        pass
+
+    def tearDown(cls):
+        pass
+    
+    @classmethod 
+    def create_quant(self, product_id, location_id, quantity, **kwargs):
+        """
+        Purpose: Format the stock quant information and pass it to stock.quant for 
+        creation.
+        Params: recordset id, recordset id, float -> stock.quant recordset 
+        """
+        Quant = self.env["stock.quant"]
+        vals = {
+            "product_id": product_id,
+            "location_id": location_id,
+            "quantity": quantity,
+        }
+        return Quant.create(vals, **kwargs)
+
+    def test01_reserve_available_stock(self):
+        # Check there is stock available 
+        # Check there is no reserved quantity and that the stock_picking is in state 'confirmed'
+        # Run reserve_stock, which should then reserve quantity and change state of stock_picking
+        self.assertEqual(self.test_quant_apple.quantity, 10.0)
+
+        Move = self.test_picking_pick.mapped("move_lines").filtered(lambda x: x.name == "Test product Apple")
+        self.assertEqual(Move.name, "Test product Apple")
+        self.assertEqual(Move.reserved_availability, 0.0)
+        self.assertEqual(Move.state, 'confirmed')
+
+        self.test_picking_pick.reserve_stock()
+
+        self.assertEqual(Move.reserved_availability, 10.0)
+        self.assertEqual(Move.state, 'assigned')
+        self.assertEqual(self.test_picking_pick.state, 'assigned')
+    
+    def test02_reserve_unavailable_stock(self):
+        # Check that a stock picking with no stock available cannot reserve stock
+        products_info = [{"product" : self.banana, "qty" : 10.0}]
+        self.test_picking_pick = self.create_picking(
+            self.picking_type_pick,
+            products_info=products_info,
+            confirm=True,
+            location_dest_id=self.test_received_location_01.id,)
+
+        Move = self.test_picking_pick.mapped("move_lines").filtered(lambda x: x.name == "Test product Banana")
+        self.assertEqual(Move.name, "Test product Banana")
+        self.assertEqual(Move.reserved_availability, 0.0)
+        self.assertEqual(Move.state, 'confirmed')
+
+        with self.assertRaises(UserError):
+            self.test_picking_pick.reserve_stock()
+
+        self.assertEqual(Move.reserved_availability, 0.0)
+        self.assertEqual(Move.state, 'confirmed')
+        self.assertEqual(self.test_picking_pick.state, 'confirmed')
+    
+    def test03_reserve_partial_stock(self):
+        # Turn both u_handle_partials and u_handle_partial_lines flags on
+        # Check that stock can be partially reserved 
+        products_info = [{"product" : self.banana, "qty" : 10.0}]
+        self.test_picking_pick = self.create_picking(
+            self.picking_type_pick,
+            products_info=products_info,
+            confirm=True,
+            location_dest_id=self.test_received_location_01.id,)
+  
+        self.test_quant_banana = self.create_quant(
+            product_id = self.banana.id,
+            location_id = self.picking_type_pick.default_location_src_id.id,
+            quantity = 5.0
+        )
+
+        Picking_type = self.test_picking_pick.mapped("picking_type_id")
+        Picking_type.u_handle_partials = True
+        Picking_type.u_handle_partial_lines = True
+        self.assertEqual(self.test_picking_pick.mapped("picking_type_id").u_handle_partials, True)
+        self.assertEqual(self.test_picking_pick.mapped("picking_type_id").u_handle_partial_lines, True)
+        
+        Move = self.test_picking_pick.mapped("move_lines").filtered(lambda x: x.name == "Test product Banana")
+        self.assertEqual(Move.name, "Test product Banana")
+        self.assertEqual(Move.reserved_availability, 0.0)
+        self.assertEqual(Move.state, 'confirmed')
+
+        self.test_picking_pick.reserve_stock()
+    
+        self.assertEqual(Move.reserved_availability, 5.0)
+        self.assertEqual(Move.state, 'partially_available')
+        self.assertEqual(self.test_picking_pick.state, 'assigned')
+
+    def test04_do_not_reserve_partial_stock(self):
+        # Turn u_handle_partials flag on adn u_handle_partial_lines off
+        # Check that stock can not be partially reserved
+        products_info = [{"product" : self.cherry, "qty" : 10.0}]
+        self.test_picking_pick = self.create_picking(
+            self.picking_type_pick,
+            products_info=products_info,
+            confirm=True,
+            location_dest_id=self.test_received_location_01.id,)
+
+        self.test_quant_cherry = self.create_quant(
+            product_id = self.cherry.id,
+            location_id = self.picking_type_pick.default_location_src_id.id,
+            quantity = 5.0
+        )
+
+        Picking_type = self.test_picking_pick.mapped("picking_type_id")
+        Picking_type.u_handle_partials = True
+        Picking_type.u_handle_partial_lines = False
+        self.assertEqual(self.test_picking_pick.mapped("picking_type_id").u_handle_partials, True)
+        self.assertEqual(self.test_picking_pick.mapped("picking_type_id").u_handle_partial_lines, False)
+        
+        Move = self.test_picking_pick.mapped("move_lines").filtered(lambda x: x.name == "Test product Cherry")
+        self.assertEqual(Move.name, "Test product Cherry")
+        self.assertEqual(Move.reserved_availability, 0.0)
+        self.assertEqual(Move.state, 'confirmed')
+
+        with self.assertRaises(UserError):
+            self.test_picking_pick.reserve_stock()
+    
+        self.assertEqual(Move.reserved_availability, 0.0)
+        self.assertEqual(Move.state, 'confirmed')
+        self.assertEqual(self.test_picking_pick.state, 'confirmed')
+    
+    def test05_no_partial_transfers(self):
+        # u_handle_partials flag is off
+        # Check that stock can not be partially reserved
+        products_info = [{"product" : self.damson, "qty" : 10.0}]
+        
+        self.test_picking_pick = self.create_picking(
+            self.picking_type_pick,
+            products_info=products_info,
+            confirm=True,
+            location_dest_id=self.test_received_location_01.id,)
+
+        self.test_quant_damson = self.create_quant(
+            product_id = self.damson.id,
+            location_id = self.picking_type_pick.default_location_src_id.id,
+            quantity = 5.0
+        )
+
+        Picking_type = self.test_picking_pick.mapped("picking_type_id")
+        Picking_type.u_handle_partials = False
+        Picking_type.u_handle_partial_lines = False
+        self.assertEqual(self.test_picking_pick.mapped("picking_type_id").u_handle_partials, False)
+        self.assertEqual(self.test_picking_pick.mapped("picking_type_id").u_handle_partial_lines, False)
+
+        Move = self.test_picking_pick.mapped("move_lines").filtered(lambda x: x.name == "Test product Damson")
+        self.assertEqual(Move.name, "Test product Damson")
+        self.assertEqual(Move.reserved_availability, 0.0)
+        self.assertEqual(Move.state, 'confirmed')
+
+        with self.assertRaises(UserError):
+            self.test_picking_pick.reserve_stock()
+    
+        self.assertEqual(Move.reserved_availability, 0.0)
+        self.assertEqual(Move.state, 'confirmed')
+        self.assertEqual(self.test_picking_pick.state, 'confirmed')

--- a/addons/udes_stock_cron/views/stock_picking_type.xml
+++ b/addons/udes_stock_cron/views/stock_picking_type.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id = "view_picking_type_form_inherit" model="ir.ui.view">
+        <field name="name">stock.picking.type.form.inherit</field>
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="stock.view_picking_type_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//form/sheet/group[last()]" position="after">
+                <group class="udes_wide_list" string="UDES Config" groups='base.group_no_one'>
+                    <field name="u_num_reservable_pickings"/>
+                    <field name="u_reserve_batches"/>
+                    <field name="u_handle_partials"/>
+                    <field name="u_handle_partial_lines"/>
+                    <field name="u_drop_location_policy"/>
+                    <field name="u_drop_location_preprocess"/>
+                    <field name="u_reserve_as_packages"/>
+                    <field name="u_post_assign_action"/>
+                </group>
+            </xpath>
+        </field> 
+    </record>
+</odoo>


### PR DESCRIPTION
Migrated over the reserve_stock method in stock_picking.py for the "reserve stock" cron job. This included Migrating over other methods which are also available in the udes_stock_cron module. Wrote some unit tests to check that partial reserves are allowed. Made a small change to the reserve_stock module - changed the way the string is formatted when a UserError exception is raised - this was to fix the error message that would be shown when no Internal Reference is input for a product.

Story/392

Signed-off-by: Jack Birch <jack.birch@unipart.io>