### PR TITLE
[IMP] udes_stock: Adding support for finding packages

### DIFF
--- a/addons/udes_stock/README.md
+++ b/addons/udes_stock/README.md
@@ -44,12 +44,10 @@ This model is used to include generic functions that are inherited by various mo
 | MSM_CREATE     | boolean       | Whether it can create a new object which the method is called from, e.g product, group etc. Set to False by default |
 | MSM_STR_DOMAIN | tuple(string) | Tuple of strings in which to search for/create the object                                                           |
 
-
-| Helpers         | Description                                                                                                                                                                         |
-|-----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| _get_msm_domain | Gets the domain                                                                                                                                                                     |
-| get_or_create   | Gets an object of the model from the identifier. In case that no results are found, creates a new object of the model depending on the create parameter and the MSM_CREATE setting. |
-
+| Helpers         | Description                                                                                                                                                                                                                                                                                                                |
+|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| _get_msm_domain | Gets the domain                                                                                                                                                                                                                                                                                                            |
+| get_or_create   | Gets an object of the model from the identifier. In case that no results are found, creates a new object of the model depending on the create parameter and the MSM_CREATE setting. If no object is found and create is False the function will raise a Validation Error unless the return_emtpy parameter is set to True. |
 
 ### Products (model: product.product)
 

--- a/addons/udes_stock/models/mixin_stock_model.py
+++ b/addons/udes_stock/models/mixin_stock_model.py
@@ -30,7 +30,7 @@ class MixinStockModel(models.AbstractModel):
 
         return domain
 
-    def get_or_create(self, identifier, create=False, aux_domain=None):
+    def get_or_create(self, identifier, create=False, aux_domain=None, return_emtpy=False):
         """Gets an object of the model from the identifier. In case that no results
             are found, creates a new object of the model depending on the create
             parameter and the MSM_CREATE setting.
@@ -40,6 +40,10 @@ class MixinStockModel(models.AbstractModel):
         :kwargs:
             - create: Boolean
                 If true, and MSM_CREATE is true, a new object is created if needed
+            - aux_domain: list
+                An additional domain to add to the search
+            - return_emtpy: Boolean
+                Allow empty/False results to be returned without raising an exception
         :returns:
             Object of the model queried
         """
@@ -68,7 +72,8 @@ class MixinStockModel(models.AbstractModel):
             elif create:
                 raise ValidationError(_(f"Cannot create a new {model_name} for %s") % model)
             else:
-                raise ValidationError(_(f"{model_name} not found for identifier %s") % identifier)
+                if not return_emtpy:
+                    raise ValidationError(_(f"{model_name} not found for identifier %s") % identifier)
         elif len(results) > 1:
             raise ValidationError(
                 _(f"Too many {model_name}s found for identifier %s in %s") % (identifier, model)

--- a/addons/udes_stock/models/stock_quant_package.py
+++ b/addons/udes_stock/models/stock_quant_package.py
@@ -88,7 +88,11 @@ class StockQuantPackage(models.Model):
 
         if aux_domain is None:
             aux_domain = [("state", "not in", ["done", "cancel"])]
-        domain = [("package_id", "in", self.ids)] + aux_domain
+        domain = aux_domain + [
+            "|",
+            ("result_package_id", "in", self.ids),
+            ("package_id", "in", self.ids),
+        ]
         move_lines = MoveLine.search(domain)
         return move_lines
 


### PR DESCRIPTION
User-story: 1169

The find_move_lines() function in stock.quant.package is not checking
for move lines that use the package as a destination package. This
change ensures this check is done.

The get_or_create() fucntion in the mixin stock model does not allow
for returning an empty result without raising an issue. Adding here
the support for such use case.

Signed-off-by: Lorenzo Cucurachi <lorenzo.cucurachi@unipart.io>