### PR TITLE
Story #1384 See who is assigned to a batch from the picking screens

### DIFF
--- a/addons/udes_stock/models/stock_picking.py
+++ b/addons/udes_stock/models/stock_picking.py
@@ -89,6 +89,14 @@ class StockPicking(models.Model):
         help="Pickings that are unused after refactoring are empty and ready to be deleted",
     )
 
+    # User responsible for Batch 
+    u_batch_user_id = fields.Many2one(
+        string="Batch User",
+        related="batch_id.user_id",
+        store=False,
+        help="User responsible for the batch",
+    )
+
     @api.depends("move_lines", "move_lines.move_orig_ids", "move_lines.move_orig_ids.picking_id")
     def _compute_first_picking_ids(self):
         """Compute first picking from moves that do not originate from other moves"""

--- a/addons/udes_stock/tests/test_stock_picking.py
+++ b/addons/udes_stock/tests/test_stock_picking.py
@@ -835,3 +835,43 @@ class TestStockPickingUnlinkingEmpties(common.BaseUDES):
         Picking.unlink_empty()
 
         self.assertTrue(pick.exists())
+
+class TestBatchUserName(common.BaseUDES):
+    """Test Batch User takes value expected and changes when expected"""
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestBatchUserName, cls).setUpClass()
+        cls.create_quant(cls.apple.id, cls.test_stock_location_01.id, 10)
+
+        cls.batch = cls.create_batch(user = cls.env.user)
+
+        cls._pick_info = [{"product": cls.apple, "uom_qty": 5}]
+        cls.picking = cls.create_picking(picking_type = cls.picking_type_pick, products_info=cls._pick_info, confirm=True)
+
+        cls.stock_manager = cls.create_user(name="Stock Manager", login="Stock Manager Dude")
+
+    def test_correct_batch_user_on_picking_tree_view(self):
+        self.picking.write({"batch_id": self.batch.id})
+
+        self.assertEqual(self.picking.u_batch_user_id, self.env.user)
+    
+    def test_no_batch_user_on_picking_when_no_batch(self):
+        self.assertEqual(len(self.picking.u_batch_user_id), 0)
+    
+    def test_batch_user_on_picking_changes_when_user_is_changed_on_batch(self):
+        self.picking.write({"batch_id": self.batch.id})
+
+        self.batch.write({"user_id": self.stock_manager.id})
+
+        self.assertEqual(self.picking.u_batch_user_id, self.stock_manager)
+    
+    def test_same_batch_user_on_multiple_pickings(self):
+        picking_2 = self.create_picking(picking_type = self.picking_type_pick, products_info=self._pick_info, confirm=True)
+
+        self.picking.write({"batch_id": self.batch.id})
+        picking_2.write({"batch_id": self.batch.id})
+
+        self.assertEqual(self.picking.u_batch_user_id, self.env.user)
+        self.assertEqual(picking_2.u_batch_user_id, self.env.user)
+

--- a/addons/udes_stock/views/stock_picking.xml
+++ b/addons/udes_stock/views/stock_picking.xml
@@ -148,4 +148,18 @@
         </field>
     </record>
 
+     <!-- Customisations for stock.picking tree -->
+    <record id="view_tree_stock_picking" model="ir.ui.view">
+        <field name="name">udes_picking_tree</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.vpicktree"/>
+        <field name="arch" type="xml">
+
+            <xpath expr="//field[@name='batch_id']" position="after">
+                <field name="u_batch_user_id"/>
+            </xpath>
+
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
 [IMP] udes_stock: Add batch user_id to the picking list view.

- Add the user responsible for the batch, to which the picking belongs, to the picking list view.

Story/1384

Signed off by: Jack Birch <jack.birch@unipart.io>