### PR TITLE
[IMP] udes_stock: origin in stock.move not set correctly

### DIFF
--- a/addons/udes_stock/tests/common.py
+++ b/addons/udes_stock/tests/common.py
@@ -1,7 +1,4 @@
-# -*- coding: utf-8 -*-
-
 from odoo.tests import common
-from collections import namedtuple
 
 SECURITY_GROUPS = [
     ('inbound', 'udes_stock.group_inbound_user'),
@@ -270,6 +267,7 @@ class UnconfiguredBaseUDES(common.SavepointCase):
             'location_dest_id': picking.location_dest_id.id,
             'picking_id': picking.id,
             'priority': picking.priority,
+            'origin': picking.origin,
             'picking_type_id': picking.picking_type_id.id,
         }
         vals.update(kwargs)

--- a/addons/udes_stock/tests/test_picking.py
+++ b/addons/udes_stock/tests/test_picking.py
@@ -69,7 +69,8 @@ class TestGoodsInPicking(common.BaseUDES):
             when package exists
         """
         returned_pickings = self.SudoPicking.get_pickings(origin=self.test_picking.origin)
-        self.assertEqual(returned_pickings.id, self.test_picking.id)
+        self.assertEqual(len(returned_pickings), 2)
+        self.assertTrue(self.test_picking in returned_pickings)
 
     def test05_get_info_all(self):
         """ Tests get_info without requesting


### PR DESCRIPTION
The tests here use an helper method to create a picking instead
of using for example create_picking() in stock.picking model.
Bebcause of this there can be differences in the tests in terms
of how a picking is cretated which can mean a different behaviour
compared to UDES is tested.

This change aligns better how a picking is created compared to UDES.

User-story: 840

Signed-off-by: Lorenzo Cucurachi <lorenzo.cucurachi@unipart.io>