### PR TITLE
[ADD] udes_ldap: UDES LDAP addon.

### DIFF
--- a/addons/udes_ldap/README.md
+++ b/addons/udes_ldap/README.md
@@ -1,0 +1,43 @@
+# UDES LDAP
+
+This addon enables authenticating logins using LDAP.  It extends the core Odoo [auth_ldap](https://github.com/odoo/odoo/tree/11.0/addons/auth_ldap) and the OCA [auth_ldaps](https://github.com/OCA/server-auth/tree/11.0/auth_ldaps) addons.
+
+
+## Functionality
+
+This module overrides the existing model to use a user's own credentials to bind to the LDAP server, instead of using a service account. The user will log in with their LDAP user id (`uid`) and password, _not_ their email address.
+
+## Configuration
+
+- To access the configuration screen, go to either of
+  - Settings / Users & Companies / LDAP Servers 
+  - Inventory / Configuration / Settings / General Settings / LDAP Authentication
+- Example values
+  - **LDAP Server address**: `ldap.example.com`
+  - **LDAP Server port**: `636`
+  - **Use TLS**: `False`
+  - **Use LDAPS**: `True`
+  - **LDAP binddn format**: `uid=%s,cn=users,cn=accounts,dc=example,dc=com`
+  - **LDAP base**: `dc=example,dc=com`
+  - **LDAP filter**: `(&(uid=%s)(objectClass=person)(memberOf=cn=mygroup,cn=groups,cn=accounts,dc=example,dc=com))`
+
+## Technical Notes
+
+### Models
+
+The `res_company_ldap` model is extended
+
+|Field Name | Type | Description |
+| --- | --- | --- |
+| u_ldap_binddn_fmt | Char | printf-style format string for the Distinguished Name used to bind to the LDAP server |
+| ldap_binddn | Char | This existing field is hidden, as we don't use it |
+| ldap_password | Char | This existing field is hidden, as we don't use it |
+
+
+### Security
+
+By default, the configuration screen is accessible only by the Admin user and users in the Trusted User and Debug User groups.
+
+LDAP installations are vulnerable to [injection](https://cheatsheetseries.owasp.org/cheatsheets/LDAP_Injection_Prevention_Cheat_Sheet.html) attacks (analogous to SQL injection).  The `uid` used at login time should be treated as untrusted input and escaped when used to bind to, or query against, the LDAP server. The [python-ldap](https://pypi.org/project/python-ldap/) package (installed by `auth_ldap`) provides functions to do the escaping.
+
+See also the README files for `auth_ldap` and `auth_ldaps`.

--- a/addons/udes_ldap/__init__.py
+++ b/addons/udes_ldap/__init__.py
@@ -1,0 +1,7 @@
+"""
+UDES LDAP package.
+
+Provides LDAP configuration and functionality for UDES.
+"""
+
+from . import models  # noqa: F401

--- a/addons/udes_ldap/__manifest__.py
+++ b/addons/udes_ldap/__manifest__.py
@@ -1,0 +1,23 @@
+{
+    "name": "UDES LDAP",
+    "summary": """
+        Lightweight Directory Access Protocol integration for UDES""",
+    "description": """UDES-specific LDAP configuration and functionality""",
+    "author": "Unipart Digital Team",
+    "website": "http://www.unipart.io",
+    # Categories can be used to filter modules in modules listing
+    # Check https://github.com/odoo/odoo/blob/master/openerp/addons/base/module/module_data.xml
+    # for the full list
+    "category": "tools",
+    "version": "11.0.3.0.0",
+    # any module necessary for this one to work correctly
+    "depends": [
+        "auth_ldaps",
+        "udes_security",
+    ],
+    # always loaded
+    "data": [
+        "security/ir.model.access.csv",
+        "views/res_company_ldap_views.xml",
+    ],
+}

--- a/addons/udes_ldap/models/__init__.py
+++ b/addons/udes_ldap/models/__init__.py
@@ -1,0 +1,3 @@
+"""Models package for udes_ldap."""
+
+from . import res_company_ldap  # noqa: F401

--- a/addons/udes_ldap/models/res_company_ldap.py
+++ b/addons/udes_ldap/models/res_company_ldap.py
@@ -1,0 +1,55 @@
+"""
+UDES LDAP configuration model.
+
+In this model we override the standard authentication approach by using the
+credentials of the logging-in user to search for themselves on the LDAP
+server.  This removes the need for a service account to perform the search.
+"""
+
+from ldap.dn import escape_dn_chars
+from odoo import models, fields
+
+
+class CompanyLDAP(models.Model):
+    """LDAP configuration model."""
+
+    _inherit = "res.company.ldap"
+
+    u_ldap_binddn_fmt = fields.Char(
+        string="LDAP Binddn Format",
+        help="A format string for the Distinguished Name used to bind to the "
+        "LDAP server.  The user's uid will be formatted into this string.",
+        default="",
+        required=True,
+    )
+
+    def get_ldap_dicts(self):
+        """Add our custom field to the conf dict and removed unused fields."""
+        res = super().get_ldap_dicts()
+        fields_to_remove = ["ldap_binddn", "ldap_password"]
+        for rec in res:
+            ldap = self.sudo().browse(rec["id"])
+            rec["u_ldap_binddn_fmt"] = ldap.u_ldap_binddn_fmt
+            for field in fields_to_remove:
+                rec.pop(field, None)
+        return res
+
+    def authenticate(self, conf, login, password):
+        """
+        Set the login credentials before the superclass authenticates.
+
+        We use the login credentials provided by the user to bind to the LDAP
+        server.
+        """
+        # The login name is untrusted and must be escaped to prevent
+        # LDAP-injection attacks.
+        escaped_login = escape_dn_chars(login)
+        # Use %-formatting to be consistent with ldap_filter, as we don't
+        # want to change python-ldap.
+        binddn = conf["u_ldap_binddn_fmt"] % escaped_login
+        conf["ldap_binddn"] = binddn
+        conf["ldap_password"] = password
+        # We don't pass the escaped login because it gets escaped when the
+        # filter is created.
+        # TODO Does user creation work if login contains exotic characters?
+        return super().authenticate(conf, login, password)

--- a/addons/udes_ldap/security/ir.model.access.csv
+++ b/addons/udes_ldap/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+"id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
+"res_company_ldap_debug_user","res_company_ldap_debug_user","udes_ldap.model_res_company_ldap","udes_security.group_debug_user","True","True","True","True"
+" res_company_ldap_trusted_user"," res_company_ldap_trusted_user","udes_ldap.model_res_company_ldap","udes_security.group_trusted_user","True","True","True","True"

--- a/addons/udes_ldap/views/res_company_ldap_views.xml
+++ b/addons/udes_ldap/views/res_company_ldap_views.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <menuitem id="udes_ldap.ldap_configuration_action"
+      parent="base.menu_users"
+      action="auth_ldap.action_ldap_installer"
+      sequence="40"
+      groups=""
+      name="LDAP Servers"
+    />
+
+    <record id="view_ldap_installer_form" model="ir.ui.view">
+        <field name="name">udes_ldap.res.company.ldap.form</field>
+        <field name="model">res.company.ldap</field>
+        <field name="inherit_id" ref="auth_ldaps.view_ldap_installer_form"/>
+        <field name="arch" type="xml">
+          <!-- Show field for DN format. -->
+          <xpath expr="//field[@name='ldap_password']" position="after">
+            <field name="u_ldap_binddn_fmt"/>
+          </xpath>
+            <!-- Remove inherited fields for login information. -->
+          <xpath expr="//field[@name='ldap_binddn']" position="replace"/>
+          <xpath expr="//field[@name='ldap_password']" position="replace"/>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
story/955

Signed-off-by: Kevin Dwyer <kevin.dwyer@unipart.io>

Code and configuration for the UDES LDAP module.

UDES LDAP overrides the Odoo auth_ldap and the OCA auth_ldaps addons
to enable authentication over LDAP using the user's LDAP credentials to
bind to the LDAP server rather than a service account.