### PR TITLE
Story #1384 See who is assigned to a batch from the picking screens

### DIFF
--- a/addons/udes_stock/models/stock_picking.py
+++ b/addons/udes_stock/models/stock_picking.py
@@ -105,6 +105,13 @@ class StockPicking(models.Model):
     # override batch_id to be copied
     batch_id = fields.Many2one("stock.picking.batch", copy=True)
 
+    u_batch_user_id = fields.Many2one(
+        string="Batch User",
+        related="batch_id.user_id",
+        store=False,
+        help="User responsible for the batch",
+    )
+
     u_quantity_done = fields.Float(
         "Quantity done",
         compute="_compute_picking_quantities",

--- a/addons/udes_stock/views/stock_picking.xml
+++ b/addons/udes_stock/views/stock_picking.xml
@@ -193,6 +193,10 @@
                 <field name="u_location_category_id"/>
             </xpath>
 
+            <xpath expr="//field[@name='batch_id']" position="after">
+                <field name="u_batch_user_id"/>
+            </xpath>
+
         </field>
     </record>
 


### PR DESCRIPTION
[IMP] udes_stock: Add batch user_id to the picking list view.

- Add the user responsible for the batch, to which the picking belongs, to the picking list view.

Story/1384

Signed off by: Jack Birch <jack.birch@unipart.io>