### PR TITLE
[FIX] udes_stock: Added readonly attr when not in draft

### DIFF
--- a/addons/udes_stock/views/stock_picking.xml
+++ b/addons/udes_stock/views/stock_picking.xml
@@ -87,7 +87,7 @@
 
             <!-- Destination location field changed to read-only for goods-in -->
             <xpath expr="//field[@name='location_dest_id']" position="attributes">
-                <attribute name="attrs">{'readonly': [('picking_type_code', '=', 'incoming')]}</attribute>
+                <attribute name="attrs">{'readonly': ['|',('picking_type_code', '=', 'incoming'),('state', 'not in', 'draft')]}</attribute>
             </xpath>
 
             <!-- origin (Source Document  field changed to required for goods-in -->


### PR DESCRIPTION
Added a readonly attribute for destination_location on when the state is not in draft to prevent circumventing the he checks already  in place by changing the destination-location on a check peacemeal.

Story/965

Signed-off-by: Nick Costa <nicholas.costa@unipart.io>