### PR TITLE
[FIX] udes_stock: Stops backorder being created for cancelled movelines

### DIFF
--- a/addons/udes_stock/models/stock_picking.py
+++ b/addons/udes_stock/models/stock_picking.py
@@ -956,19 +956,17 @@ class StockPicking(models.Model):
             )
 
     def _requires_backorder(self, mls):
-        """Checks if a backorder is required
-        by checking if all move.lines
-        within a picking is present in mls
+        """
+        Checks if a backorder is required by checking if all moves within a picking are present
+        in the movelines. Cancelled moves are not considered.
         """
         mls_moves = mls.mapped("move_id")
-        # return (mls_moves | self.move_lines) != mls_moves or \
-        # (mls | self.move_line_ids) != mls or \
-        # self.mapped('move_lines.move_orig_ids').filtered(lambda x: x.state not in ('done', 'cancel'))
-        for move in self.move_lines:
+        
+        for move in self.move_lines.filtered(lambda mv: mv.state != "cancel"):
             if (
                 move not in mls_moves
-                or not move.move_line_ids == mls.filtered(lambda x: x.move_id == move)
-                or move.move_orig_ids.filtered(lambda x: x.state not in ("done", "cancel"))
+                or not move.move_line_ids == mls.filtered(lambda ml: ml.move_id == move)
+                or move.move_orig_ids.filtered(lambda mv: mv.state not in ("done", "cancel"))
             ):
                 return True
         return False

--- a/addons/udes_stock/tests/__init__.py
+++ b/addons/udes_stock/tests/__init__.py
@@ -34,3 +34,4 @@ from . import test_stock_location_picking_zone
 from . import test_location_countable
 from . import test_location_state
 from . import test_product_template  # noqa: F401
+from . import test_backorder

--- a/addons/udes_stock/tests/test_backorder.py
+++ b/addons/udes_stock/tests/test_backorder.py
@@ -1,0 +1,51 @@
+from . import common
+
+
+class TestBackOrder(common.BaseUDES):
+    @classmethod
+    def setUpClass(cls):
+        super(TestBackOrder, cls).setUpClass()
+
+        # Create two quants in location_01
+        cls.create_quant(cls.apple.id, cls.test_location_01.id, 5)
+        cls.create_quant(cls.banana.id, cls.test_location_01.id, 5)
+        # Create a picking for two different products
+        cls.pick1 = cls.create_picking(
+            picking_type=cls.picking_type_pick,
+            products_info=[
+                {"product": cls.apple, "qty": 5},
+                {"product": cls.banana, "qty": 5},
+            ],
+            assign=True,
+        )
+
+    def test_requires_backorder_for_incomplete_moves(self):
+        """
+        Test a picking is flagged as needing a backorder if it has incomplete
+        moves.
+        """
+
+        # Set qty done to 5 for apple and leave as 0 banana
+        apple_move_lines = self.pick1.move_line_ids.filtered(lambda ml: ml.product_id == self.apple)
+        apple_move_lines.qty_done = 5
+
+        # Assert that this picking requires a backorder
+        self.assertTrue(self.pick1._requires_backorder(apple_move_lines))
+
+    def test_backorder_not_created_for_cancelled_moves(self):
+        """
+        Test a picking is not flagged as needing a backorder if the remaining incomplete
+        moves are cancelled.
+        """
+        # Set qty done to 5 on apple
+        apple_move_lines = self.pick1.move_line_ids.filtered(lambda ml: ml.product_id == self.apple)
+        apple_move_lines.qty_done = 5
+
+        # Cancel the banana move
+        banana_move = self.pick1.move_lines.filtered(
+            lambda ml: ml.product_id == self.banana
+        ).ensure_one()
+        banana_move._action_cancel()
+
+        # Assert that this picking does not require a backorder
+        self.assertFalse(self.pick1._requires_backorder(apple_move_lines))


### PR DESCRIPTION
Fix to the _requires_backorder method which used to check if ALL moves within
a picking were present in the movelines, but now a filter has been applied
to not consider cancelled moves.

User-story: 1773

Signed-off-by: Caleb Shelton <caleb.shelton@unipart.io>