### PR TITLE
[FIX] udes_stock: Do not change parent package if no quantity specified

### DIFF
--- a/addons/udes_stock/models/stock_inventory.py
+++ b/addons/udes_stock/models/stock_inventory.py
@@ -438,7 +438,9 @@ class StockInventoryLine(models.Model):
     def _update_package_parent(self):
         """Update Package's Parent Package if it has been updated on the Inventory Line"""
         for line in self.filtered(
-            lambda l: l.package_id and l.u_result_parent_package_id != l.u_package_parent_package_id
+            lambda l: l.package_id
+            and l.u_result_parent_package_id != l.u_package_parent_package_id
+            and l.product_qty != 0 
         ):
             line.package_id.sudo().write({"package_id": line.u_result_parent_package_id.id})
 


### PR DESCRIPTION
This was a side-issue discovered during sign off, prevents zeroed lines with pallet change information from actually changing pallet information.

If a quantity is specified, then the parent package change still needs to occur, but in instances where no quantity is specified, then either moves will be generated to write off the quantity, or (if no theoretical quantity) nothing will happen with any quants

Signed-off-by: Peter Alabaster <peter.alabaster@unipart.io>

User-story: 1402