### PR TITLE
[FIX] udes_stock_picking_batch: Update to selection_add

### DIFF
--- a/addons/udes_stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/udes_stock_picking_batch/models/stock_picking_batch.py
@@ -60,16 +60,17 @@ class StockPickingBatch(models.Model):
     # Note: state field has been found to recompute itself everytime it was accessed even with store=True
     # lock_batch_state has been put in places to ensure correct behaviour.
     state = fields.Selection(
-        selection=[
-            ("draft", "Draft"),
+        selection_add=[
             ("waiting", "Waiting"),
             ("ready", "Ready"),
-            ("in_progress", "Running"),
-            ("done", "Done"),
-            ("cancel", "Cancelled"),
+            ("in_progress", "Running")
         ],
         compute="_compute_state",
         store=True,
+        ondelete={
+            "waiting": lambda spb: spb.write({"state": "draft"}),
+            "ready": lambda spb: spb.write({"state": "draft"})
+        },
     )
     picking_ids = fields.One2many(
         "stock.picking",


### PR DESCRIPTION
Update the state field on the stock.picking.batch model to use selection_add instead of redefining all the states.

Signed-off-by: Adam Patrick <adam.patrick@unipart.io>