### PR TITLE
#1805 Stock - Picking Types handled inconsistently

### DIFF
--- a/addons/udes_stock/data/picking_types.xml
+++ b/addons/udes_stock/data/picking_types.xml
@@ -48,7 +48,6 @@
       <field name="sequence" eval="10"/>
       <field name="code">incoming</field>
       <field name="sequence_id" ref="sequence_in"/>
-      <field name="sequence_code">In</field>
       <field name="use_create_lots" eval="1"/>
       <field name="default_location_src_id" ref="stock.stock_location_suppliers"/>
       <field name="default_location_dest_id" ref="location_input_received"/>
@@ -64,7 +63,6 @@
       <field name="sequence" eval="21"/>
       <field name="code">internal</field>
       <field name="sequence_id" ref="sequence_out"/>
-      <field name="sequence_code">Out</field>
       <field name="use_existing_lots" eval="1"/>
       <field name="show_operations" eval="1"/>
       <field name="active">True</field>
@@ -90,7 +88,6 @@
       <field name="sequence" eval="40"/>
       <field name="code">internal</field>
       <field name="sequence_id" ref="sequence_stock_inv"/>
-      <field name="sequence_code"></field>
       <field name="use_existing_lots" eval="1"/>
       <field name="default_location_src_id" ref="stock.stock_location_stock"/>
       <field name="default_location_dest_id" ref="location_stock_investigation"/>
@@ -104,7 +101,6 @@
       <field name="sequence" eval="19"/>
       <field name="code">internal</field>
       <field name="sequence_id" ref="sequence_replen"/>
-      <field name="sequence_code">Replen</field>
       <field name="use_existing_lots" eval="1"/>
       <field name="default_location_src_id" ref="stock.stock_location_stock"/>
       <field name="default_location_dest_id" ref="stock.stock_location_output"/>

--- a/addons/udes_stock/models/stock_picking_type.py
+++ b/addons/udes_stock/models/stock_picking_type.py
@@ -1,5 +1,8 @@
-from odoo import fields, models
+import logging
 
+from odoo import fields, models, _, api
+
+_logger = logging.getLogger(__name__)
 
 TARGET_STORAGE_FORMAT_OPTIONS = [
     ("pallet_products", "Pallet of products"),
@@ -11,6 +14,9 @@ TARGET_STORAGE_FORMAT_OPTIONS = [
 
 class StockPickingType(models.Model):
     _inherit = "stock.picking.type"
+
+    # Overwrite sequence_code as it is only needed for old Odoo prefixes.
+    sequence_code = fields.Char("Sequence_code", required=False)
 
     u_user_scans = fields.Selection(
         [("pallet", "Pallets"), ("package", "Packages"), ("product", "Products")],
@@ -46,9 +52,8 @@ class StockPickingType(models.Model):
     # Enable multi users processing same picking simultaneously
     u_multi_users_enabled = fields.Boolean(
         string="Multi Users Enabled",
-        help="Flag to enable multi users processing same picking simultaneously. "
-             "On validate of picking will be confirmed only what is done by the specific user "
-             "unless all moves have been picked from other users on the validation time.",
+        help="Flag to enable multiple users to work on a picking simultaneously."
+        "On validation of a picking only the moves done by the specific user will be confirmed unless all moves have already been picked by other users",
         default=False,
     )
     u_enable_unpickable_items = fields.Boolean(
@@ -67,3 +72,33 @@ class StockPickingType(models.Model):
         """
         self.ensure_one()
         return self.u_multi_users_enabled
+
+    def write(self, vals):
+        """
+        Purpose: This will remove the sequence code from the list of values to be updated. This is to prevent the sequences
+        for each picking type from being updated with hardcoded values. sequence_code is only relevant to the old odoo prefixes
+        and not the UDES ones, hence a warning message is also displayed.
+        """
+        if "sequence_code" in vals:
+            _logger.warning(
+                _(
+                    "The 'sequence code' field, which has value: (%s), is no longer being used in UDES, this field has been removed from the values to update and will not be updated.",
+                    vals["sequence_code"],
+                )
+            )
+            del vals["sequence_code"]
+        return super(StockPickingType, self).write(vals)
+
+        
+    @api.model
+    def create(self, vals):
+        """
+        Purpose: If picking_type is to be full copy, then set the sequence_id on the record else set the sequence_code to the name 
+        """
+        Stockpickingtype = self.env["stock.picking.type"]
+        stock_picking_type_record = Stockpickingtype.search([("name","=",vals["name"])])
+        if len(stock_picking_type_record) != 0: 
+            vals["sequence_id"] = stock_picking_type_record[0].sequence_id.id
+        else:
+            vals["sequence_code"] = vals["name"]
+        return super(StockPickingType, self).create(vals)

--- a/addons/udes_stock/models/stock_picking_type.py
+++ b/addons/udes_stock/models/stock_picking_type.py
@@ -16,7 +16,7 @@ class StockPickingType(models.Model):
     _inherit = "stock.picking.type"
 
     # Overwrite sequence_code as it is only needed for old Odoo prefixes.
-    sequence_code = fields.Char("Sequence_code", required=False)
+    sequence_code = fields.Char(required=False)
 
     u_user_scans = fields.Selection(
         [("pallet", "Pallets"), ("package", "Packages"), ("product", "Products")],
@@ -93,7 +93,11 @@ class StockPickingType(models.Model):
     @api.model
     def create(self, vals):
         """
-        Purpose: If picking_type is to be full copy, then set the sequence_id on the record else set the sequence_code to the name 
+        Purpose: When copying the picking type, the sequence id is not copied. This can lead to issues when trying to create the picking type.
+        If the picking type is to be a direct copy then a search will be done for the original record and the sequence will be attached to the
+        new record. If it isn't going to be a direct copy i.e. have a different name, then the sequence code should be set. This can happen when
+        calling .copy(vals) on a record, where vals contains an updated name field. In this case the copied record will have the old Odoo style
+        prefix.  
         """
         Stockpickingtype = self.env["stock.picking.type"]
         stock_picking_type_record = Stockpickingtype.search([("name","=",vals["name"])])

--- a/addons/udes_stock/models/stock_warehouse.py
+++ b/addons/udes_stock/models/stock_warehouse.py
@@ -67,22 +67,17 @@ class StockWarehouse(models.Model):
             raise ValidationError(_("Cannot find picking types for warehouse %s.") % self.name)
 
         return picking_types
-    
+
     def _get_sequence_values(self):
         """
         Purpose: Overwrite the hardcoded sequence values. This will mean that when the warehouse is created the sequences for each picking type
         will not be created with the old Odoo prefix (The sequences should not be created at all). When the warehouse name is updated the
-        sequences for the picking types will not be updated with the old Odoo prefix. 
+        sequences for the picking types will not be updated with the old Odoo prefix.
         """
         return {
-            'in_type_id': {
-            },
-            'out_type_id': {
-            },
-            'pack_type_id': {
-            },
-            'pick_type_id': {
-            },
-            'int_type_id': {
-            },
+            "in_type_id": {},
+            "out_type_id": {},
+            "pack_type_id": {},
+            "pick_type_id": {},
+            "int_type_id": {},
         }

--- a/addons/udes_stock/models/stock_warehouse.py
+++ b/addons/udes_stock/models/stock_warehouse.py
@@ -67,3 +67,22 @@ class StockWarehouse(models.Model):
             raise ValidationError(_("Cannot find picking types for warehouse %s.") % self.name)
 
         return picking_types
+    
+    def _get_sequence_values(self):
+        """
+        Purpose: Overwrite the hardcoded sequence values. This will mean that when the warehouse is created the sequences for each picking type
+        will not be created with the old Odoo prefix (The sequences should not be created at all). When the warehouse name is updated the
+        sequences for the picking types will not be updated with the old Odoo prefix. 
+        """
+        return {
+            'in_type_id': {
+            },
+            'out_type_id': {
+            },
+            'pack_type_id': {
+            },
+            'pick_type_id': {
+            },
+            'int_type_id': {
+            },
+        }

--- a/addons/udes_stock/tests/__init__.py
+++ b/addons/udes_stock/tests/__init__.py
@@ -14,3 +14,4 @@ from . import test_stock_location
 from . import test_scanned_by
 from . import test_stock_picking_user_assignment
 from . import test_utils
+from . import test_stock_picking_type

--- a/addons/udes_stock/tests/test_stock_picking_type.py
+++ b/addons/udes_stock/tests/test_stock_picking_type.py
@@ -4,24 +4,27 @@ from . import common
 
 
 class TestStockPickingType(common.BaseUDES):
-    
     def test_writing_to_picking_type_does_reset_prefix_to_Odoo_style(self):
         Pickingtype = self.env["stock.picking.type"]
 
-        goods_out = Pickingtype.search([("name", "=", "Goods Out")])
+        goods_out = self.env.ref("stock.picking_type_out")
         goods_out_prefix = goods_out.sequence_id.prefix
         self.assertEqual(goods_out_prefix, "OUT")
 
         goods_out.write({"name": "Changed goods out", "sequence_code": "out"})
+
+        goods_out = self.env.ref("stock.picking_type_out")
         goods_out_prefix = goods_out.sequence_id.prefix
-        
+
         self.assertEqual(goods_out_prefix, "OUT")
 
         self.create_quant(self.apple.id, self.test_stock_location_01.id, 10)
         products_info = [{"product": self.apple, "uom_qty": 10}]
-        
         picking = self.create_picking(
-            picking_type=goods_out, products_info=products_info, confirm=True, location_dest_id=self.test_received_location_01.id,
+            picking_type=goods_out,
+            products_info=products_info,
+            confirm=True,
+            location_dest_id=self.test_received_location_01.id,
         )
 
-        self.assertEqual(bool(re.search(r"OUT\d{5}", picking.name)), True)
+        self.assertTrue(bool(re.fullmatch(r"OUT\d{5}", picking.name)))

--- a/addons/udes_stock/tests/test_stock_picking_type.py
+++ b/addons/udes_stock/tests/test_stock_picking_type.py
@@ -1,0 +1,27 @@
+import re
+
+from . import common
+
+
+class TestStockPickingType(common.BaseUDES):
+    
+    def test_writing_to_picking_type_does_reset_prefix_to_Odoo_style(self):
+        Pickingtype = self.env["stock.picking.type"]
+
+        goods_out = Pickingtype.search([("name", "=", "Goods Out")])
+        goods_out_prefix = goods_out.sequence_id.prefix
+        self.assertEqual(goods_out_prefix, "OUT")
+
+        goods_out.write({"name": "Changed goods out", "sequence_code": "out"})
+        goods_out_prefix = goods_out.sequence_id.prefix
+        
+        self.assertEqual(goods_out_prefix, "OUT")
+
+        self.create_quant(self.apple.id, self.test_stock_location_01.id, 10)
+        products_info = [{"product": self.apple, "uom_qty": 10}]
+        
+        picking = self.create_picking(
+            picking_type=goods_out, products_info=products_info, confirm=True, location_dest_id=self.test_received_location_01.id,
+        )
+
+        self.assertEqual(bool(re.search(r"OUT\d{5}", picking.name)), True)

--- a/addons/udes_stock/tests/test_stock_warehouse.py
+++ b/addons/udes_stock/tests/test_stock_warehouse.py
@@ -1,3 +1,5 @@
+import re
+
 from .common import BaseUDES
 
 
@@ -26,18 +28,28 @@ class TestStockWarehouseModel(BaseUDES):
         new_warehouse = self.Warehouse.search([("company_id", "=", test_company.id)])
         test_picking_types = new_warehouse.get_picking_types()
         self.assertEqual(len(test_picking_types), 3)
-    
+
     def test_check_picking_types_prefix_after_updating_warehouse_code(self):
         """
-        Test that making changes to the warehouse does not cause the pickingtype prefixes to be reset. 
-        """ 
-        Pickingtype = self.env["stock.picking.type"]
-        
-        goods_in_prefix = Pickingtype.search([("name", "=", "Goods In")]).sequence_id.prefix
-        self.assertEqual(goods_in_prefix, "IN")
-        
-        self.warehouse.write({"code":"NEW_WAREHOUSE_CODE"})
-
-        goods_in_prefix = Pickingtype.search([("name", "=", "Goods In")]).sequence_id.prefix
+        Test that making changes to the warehouse does not cause the picking type prefixes to be reset.
+        """
+        goods_in = self.env.ref("stock.picking_type_in")
+        goods_in_prefix = goods_in.sequence_id.prefix
         self.assertEqual(goods_in_prefix, "IN")
 
+        self.warehouse.write({"code": "NEW_WAREHOUSE_CODE"})
+
+        goods_in = self.env.ref("stock.picking_type_in")
+        goods_in_prefix = goods_in.sequence_id.prefix
+        self.assertEqual(goods_in_prefix, "IN")
+
+        self.create_quant(self.apple.id, self.test_stock_location_01.id, 10)
+        products_info = [{"product": self.apple, "uom_qty": 10}]
+        picking = self.create_picking(
+            picking_type=goods_in,
+            products_info=products_info,
+            confirm=True,
+            location_dest_id=self.test_received_location_01.id,
+        )
+
+        self.assertTrue(bool(re.fullmatch(r"IN\d{5}", picking.name)))

--- a/addons/udes_stock/tests/test_stock_warehouse.py
+++ b/addons/udes_stock/tests/test_stock_warehouse.py
@@ -7,22 +7,37 @@ class TestStockWarehouseModel(BaseUDES):
         super(TestStockWarehouseModel, cls).setUpClass()
         cls.Warehouse = cls.env["stock.warehouse"]
 
-    def test01_get_test_picking_types(self):
+    def test_can_find_expected_picking_type(self):
         """Test checks if the test picking types are present"""
         test_picking_types = self.warehouse.get_picking_types().filtered(
             lambda pt: "TEST" in pt.name
         )
         self.assertEqual(len(test_picking_types), 6)
 
-    def test02_get_picking_types(self):
+    def test_finds_expected_number_of_picking_types(self):
         """Test checks if the test picking types and the normal pick types are present"""
         test_picking_types = self.warehouse.get_picking_types()
         self.assertEqual(len(test_picking_types), 9)
 
-    def test03_get_default_picking_types_new_warehouse(self):
+    def test_get_default_picking_types_new_warehouse(self):
         """Create a new warehouse and look at the default picking types"""
         # Create a new company creates a new warehouse
         test_company = self.create_company("test_company")
         new_warehouse = self.Warehouse.search([("company_id", "=", test_company.id)])
         test_picking_types = new_warehouse.get_picking_types()
         self.assertEqual(len(test_picking_types), 3)
+    
+    def test_check_picking_types_prefix_after_updating_warehouse_code(self):
+        """
+        Test that making changes to the warehouse does not cause the pickingtype prefixes to be reset. 
+        """ 
+        Pickingtype = self.env["stock.picking.type"]
+        
+        goods_in_prefix = Pickingtype.search([("name", "=", "Goods In")]).sequence_id.prefix
+        self.assertEqual(goods_in_prefix, "IN")
+        
+        self.warehouse.write({"code":"NEW_WAREHOUSE_CODE"})
+
+        goods_in_prefix = Pickingtype.search([("name", "=", "Goods In")]).sequence_id.prefix
+        self.assertEqual(goods_in_prefix, "IN")
+

--- a/addons/udes_stock/views/stock_picking_type.xml
+++ b/addons/udes_stock/views/stock_picking_type.xml
@@ -20,6 +20,10 @@
                     <field name="u_enable_unpickable_items" />
                 </group>
             </xpath>
+
+            <!-- Not needed for UDES as in only applicable to Odoo style prefix -->
+            <xpath expr="//field[@name='sequence_code']" position="replace"/>
+
         </field>
     </record>
 


### PR DESCRIPTION
[IMP] udes_stock: Ensure that the prefixes of picking types are consistent with the UDES style and not Odoo's style.

The sequence_code field is not needed in UDES as it is used strictly in the Odoo style sequence (which we do not want). When updating picking_types, if there was sequence_code field in the values to update, Odoo was hardcoded to update the sequences on the picking types to the Odoo prefix style. This resulted in changes to prefixes when changing data on the picking type, such as updating the picking_type with data that set a sequence_code.

Additionally when the warehouse is created or updated with a new name or code, Odoo would update the picking type sequence prefixes.  _get_sequence_values() was were these new picking_type sequences prefixes were generated. This method has been overwritten to prevent this from happening.

Some unit tests were added to ensure that writing to a picking type or updating the warehouse name didn't result in a change to the picking type sequence prefix.

Story/1805

Signed off by: Jack Birch <jack.birch@unipart.io>