### PR TITLE
[IMP] udes_stock_picking_batch: Recompute state after action done

### DIFF
--- a/addons/udes_stock_picking_batch/models/stock_picking.py
+++ b/addons/udes_stock_picking_batch/models/stock_picking.py
@@ -52,11 +52,21 @@ class StockPicking(models.Model):
 
     def action_assign(self):
         """
-        Recompute batch state. In theory this is not necessary
+        Ensure the batch state is recomputed. In theory this is not necessary
         but the constraint on state has not proven to work correctly.
         """
-        super().action_assign()
+        res = super().action_assign()
         self.batch_id._compute_state()
+        return res
+
+    def _action_done(self):
+        """
+        Ensure the batch state is recomputed. In theory this is not necessary
+        but the constraint on state has not proven to work correctly.
+        """
+        res = super()._action_done()
+        self.batch_id._compute_state()
+        return res
 
     @api.model
     def create(self, vals):


### PR DESCRIPTION
This fixes the test for the backordering logic where the batch state
is not being updated after the picking is done.

User-story: x1800

Signed-off-by: Lorenzo Cucurachi <lorenzo.cucurachi@unipart.io>