### PR TITLE
[ADD] udes_stock: Add method to set orig picking on pickings

### DIFF
--- a/addons/udes_delivery_control/views/stock_picking.xml
+++ b/addons/udes_delivery_control/views/stock_picking.xml
@@ -21,7 +21,7 @@
             </xpath>
             <!-- Make partner field mandatory -->
             <xpath expr="//field[@name='partner_id']" position="attributes">
-                <attribute name="attrs">{'required': [('u_is_delivery_control', '=', True)]}</attribute>
+                <attribute name="attrs">{'required': [('u_is_delivery_control', '=', True)], 'readonly': [('state', '!=', 'draft')]}</attribute>
             </xpath>
             <!-- Add page to notebook -->
             <xpath expr="//page[@name='extra']" position="before">

--- a/addons/udes_stock/__manifest__.py
+++ b/addons/udes_stock/__manifest__.py
@@ -39,6 +39,7 @@
         "data/report_paperformat.xml",
         "data/readonly_desktop_user_exception.xml",
         "data/res_archiving_restriction.xml",
+        "data/stock_picking.xml",
         "report/product_product_templates.xml",
         "report/report_stockpicking_operations.xml",
         "views/edi_menu_views.xml",

--- a/addons/udes_stock/data/stock_picking.xml
+++ b/addons/udes_stock/data/stock_picking.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<odoo>
+    <data>
+
+        <function model="stock.picking" name="_set_original_picking_on_pickings"/>
+
+    </data>
+
+</odoo>

--- a/addons/udes_stock/models/stock_picking.py
+++ b/addons/udes_stock/models/stock_picking.py
@@ -2838,3 +2838,8 @@ class StockPicking(models.Model):
             self.env.cr.execute(update_query, update_values)
 
             _logger.info("Original Picking value set on %s pickings", picking_count)
+
+    def _create_backorder(self, backorder_moves=[]):
+        """Add `created_due_to_backorder` to context when creating a backorder through UI"""
+        self = self.with_context(created_due_to_backorder=True)
+        return super()._create_backorder(backorder_moves)

--- a/addons/udes_stock/models/stock_picking.py
+++ b/addons/udes_stock/models/stock_picking.py
@@ -175,6 +175,11 @@ class StockPicking(models.Model):
             picking.write({"u_original_picking_id": picking.id})
         return picking
 
+    def copy(self, default=None):
+        """Set `planned_picking` to True in context"""
+        self = self.with_context(planned_picking=True)
+        return super().copy(default)
+
     @api.depends("move_line_ids", "move_line_ids.location_id")
     @api.one
     def _compute_location_category(self):

--- a/addons/udes_stock/models/stock_picking_batch.py
+++ b/addons/udes_stock/models/stock_picking_batch.py
@@ -813,7 +813,9 @@ class StockPickingBatch(models.Model):
                 pick_mls = completed_move_lines.filtered(lambda x: x.picking_id == pick)
 
                 if pick._requires_backorder(pick_mls):
-                    pick_todo = pick._backorder_movelines(pick_mls)
+                    pick_todo = pick.with_context(
+                        done_mls_into_backorder=True
+                    )._backorder_movelines(pick_mls)
 
                     to_add |= pick_todo
 

--- a/addons/udes_stock/views/stock_picking.xml
+++ b/addons/udes_stock/views/stock_picking.xml
@@ -80,9 +80,12 @@
                 <attribute name="string">Cancel Pick</attribute>
             </xpath>
 
-            <!-- Partner field filtered to only see suppliers -->
+            <!--
+                Partner field filtered to only see suppliers
+                Parter readonly unless picking is in draft state
+            -->
             <xpath expr="//field[@name='partner_id']" position="replace">
-                <field name="partner_id" domain="[('supplier', '=', True)]" context="{'default_supplier': True, 'default_customer': False}"/>
+                <field name="partner_id" domain="[('supplier', '=', True)]" attrs="{'readonly': [('state', '!=', 'draft')]}" context="{'default_supplier': True, 'default_customer': False}"/>
             </xpath>
 
             <!-- Destination location field changed to read-only for goods-in -->
@@ -90,10 +93,18 @@
                 <attribute name="attrs">{'readonly': ['|',('picking_type_code', '=', 'incoming'),('state', 'not in', 'draft')]}</attribute>
             </xpath>
 
-            <!-- origin (Source Document  field changed to required for goods-in -->
+            <!-- 
+                Origin (Source Document) field changed to required for goods-in
+                Origin also set to readonly unless the picking is in draft state
+            -->
             <xpath expr="//field[@name='origin']" position="attributes">
-                <attribute name="attrs">{'required': [('picking_type_code', '=', 'incoming')]}</attribute>
+                <attribute name="attrs">{'readonly': [('state', '!=', 'draft')],  'required': [('picking_type_code', '=', 'incoming')]}</attribute>
             </xpath>
+
+            <!-- Set scheduled date to be readonly unless picking is in draft state -->
+            <field name="scheduled_date" position="attributes">
+                <attribute name="attrs">{'readonly': [('state', '=', 'done')], 'required': [('id', '!=', False)]}</attribute>
+            </field>
 
             <!-- Add date done to form view -->
             <xpath expr="//field[@name='scheduled_date']" position="after">


### PR DESCRIPTION
Added "_set_original_picking_on_historical_pickings" which identifies
any pickings in the system that don't have "u_original_picking_id" set
and sets the value.

Method call in XML which is run when udes_stock is installed or updated.

Story/907

Signed-off-by: Peter Clark <peter.clark@unipart.io>