### PR TITLE
[FIX] udes_stock: Allow multiple location barcodes

### DIFF
--- a/addons/udes_stock/report/location_templates.xml
+++ b/addons/udes_stock/report/location_templates.xml
@@ -12,25 +12,25 @@
 
       <!-- Labels -->
       <t t-call="web.html_container">
-        <t t-call="web.internal_layout">
-          <t t-set="page_style" t-value="'width: 100%; height: 60%;
-			    	     margin-top: 20%; margin-bottom: 20%;
-		    		     text-align: center;'"/>
-	      <t t-foreach="docs" t-as="location">
-            <div t-att-style ="page_style">
-	          <strong>
-		        <span style="font-size: 24pt;" t-esc="location.name"/>
-	          </strong>
-	          <img t-att-src="barcode_url % location.barcode" style="width: 100%;"/>
-	          <strong>
-		        <span style="font-size: 18pt;" t-esc="location.barcode"/>
-	          </strong>
-            </div>
-            <!-- Add page breaks for each following barcode -->
+        <t t-foreach="docs" t-as="location">
+          <t t-call="web.internal_layout">
             <t t-set="page_style" t-value="'width: 100%; height: 60%;
-			    	     margin-top: 20%; margin-bottom: 20%;
-		    		     text-align: center; page-break-before: always;'"/>
-	      </t>
+                  margin-top: 20%; margin-bottom: 20%;
+                  text-align: center;'"/>
+              <div t-att-style ="page_style">
+              <strong>
+              <span style="font-size: 24pt;" t-esc="location.name"/>
+              </strong>
+              <img t-att-src="barcode_url % location.barcode" style="width: 100%;"/>
+              <strong>
+              <span style="font-size: 18pt;" t-esc="location.barcode"/>
+              </strong>
+              </div>
+              <!-- Add page breaks for each following barcode -->
+              <t t-set="page_style" t-value="'width: 100%; height: 60%;
+                  margin-top: 20%; margin-bottom: 20%;
+                  text-align: center; page-break-before: always;'"/>
+          </t>
         </t>
       </t>
     </template>


### PR DESCRIPTION
Fix to allow multiple location barcodes to be printed without overlapping. Page breaks were not working prior to this fix.

Story/X1016

Signed-off-by: Adam Patrick <adam.patrick@unipart.io>