### PR TITLE
[IMP] udes_simple_location_blocking: Add new module for blocking locations

### DIFF
--- a/addons/udes_simple_location_blocking/README.md
+++ b/addons/udes_simple_location_blocking/README.md
@@ -1,0 +1,56 @@
+# UDES Simple Location Blocking
+This module implements the logic to allow the blocking of a location. This includes checking and blocking operations that
+try to use a blocked location. Also avoid returning locations that are blocked when performing a stock inventory check,
+a picking, setting a location for a stock move or move line or when retrieving product quantities for a location. 
+
+## Default settings
+None
+
+## Requires
+- stock:
+  This module needs to inherit and add functionality to models from stock 
+
+## Models
+
+### Inventory (model: stock.inventory)
+Constrain location_ids field to ensure no blocked locations are used in a stock inventory.
+
+| Function     | Description                                                                                              |
+|--------------|----------------------------------------------------------------------------------------------------------|
+| _action_done | Checks that none of the locations used are blocked and then tries to set an inventory adjustment to done |
+
+### Inventory Line (model: stock.inventory)
+Constrain location_id field to ensure no blocked locations are used in a stock inventory line.
+
+### Locations (model: stock.location)
+This model is expanded to include a simple way to block a location with the use of a flag/boolean field.
+
+| Field Name       | Type    | Description                                                           |
+|------------------|---------|-----------------------------------------------------------------------|
+| u_blocked        | Boolean | True if the location is black, False otherwise                        |
+| u_blocked_reason | Char    | One or multiple reasons for the location being blocked, not required  |
+
+| Helpers                                   | Description                                                                                                         |
+|-------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
+| check_blocked                             | Checks whether a location or more are blocked and raises a ValidationError .                                        |
+| _prepare_blocked_msg                      | Returns a string with the reason why one or more locations are blocked                                              |
+| onchange_u_blocked                        | Set the u_blocked_reason to an empty string when the location is unblocked on a form                                |
+| _check_reserved_quants_and_blocked_reason | Checks that when a location is blocked there are no stock quantities reserved and that a reason for blocking is set |
+
+### Stock Moves (model: stock.move)
+Constrain location_id and location_dest_id fields to ensure no blocked locations are used in a stock move.
+
+### Stock Move Lines (model: stock.move.line)
+Constrain location_id and location_dest_id fields to ensure no blocked locations are used in a stock move line.
+
+### Pickings (model: stock.picking)
+Constrain location_id and location_dest_id fields to ensure no blocked locations are used in a picking.
+
+### Quants (model: stock.quant)
+Add functionality to ensure quantities of products in blocked locations are not retrieved/used.
+
+| Function  | Description                                                              |
+|-----------|--------------------------------------------------------------------------|
+| _gather   | Returns the quantities of a product in a location when it is not blocked |
+
+## Future work:

--- a/addons/udes_simple_location_blocking/__init__.py
+++ b/addons/udes_simple_location_blocking/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import tests

--- a/addons/udes_simple_location_blocking/__manifest__.py
+++ b/addons/udes_simple_location_blocking/__manifest__.py
@@ -1,0 +1,13 @@
+{
+    "name": "UDES Simple Location Blocking",
+    "summary": "Simple Location Blocking",
+    "description": "Implements a simple way of blocking locations - Odoo 14",
+    "author": "Unipart Digital",
+    "website": "http://github/unipartdigital/udes-open",
+    "category": "UDES",
+    "version": "0.1",
+    "depends": ["base", "stock", "udes_stock"],
+    "data": [
+        "views/stock_location.xml"
+    ],
+}

--- a/addons/udes_simple_location_blocking/models/__init__.py
+++ b/addons/udes_simple_location_blocking/models/__init__.py
@@ -1,0 +1,6 @@
+from . import stock_inventory
+from . import stock_location
+from . import stock_move
+from . import stock_move_line
+from . import stock_picking
+from . import stock_quant

--- a/addons/udes_simple_location_blocking/models/stock_inventory.py
+++ b/addons/udes_simple_location_blocking/models/stock_inventory.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+from odoo import api, models, _
+
+
+class StockInventoryLine(models.Model):
+    _inherit = 'stock.inventory.line'
+
+    @api.constrains('location_id')
+    def _check_location_not_blocked(self):
+        """
+        Check if any of the inventory line locations are blocked
+        """
+        self.location_id.check_blocked(prefix=_('Cannot create inventory adjustment line.'))
+
+
+class StockInventory(models.Model):
+    _inherit = "stock.inventory"
+
+    @api.constrains('location_ids')
+    def _check_location_not_blocked(self):
+        """
+        Check if any of the locations are blocked
+        """
+        self.location_ids.check_blocked(prefix=_('Cannot create inventory adjustment.'))
+
+    def _action_done(self):
+        """
+        Check if any of the inventory or inventory line locations are blocked
+        """
+        self.location_ids.check_blocked(prefix=_('Cannot validate inventory adjustment.'))
+        self.line_ids.location_id.check_blocked(prefix=_('Cannot validate inventory adjustment line.'))
+
+        return super(StockInventory, self)._action_done()

--- a/addons/udes_simple_location_blocking/models/stock_location.py
+++ b/addons/udes_simple_location_blocking/models/stock_location.py
@@ -1,0 +1,80 @@
+from odoo import api, models, fields, _
+from odoo.exceptions import ValidationError
+
+
+class StockLocation(models.Model):
+    _inherit = "stock.location"
+
+    u_blocked = fields.Boolean(
+        string="Is Blocked?",
+        help=_("Check this box to prevent stock picks from this location"),
+        index=True,
+    )
+
+    u_blocked_reason = fields.Char(string="Reason for Block:", required=False)
+
+    def check_blocked(self, prefix="", extra=[]):
+        """
+        Checks if any of the locations in self are blocked and if blocked raise a ValidationError.
+
+        :param prefix: string
+        :param prefix: list: names of Boolean fields to use to filter blocked locations
+        """
+        if not isinstance(prefix, str):
+            raise ValidationError(_("Prefix parameter for check_blocked should be string"))
+        blocked_locations = self.filtered(lambda x: x.u_blocked)
+        if not isinstance(extra, list):
+            raise ValidationError(_("Extra parameter for check_blocked should be list"))
+        for field in extra:
+            blocked_locations = self.filtered(lambda x: getattr(x, field))
+        if blocked_locations:
+            raise ValidationError(
+                _("%s %s Please speak to a team leader to resolve the issue.")
+                % (prefix, "".join(blocked_locations._prepare_blocked_msg()))
+            )
+
+    def _prepare_blocked_msg(self):
+        """
+        Prepares a message for the locations depending on if it is blocked or not.
+        """
+        msg = []
+        for location in self:
+            if location.u_blocked:
+                reason = _("(reason: no reason specified)")
+                if location.u_blocked_reason:
+                    reason = _("(reason: %s)") % (str(location.u_blocked_reason))
+                msg.append(_("Location %s is blocked %s.") % (location.name, reason))
+            else:
+                msg.append(_("Location %s is not blocked.") % location.name)
+        msg = " ".join(msg)
+        return msg
+
+    @api.onchange("u_blocked")
+    def onchange_u_blocked(self):
+        """Empty blocked reason when locations are unblocked"""
+        if not self.u_blocked:
+            self.u_blocked_reason = ""
+
+    @api.constrains("u_blocked")
+    def _check_reserved_quants_and_blocked_reason(self):
+        """
+        Check if there is any stock.quant already reserved for the locations trying to be blocked.
+        Also check if a blocked reason is given when blocking the location.
+        """
+        Quant = self.env["stock.quant"]
+        for record in self:
+            if record.u_blocked:
+                n_quants = Quant.search_count(
+                    [
+                        ("reserved_quantity", ">", 0),
+                        ("location_id", "=", record.id),
+                    ]
+                )
+                if n_quants > 0:
+                    raise ValidationError(
+                        _("Location cannot be blocked because it contains reserved stock.")
+                    )
+                if not record.u_blocked_reason:
+                    raise ValidationError(
+                        _("A reason for blocking the locations is required when attempting to block a location.")
+                    )

--- a/addons/udes_simple_location_blocking/models/stock_move.py
+++ b/addons/udes_simple_location_blocking/models/stock_move.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+
+from odoo import api, models, _
+
+
+class StockMove(models.Model):
+    _inherit = 'stock.move'
+
+    @api.constrains('location_id','location_dest_id')
+    def _check_locations_not_blocked(self):
+        """ Check if any of the source or destination locations are blocked
+        """
+        self.location_id.check_blocked(prefix=_('Wrong source location creating stock move.'))
+        self.location_dest_id.check_blocked(prefix=_('Wrong destination location creating stock move.'))

--- a/addons/udes_simple_location_blocking/models/stock_move_line.py
+++ b/addons/udes_simple_location_blocking/models/stock_move_line.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+
+from odoo import api, models, _
+
+
+class StockMoveLine(models.Model):
+    _inherit = 'stock.move.line'
+
+    @api.constrains('location_id','location_dest_id')
+    def _check_locations_not_blocked(self):
+        """ Check if any of the source or destination locations are blocked
+        """
+        self.location_id.check_blocked(prefix=_('Wrong source location creating stock move line.'))
+        self.location_dest_id.check_blocked(prefix=_('Wrong destination location creating stock move line.'))

--- a/addons/udes_simple_location_blocking/models/stock_picking.py
+++ b/addons/udes_simple_location_blocking/models/stock_picking.py
@@ -1,0 +1,23 @@
+from odoo import api, models, _
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    def get_empty_location_domain(self):
+        """
+        Expand empty location domain from udes_stock to include non-blocked locations
+        """
+        domain = super().get_empty_location_domain()
+        domain.append(("u_blocked", "=", False))
+        return domain
+
+    @api.constrains("location_id", "location_dest_id")
+    def _check_locations_not_blocked(self):
+        """
+        Check if any of the source or destination locations are blocked
+        """
+        self.location_id.check_blocked(prefix=_("Wrong source location creating transfer."))
+        self.location_dest_id.check_blocked(
+            prefix=_("Wrong destination location creating transfer.")
+        )

--- a/addons/udes_simple_location_blocking/models/stock_quant.py
+++ b/addons/udes_simple_location_blocking/models/stock_quant.py
@@ -1,0 +1,13 @@
+from odoo import models
+
+
+class StockQuant(models.Model):
+    _inherit = 'stock.quant'
+
+    def _gather(self, product_id, location_id, **kwargs):
+        """ Filter quants of blocked locations.
+            It is done afterwards because location_id might
+            an ancestor of the quants locations.
+        """
+        quants = super(StockQuant, self)._gather(product_id, location_id, **kwargs)
+        return quants.filtered(lambda q: not q.location_id.u_blocked)

--- a/addons/udes_simple_location_blocking/tests/__init__.py
+++ b/addons/udes_simple_location_blocking/tests/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+
+from . import test_inventory
+from . import test_location
+from . import test_move
+from . import test_move_line
+from . import test_picking
+from . import test_quant

--- a/addons/udes_simple_location_blocking/tests/common.py
+++ b/addons/udes_simple_location_blocking/tests/common.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+
+from odoo.tests import common
+
+class BaseBlocked(common.SavepointCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(BaseBlocked, cls).setUpClass()
+        Location = cls.env['stock.location']
+
+        # Locations
+        cls.stock_location = cls.env.ref('stock.stock_location_stock')
+        cls.test_location_01 = Location.create({
+                'name': "Test location 01",
+                'barcode': "LTEST01",
+                'location_id': cls.stock_location.id,
+            })
+        cls.test_location_02 = Location.create({
+                'name': "Test location 02",
+                'barcode': "LTEST02",
+                'location_id': cls.stock_location.id,
+            })
+        cls.test_locations = cls.test_location_01 + cls.test_location_02
+
+        # Products
+        cls.apple = cls.create_product('Apple')
+
+        # Picking types
+        cls.picking_type_internal = cls.env.ref('stock.picking_type_internal')
+
+    @classmethod
+    def create_inventory_line(cls, inventory, product, **kwargs):
+        """ Create and return an inventory line for the given inventory and product."""
+        InventoryLine = cls.env['stock.inventory.line']
+        vals = {
+            'product_id': product.id,
+            'location_id': inventory.location_id.id,
+            'inventory_id': inventory.id,
+        }
+        vals.update(kwargs)
+        return InventoryLine.create(vals)
+
+    @classmethod
+    def create_inventory(cls, location, **kwargs):
+        """ Create and return an inventory for the given location."""
+        Inventory = cls.env['stock.inventory']
+        vals = {
+            'location_ids': [(6, 0, [location.id])],
+            'name': location.name,
+        }
+        vals.update(kwargs)
+        return Inventory.create(vals)
+
+    @classmethod
+    def create_move_line(cls, move, qty, **kwargs):
+        """ Create and return a move line for the given move and qty."""
+        MoveLine = cls.env['stock.move.line']
+        vals = {
+            'product_id': move.product_id.id,
+            'product_uom_id': move.product_id.uom_id.id,
+            'product_uom_qty': qty,
+            'location_id': move.location_id.id,
+            'location_dest_id': move.location_dest_id.id,
+            'move_id': move.id,
+        }
+        vals.update(kwargs)
+        return MoveLine.create(vals)
+
+    @classmethod
+    def create_move(cls, product, qty, picking, **kwargs):
+        """ Create and return a move for the given product and qty."""
+        Move = cls.env['stock.move']
+        vals = {
+            'product_id': product.id,
+            'name': product.name,
+            'product_uom': product.uom_id.id,
+            'product_uom_qty': qty,
+            'location_id': picking.location_id.id,
+            'location_dest_id': picking.location_dest_id.id,
+            'picking_id': picking.id,
+            'priority': picking.priority,
+        }
+        vals.update(kwargs)
+        return Move.create(vals)
+
+    @classmethod
+    def create_picking(cls, picking_type, **kwargs):
+        """ Create and return a picking for the given picking_type."""
+        Picking = cls.env['stock.picking']
+        vals = {
+            'picking_type_id': picking_type.id,
+            'location_id': picking_type.default_location_src_id.id,
+            'location_dest_id': picking_type.default_location_dest_id.id,
+        }
+        vals.update(kwargs)
+        return Picking.create(vals)
+
+    @classmethod
+    def create_product(cls, name, **kwargs):
+        """ Create and return a product."""
+        Product = cls.env['product.product']
+        vals = {
+            'name': 'Test product {}'.format(name),
+            'barcode': 'product{}'.format(name),
+            'default_code': 'product{}'.format(name),
+            'type': 'product',
+        }
+        vals.update(kwargs)
+        return Product.create(vals)
+
+    @classmethod
+    def create_quant(cls, product_id, location_id, qty, **kwargs):
+        """ Create and return a quant of a product at location."""
+        Quant = cls.env['stock.quant']
+        vals = {
+            'product_id': product_id,
+            'location_id': location_id,
+            'quantity': qty,
+        }
+        vals.update(kwargs)
+        return Quant.create(vals)

--- a/addons/udes_simple_location_blocking/tests/test_inventory.py
+++ b/addons/udes_simple_location_blocking/tests/test_inventory.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+
+from odoo.exceptions import ValidationError
+from .common import BaseBlocked
+
+class TestStockInventory(BaseBlocked):
+    def test01_create_inventory_location_blocked(self):
+        """ Creating an inventory using a blocked location
+            raises an error.
+        """
+        self.test_location_01.u_blocked_reason = "Stock Damaged"
+        self.test_location_01.u_blocked = True
+
+        with self.assertRaises(ValidationError) as e:
+            inventory = self.create_inventory(self.test_location_01)
+        self.assertEqual(e.exception.name,
+                'Cannot create inventory adjustment. Location %s is'
+                ' blocked (reason: %s). Please speak'
+                ' to a team leader to resolve the issue.' %
+                (self.test_location_01.name, self.test_location_01.u_blocked_reason))
+
+    def test02_create_inventory_lines_location_blocked(self):
+        """ Creating an inventory line from a blocked location
+            raises an error.
+        """
+        inventory = self.create_inventory(self.test_location_01)
+        self.create_quant(self.apple.id, self.test_location_01.id, 10)
+        self.test_location_01.u_blocked_reason = "Stock Damaged"
+        self.test_location_01.u_blocked = True
+        with self.assertRaises(ValidationError) as e:
+            inventory.action_start()
+        self.assertEqual(e.exception.name,
+                'Cannot create inventory adjustment line. Location %s is'
+                ' blocked (reason: %s). Please speak'
+                ' to a team leader to resolve the issue.' %
+                (self.test_location_01.name, self.test_location_01.u_blocked_reason))
+                
+    def test03_validate_inventory_location_blocked(self):
+        """ Validating an inventory of a blocked location
+            raises an error.
+        """
+        inventory = self.create_inventory(self.test_location_01)
+        self.create_quant(self.apple.id, self.test_location_01.id, 10)
+        inventory.action_start()
+        self.test_location_01.u_blocked_reason = "Stock Damaged"
+        self.test_location_01.u_blocked = True
+        with self.assertRaises(ValidationError) as e:
+            inventory._action_done()
+        self.assertEqual(e.exception.name,
+                'Cannot validate inventory adjustment. Location %s is'
+                ' blocked (reason: %s). Please speak'
+                ' to a team leader to resolve the issue.' %
+                (self.test_location_01.name, self.test_location_01.u_blocked_reason))
+
+    def test04_validate_inventory_line_location_blocked(self):
+        """ Validating an inventory line of a blocked location
+            raises an error.
+        """
+        inventory = self.create_inventory(self.stock_location)
+        self.create_quant(self.apple.id, self.test_location_01.id, 10)
+        inventory.action_start()
+        self.test_location_01.u_blocked_reason = "Stock Damaged"
+        self.test_location_01.u_blocked = True
+        with self.assertRaises(ValidationError) as e:
+            inventory._action_done()
+        self.assertEqual(e.exception.name,
+                'Cannot validate inventory adjustment line. Location %s is'
+                ' blocked (reason: %s). Please speak'
+                ' to a team leader to resolve the issue.' %
+                (self.test_location_01.name, self.test_location_01.u_blocked_reason))
+
+    def test05_validate_inventory_location_non_blocked(self):
+        """ Validating an inventory of a non blocked location
+            does not raise an error.
+            Change 10 apples to 9.
+        """
+        Location = self.env['stock.location']
+        # create sublocation for test_location_01
+        test_location_01_01 = Location.create({
+                'name': "Test location 01 01",
+                'barcode': "LTEST0101",
+                'location_id': self.test_location_01.id,
+            })
+        # create inventory for test_location_01
+        inventory = self.create_inventory(self.test_location_01)
+        # create quant at the sublocation
+        quant = self.create_quant(self.apple.id, test_location_01_01.id, 10)
+        inventory.action_start()
+        apple_line = inventory.line_ids.filtered(lambda l: l.product_id == self.apple)
+        apple_line.product_qty = 9
+        inventory._action_done()
+        self.assertEqual(quant.quantity, 9)
+

--- a/addons/udes_simple_location_blocking/tests/test_location.py
+++ b/addons/udes_simple_location_blocking/tests/test_location.py
@@ -1,0 +1,116 @@
+from odoo.exceptions import ValidationError
+from .common import BaseBlocked
+
+
+class TestStockLocation(BaseBlocked):
+    def test01_check_blocked_wrong_prefix_type(self):
+        """Call check blocked with wrong prefix type will
+        raise a ValidationError.
+
+        Prefix is expected to be a string.
+        """
+        with self.assertRaises(ValidationError) as e:
+            self.test_location_01.check_blocked(prefix=7)
+
+        self.assertEqual(e.exception.name, "Prefix parameter for check_blocked should be string")
+
+    def test02_check_blocked_one_location_one_blocked_location(self):
+        """Block test_location_01 and check if it is blocked, which will
+        raise a ValidationError.
+        """
+        self.test_location_01.u_blocked_reason = "Stock Damaged"
+        self.test_location_01.u_blocked = True
+
+        with self.assertRaises(ValidationError) as e:
+            self.test_location_01.check_blocked()
+
+        self.assertEqual(
+            e.exception.name,
+            " Location %s is blocked (reason: %s)."
+            " Please speak to a team leader to resolve the issue." % (self.test_location_01.name, self.test_location_01.u_blocked_reason)
+        )
+
+    def test03_check_blocked_two_locations_one_blocked_location(self):
+        """Block test_location_01 and check if either test_location_01
+        or test_location_02 are blocked, which will raise a
+        ValidationError.
+        """
+        self.test_location_01.u_blocked_reason = "Stock Damaged"
+        self.test_location_01.u_blocked = True
+
+        with self.assertRaises(ValidationError) as e:
+            self.test_locations.check_blocked()
+
+        self.assertEqual(
+            e.exception.name,
+            " Location %s is blocked (reason: %s)."
+            " Please speak to a team leader to resolve the issue." % (self.test_location_01.name, self.test_location_01.u_blocked_reason)
+        )
+
+    def test04_prepare_blocked_msg_blocked_location_no_reason(self):
+        """Prepare the message of a blocked location without reason."""
+        self.test_location_01.u_blocked_reason = "Stock Damaged"
+        self.test_location_01.u_blocked = True
+        msg = self.test_location_01._prepare_blocked_msg()
+        self.assertEqual(
+            msg,
+            "Location %s is blocked (reason: %s)." % (self.test_location_01.name, self.test_location_01.u_blocked_reason)
+        )
+
+    def test05_prepare_blocked_msg_blocked_location_with_reason(self):
+        """Prepare the message of a blocked location with reason."""
+        self.test_location_01.u_blocked_reason = "Stock Damaged"
+        self.test_location_01.u_blocked = True
+        msg = self.test_location_01._prepare_blocked_msg()
+        self.assertEqual(
+            msg,
+            "Location %s is blocked (reason: %s)." % (self.test_location_01.name, self.test_location_01.u_blocked_reason)
+        )
+
+    def test06_prepare_blocked_msg_non_blocked_location(self):
+        """Prepare the message of a non blocked location."""
+        msg = self.test_location_01._prepare_blocked_msg()
+        self.assertEqual(
+            msg,
+            "Location %s is not blocked." % self.test_location_01.name
+        )
+
+    def test07_onchange_blocked_to_false(self):
+        """Check that blocked reason becomes empty when the
+        location is unblocked
+        """
+        self.test_location_01.u_blocked_reason = "Stock Damaged"
+        self.test_location_01.u_blocked = True
+        msg = self.test_location_01._prepare_blocked_msg()
+        self.assertEqual(
+            msg,
+            "Location %s is blocked (reason: %s)." % (self.test_location_01.name, self.test_location_01.u_blocked_reason)
+        )
+
+        self.test_location_01.u_blocked = False
+        # simulate the triggering of the onchange
+        self.test_location_01.onchange_u_blocked()
+        self.assertEqual(self.test_location_01.u_blocked_reason, "")
+
+    def test08_check_reserved_quants(self):
+        """Blocking a location with reserved quants will raise an error."""
+        self.create_quant(self.apple.id, self.test_location_01.id, 10, reserved_quantity=10)
+
+        with self.assertRaises(ValidationError) as e:
+            self.test_location_01.u_blocked_reason = "Stock Damaged"
+            self.test_location_01.u_blocked = True
+
+        self.assertEqual(
+            e.exception.name, "Location cannot be blocked because it contains reserved stock."
+        )
+
+    def test09_check_blocked_reason(self):
+        """Blocking a location with no reason given will raise and error"""
+
+        with self.assertRaises(ValidationError) as e:
+            self.test_location_01.u_blocked = True
+
+        self.assertEqual(
+            e.exception.name,
+            "A reason for blocking the locations is required when attempting to block a location.",
+        )

--- a/addons/udes_simple_location_blocking/tests/test_move.py
+++ b/addons/udes_simple_location_blocking/tests/test_move.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+
+from odoo.exceptions import ValidationError
+from .common import BaseBlocked
+
+class TestStockMove(BaseBlocked):
+    def test01_create_move_source_location_blocked(self):
+        """ Creating a move using as source location a blocked
+            location raises an error.
+        """
+        self.test_location_01.u_blocked_reason = "Stock Damaged"
+        self.test_location_01.u_blocked = True
+        picking = self.create_picking(self.picking_type_internal)
+        with self.assertRaises(ValidationError) as e:
+            move = self.create_move(self.apple, 10, picking,
+                                    location_id=self.test_location_01.id)
+        self.assertEqual(e.exception.name,
+                         'Wrong source location creating stock move. Location %s '
+                         'is blocked (reason: %s). Please speak'
+                         ' to a team leader to resolve the issue.' % 
+                         (self.test_location_01.name, self.test_location_01.u_blocked_reason))
+
+    def test02_create_move_destination_location_blocked(self):
+        """ Creating a move using as destination location a blocked
+            location raises an error.
+        """
+        self.test_location_01.u_blocked_reason = "Stock Damaged"
+        self.test_location_01.u_blocked = True
+        picking = self.create_picking(self.picking_type_internal)
+        with self.assertRaises(ValidationError) as e:
+            move = self.create_move(self.apple, 10, picking,
+                                    location_dest_id=self.test_location_01.id)
+        self.assertEqual(e.exception.name,
+                         'Wrong destination location creating stock move. Location %s '
+                         'is blocked (reason: %s). Please speak'
+                         ' to a team leader to resolve the issue.' % 
+                         (self.test_location_01.name, self.test_location_01.u_blocked_reason))
+
+    def test03_update_move_source_location_blocked(self):
+        """ Updating the source location of a move using a blocked
+            location raises an error.
+        """
+        picking = self.create_picking(self.picking_type_internal)
+        move = self.create_move(self.apple, 10, picking)
+        self.assertEqual(len(move), 1)
+        self.test_location_01.u_blocked_reason = "Stock Damaged"
+        self.test_location_01.u_blocked = True
+        with self.assertRaises(ValidationError) as e:
+            move.location_id=self.test_location_01
+        self.assertEqual(e.exception.name,
+                         'Wrong source location creating stock move. Location %s '
+                         'is blocked (reason: %s). Please speak'
+                         ' to a team leader to resolve the issue.' % 
+                         (self.test_location_01.name, self.test_location_01.u_blocked_reason))
+
+    def test04_update_move_destination_location_blocked(self):
+        """ Updating the destination location of a move using a blocked
+            location raises an error.
+        """
+        picking = self.create_picking(self.picking_type_internal)
+        move = self.create_move(self.apple, 10, picking)
+        self.assertEqual(len(move), 1)
+        self.test_location_01.u_blocked_reason = "Stock Damaged"
+        self.test_location_01.u_blocked = True
+        with self.assertRaises(ValidationError) as e:
+            move.location_dest_id=self.test_location_01
+        self.assertEqual(e.exception.name,
+                         'Wrong destination location creating stock move. Location %s '
+                         'is blocked (reason: %s). Please speak'
+                         ' to a team leader to resolve the issue.' % 
+                         (self.test_location_01.name, self.test_location_01.u_blocked_reason))

--- a/addons/udes_simple_location_blocking/tests/test_move_line.py
+++ b/addons/udes_simple_location_blocking/tests/test_move_line.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+
+from odoo.exceptions import ValidationError
+from .common import BaseBlocked
+
+class TestStockMoveLine(BaseBlocked):
+    def test01_create_move_line_source_location_blocked(self):
+        """ Creating a move line using as source location a blocked
+            location raises an error.
+        """
+        self.test_location_01.u_blocked_reason = "Stock Damaged"
+        self.test_location_01.u_blocked = True
+        picking = self.create_picking(self.picking_type_internal)
+        move = self.create_move(self.apple, 10, picking)
+        with self.assertRaises(ValidationError) as e:
+            move_line = self.create_move_line(move, 10,
+                                    location_id=self.test_location_01.id)
+        self.assertEqual(e.exception.name,
+                         'Wrong source location creating stock move line. Location %s '
+                         'is blocked (reason: %s). Please speak'
+                         ' to a team leader to resolve the issue.' % 
+                         (self.test_location_01.name, self.test_location_01.u_blocked_reason))
+
+    def test02_create_move_line_destination_location_blocked(self):
+        """ Creating a move line using as destination location a blocked
+            location raises an error.
+        """
+        self.test_location_01.u_blocked_reason = "Stock Damaged"
+        self.test_location_01.u_blocked = True
+        picking = self.create_picking(self.picking_type_internal)
+        move = self.create_move(self.apple, 10, picking)
+        with self.assertRaises(ValidationError) as e:
+            move_line = self.create_move_line(move, 10,
+                                    location_dest_id=self.test_location_01.id)
+        self.assertEqual(e.exception.name,
+                         'Wrong destination location creating stock move line. Location %s '
+                         'is blocked (reason: %s). Please speak'
+                         ' to a team leader to resolve the issue.' % 
+                         (self.test_location_01.name, self.test_location_01.u_blocked_reason))
+
+    def test03_update_move_line_source_location_blocked(self):
+        """ Updating the source location of a move line using a blocked
+            location raises an error.
+        """
+        picking = self.create_picking(self.picking_type_internal)
+        move = self.create_move(self.apple, 10, picking)
+        move_line = self.create_move_line(move, 10)
+        self.assertEqual(len(move), 1)
+        self.test_location_01.u_blocked_reason = "Stock Damaged"
+        self.test_location_01.u_blocked = True
+        with self.assertRaises(ValidationError) as e:
+            move_line.location_id=self.test_location_01
+        self.assertEqual(e.exception.name,
+                         'Wrong source location creating stock move line. Location %s '
+                         'is blocked (reason: %s). Please speak'
+                         ' to a team leader to resolve the issue.' % 
+                         (self.test_location_01.name, self.test_location_01.u_blocked_reason))
+
+    def test04_update_move_line_destination_location_blocked(self):
+        """ Updating the destination location of a move line using a blocked
+            location raises an error.
+        """
+        picking = self.create_picking(self.picking_type_internal)
+        move = self.create_move(self.apple, 10, picking)
+        move_line = self.create_move_line(move, 10)
+        self.assertEqual(len(move), 1)
+        self.test_location_01.u_blocked_reason = "Stock Damaged"
+        self.test_location_01.u_blocked = True
+        with self.assertRaises(ValidationError) as e:
+            move_line.location_dest_id=self.test_location_01
+        self.assertEqual(e.exception.name,
+                         'Wrong destination location creating stock move line. Location %s '
+                         'is blocked (reason: %s). Please speak'
+                         ' to a team leader to resolve the issue.' % 
+                         (self.test_location_01.name, self.test_location_01.u_blocked_reason))

--- a/addons/udes_simple_location_blocking/tests/test_picking.py
+++ b/addons/udes_simple_location_blocking/tests/test_picking.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+
+from odoo.exceptions import ValidationError
+from .common import BaseBlocked
+
+class TestStockPicking(BaseBlocked):
+    def test01_create_picking_source_location_blocked(self):
+        """ Creating a picking using as source location a blocked
+            location raises an error.
+        """
+        self.test_location_01.u_blocked_reason = "Stock Damaged"
+        self.test_location_01.u_blocked = True
+        with self.assertRaises(ValidationError) as e:
+            picking = self.create_picking(self.picking_type_internal,
+                                          location_id=self.test_location_01.id)
+        self.assertEqual(e.exception.name,
+                         'Wrong source location creating transfer. Location %s '
+                         'is blocked (reason: %s). Please speak'
+                         ' to a team leader to resolve the issue.' % 
+                         (self.test_location_01.name, self.test_location_01.u_blocked_reason))
+
+    def test02_create_picking_destination_location_blocked(self):
+        """ Creating a picking using as destination location a blocked
+            location raises an error.
+        """
+        self.test_location_01.u_blocked_reason = "Stock Damaged"
+        self.test_location_01.u_blocked = True
+        with self.assertRaises(ValidationError) as e:
+            picking = self.create_picking(self.picking_type_internal,
+                                          location_dest_id=self.test_location_01.id)
+        self.assertEqual(e.exception.name,
+                         'Wrong destination location creating transfer. Location %s '
+                         'is blocked (reason: %s). Please speak'
+                         ' to a team leader to resolve the issue.' % 
+                         (self.test_location_01.name, self.test_location_01.u_blocked_reason))
+
+    def test03_update_picking_source_location_blocked(self):
+        """ Updating the source location of a picking using a blocked
+            location raises an error.
+        """
+        picking = self.create_picking(self.picking_type_internal)
+        self.assertEqual(len(picking), 1)
+        self.test_location_01.u_blocked_reason = "Stock Damaged"
+        self.test_location_01.u_blocked = True
+        with self.assertRaises(ValidationError) as e:
+            picking.location_id=self.test_location_01
+        self.assertEqual(e.exception.name,
+                         'Wrong source location creating transfer. Location %s '
+                         'is blocked (reason: %s). Please speak'
+                         ' to a team leader to resolve the issue.' % 
+                         (self.test_location_01.name, self.test_location_01.u_blocked_reason))
+
+    def test04_update_picking_destination_location_blocked(self):
+        """ Updating the destination location of a picking using a blocked
+            location raises an error.
+        """
+        picking = self.create_picking(self.picking_type_internal)
+        self.assertEqual(len(picking), 1)
+        self.test_location_01.u_blocked_reason = "Stock Damaged"
+        self.test_location_01.u_blocked = True
+        with self.assertRaises(ValidationError) as e:
+            picking.location_dest_id=self.test_location_01
+        self.assertEqual(e.exception.name,
+                         'Wrong destination location creating transfer. Location %s '
+                         'is blocked (reason: %s). Please speak'
+                         ' to a team leader to resolve the issue.' % 
+                         (self.test_location_01.name, self.test_location_01.u_blocked_reason))

--- a/addons/udes_simple_location_blocking/tests/test_quant.py
+++ b/addons/udes_simple_location_blocking/tests/test_quant.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+from odoo.exceptions import ValidationError
+from .common import BaseBlocked
+
+class TestStockQuant(BaseBlocked):
+    def setUp(self):
+        super(TestStockQuant, self).setUp()
+        # create 10 apples at test_location_01 for all the tests
+        self.create_quant(self.apple.id, self.test_location_01.id, 10)
+
+    def test01_gather_blocked_location(self):
+        """ Gather quants from a blocked location should return
+            an empty recordset.
+        """
+        Quant = self.env['stock.quant']
+        self.test_location_01.u_blocked_reason = "Stock Damaged"
+        self.test_location_01.u_blocked = True
+        quants = Quant._gather(self.apple, self.test_location_01)
+        self.assertEqual(len(quants), 0)
+
+    def test02_gather_non_blocked_location(self):
+        """ Gather quants from a non blocked location should return
+            the quants at that location.
+        """
+        Quant = self.env['stock.quant']
+        quants = Quant._gather(self.apple, self.test_location_01)
+        self.assertEqual(len(quants), 1)
+
+    def test03_gather_parent_of_one_blocked_location(self):
+        """ Gather quants from a parent location of a blocked location
+            should return an empty recordset.
+        """
+        Quant = self.env['stock.quant']
+        self.test_location_01.u_blocked_reason = "Stock Damaged"
+        self.test_location_01.u_blocked = True
+        quants = Quant._gather(self.apple, self.stock_location)
+        self.assertEqual(len(quants), 0)
+
+    def test04_gather_parent_of_two_locations_one_blocked(self):
+        """ Gather quants from a parent location of two locations, where
+            one of them is blocked should return the quants of the non
+            blocked location.
+        """
+        Quant = self.env['stock.quant']
+        self.test_location_01.u_blocked_reason = "Stock Damaged"
+        self.test_location_01.u_blocked = True
+        self.create_quant(self.apple.id, self.test_location_02.id, 10)
+        quants = Quant._gather(self.apple, self.stock_location)
+        self.assertEqual(len(quants), 1)

--- a/addons/udes_simple_location_blocking/views/stock_location.xml
+++ b/addons/udes_simple_location_blocking/views/stock_location.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<odoo>
+    <data>
+        <!-- Change default stock.view_location_search -->
+        <record id="view_search_stock_location_udes" model="ir.ui.view">
+            <field name="name">Changes to location search for blocked locations</field>
+            <field name="model">stock.location</field>
+            <field name="inherit_id" ref="stock.view_location_search"/>
+            <field name="arch" type="xml">
+                <!-- Append u_blocked filter -->
+                <xpath expr="//search" position="inside">
+                    <separator/>
+                    <filter name="u_blocked"
+                            string="Blocked"
+                            domain="[('u_blocked', '=', 'True')]"
+                            help="Show only blocked locations."/>
+                </xpath>
+            </field>
+        </record>
+
+        <!-- Changes to stock.view_location_form -->
+        <record id="view_form_stock_location_udes" model="ir.ui.view">
+            <field name="name">Location form with blocked options</field>
+            <field name="model">stock.location</field>
+            <field name="inherit_id" ref="stock.view_location_form"/>
+            <field name="arch" type="xml">
+                <!-- Add u_blocked and u_blocked_reason -->
+                <xpath expr="//field[@name='scrap_location']" position="before">
+                    <field name="u_blocked"/>
+                    <field name="u_blocked_reason" attrs="{'invisible': [('u_blocked', '=', False)], 'required': [('u_blocked', '=', True)]}"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/addons/udes_stock/models/stock_picking.py
+++ b/addons/udes_stock/models/stock_picking.py
@@ -162,6 +162,12 @@ class StockPicking(models.Model):
         for picking in self:
             picking.u_num_pallets = len(picking.move_line_ids.result_package_id)
 
+    def get_empty_location_domain(self):
+        """
+        Return the domain for searching empty locations
+        """
+        return [("barcode", "!=", False), ("quant_ids", "=", False)]
+
     def get_empty_locations(self, limit=None, sort=True):
         """Returns the recordset of locations that are child of the
         instance dest location and are empty.
@@ -177,7 +183,7 @@ class StockPicking(models.Model):
         :returns: Move lines of picking
         """
         locations = self._get_child_dest_locations(
-            aux_domain=[("barcode", "!=", False), ("quant_ids", "=", False)], limit=limit
+            self.get_empty_location_domain(), limit=limit
         )
 
         if sort:

--- a/addons/udes_suggest_location/__manifest__.py
+++ b/addons/udes_suggest_location/__manifest__.py
@@ -11,6 +11,7 @@
         "udes_get_info",
         "udes_common",
         "udes_stock",
+        "udes_simple_location_blocking"
     ],
     "data": ["views/stock_picking_type.xml"],
 }

--- a/addons/udes_suggest_location/registry/suggest_by_empty_location.py
+++ b/addons/udes_suggest_location/registry/suggest_by_empty_location.py
@@ -40,13 +40,12 @@ class ByEmptyLocation(SuggestLocationPolicy):
         Location = self.env["stock.location"]
         
         # Add order="id" for performance as we don't care about the order
-        # TODO: When u_blocked is ported add it in as part of search criteria
-        # ("u_blocked", "!=", False)
         child_locations_of_picking_destination = Location.search(
             [
                 ("location_id", "child_of", location.id),
                 ("barcode", "!=", False),
                 ("quant_ids", "=", False),
+                ("u_blocked", "=", False),
             ],
             order="id",
         )

--- a/addons/udes_suggest_location/tests/test_stock_move_line.py
+++ b/addons/udes_suggest_location/tests/test_stock_move_line.py
@@ -60,6 +60,7 @@ class TestStockMoveLine(common.SuggestedLocations):
         # Check naming
         self.assertEqual(by_product.name(), "by_product")
         # Check error raised when no policy found
+        self.picking_type_internal.u_suggest_locations_policy = False
         with self.assertRaises(ValueError) as e:
             self.MoveLine._get_policy_class(self.picking_type_internal)
         self.assertEqual(str(e.exception), f"Policy with name=False could not be found")

--- a/addons/udes_suggest_location/tests/test_suggest_by_empty_location.py
+++ b/addons/udes_suggest_location/tests/test_suggest_by_empty_location.py
@@ -15,7 +15,6 @@ class TestSuggestByEmptyLocation(common.SuggestedLocations):
 
         cls._pick_info = [{"product": cls.apple, "uom_qty": 5}]
 
-
     def test_correct_location_suggested_when_empty_child_location_is_available(self):
         mls = self._generate_move_lines_for_picking_for_given_destination_location(
             self.out_location.id
@@ -25,7 +24,6 @@ class TestSuggestByEmptyLocation(common.SuggestedLocations):
             mls, self.test_goodsout_location_01
         )
 
-
     def test_correct_location_suggested_when_no_empty_child_location_is_available(self):
         mls = self._generate_move_lines_for_picking_for_given_destination_location(
             self.test_goodsout_location_01.id
@@ -34,7 +32,6 @@ class TestSuggestByEmptyLocation(common.SuggestedLocations):
         self._check_move_lines_destination_location_match_expected_location(
             mls, self.test_goodsout_location_01
         )
-
 
     def test_correct_location_suggested_when_empty_child_location_but_no_barcode(self):
         # These are all children of out_location
@@ -47,15 +44,10 @@ class TestSuggestByEmptyLocation(common.SuggestedLocations):
             self.out_location.id
         )
 
-        self._check_move_lines_destination_location_match_expected_location(
-            mls, self.out_location
-        )
-
+        self._check_move_lines_destination_location_match_expected_location(mls, self.out_location)
 
     def test_correct_location_suggested_when_child_location_but_not_empty(self):
-        self._create_one_non_empty_child_location_for_given_location(
-            self.test_goodsout_location_01
-        )
+        self._create_one_non_empty_child_location_for_given_location(self.test_goodsout_location_01)
 
         mls = self._generate_move_lines_for_picking_for_given_destination_location(
             self.test_goodsout_location_01.id
@@ -77,7 +69,6 @@ class TestSuggestByEmptyLocation(common.SuggestedLocations):
         )
 
         self.create_quant(self.banana.id, child_location_with_quant.id, 5)
-
 
     def test_validate_location_dest_fails_when_bad_location_is_passed(self):
         self.picking_type_pick.write({"u_drop_location_constraint": "enforce"})


### PR DESCRIPTION
[IMP] udes_simple_location_blocking: Add new module for blocking locations

User-story: 1277

Add a new module from UDES11 to block locations from being used by pickings,
stock moves, stock move lines and stock inventory adjustments.
Also avoid stock quantities that are in blocked location from being used.

Additionally, this module is now a dependency of udes_stock and udes_suggest_location.

Signed-off-by: Lorenzo Cucurachi <lorenzo.cucurachi@unipart.io>