### PR TITLE
[FIX] udes_stock_refactoring: Always set value for grouping key

### DIFF
--- a/addons/udes_stock_refactoring/models/stock_move.py
+++ b/addons/udes_stock_refactoring/models/stock_move.py
@@ -47,20 +47,22 @@ class StockMove(models.Model):
 
         # The environment must include {'compute_key': True}
         # to allow the keys to be computed.
-        if not self._context.get("compute_key", False):
-            return
+        compute_key = self.env.context.get("compute_key")
+
         for move in self:
-            format_str = move.picking_id.picking_type_id.u_move_key_format
-            if not format_str:
-                move.u_grouping_key = None
-            else:
-                # Generating a list of fields that are in u_move_key_format.
-                move_fields = StockPickingType.get_fields_from_key_format(format_str)
-                move_vals = {
-                    field_name: move[field_name]
-                    for field_name in move_fields
-                }
-                move.u_grouping_key = format_str.format(**move_vals)
+            grouping_key = None
+            if compute_key:
+                format_str = move.picking_id.picking_type_id.u_move_key_format
+                if format_str:
+                    # Generating a list of fields that are in u_move_key_format.
+                    move_fields = StockPickingType.get_fields_from_key_format(format_str)
+                    move_vals = {
+                        field_name: move[field_name]
+                        for field_name in move_fields
+                    }
+                    grouping_key = format_str.format(**move_vals)
+
+            move.u_grouping_key = grouping_key
 
     u_grouping_key = fields.Char("Key", compute="_compute_grouping_key")
 

--- a/addons/udes_stock_refactoring/models/stock_move_line.py
+++ b/addons/udes_stock_refactoring/models/stock_move_line.py
@@ -11,22 +11,25 @@ class StockMoveLine(models.Model):
     def _compute_grouping_key(self):
         """Compute grouping key from move line"""
         StockPickingType = self.env["stock.picking.type"]
+
         # The environment must include {'compute_key': True}
         # to allow the keys to be computed.
-        if not self.env.context.get("compute_key", False):
-            return
+        compute_key = self.env.context.get("compute_key")
+
         for move_line in self:
-            format_str = move_line.picking_id.picking_type_id.u_move_line_key_format
-            if not format_str:
-                move_line.u_grouping_key = None
-            else:
-                # Generating a list of fields that are in u_move_line_key_format.
-                move_line_fields = StockPickingType.get_fields_from_key_format(format_str)
-                move_line_vals = {
-                    field_name: move_line[field_name]
-                    for field_name in move_line_fields
-                }
-                move_line.u_grouping_key = format_str.format(**move_line_vals)
+            grouping_key = None
+            if compute_key:
+                format_str = move_line.picking_id.picking_type_id.u_move_line_key_format
+                if format_str:
+                    # Generating a list of fields that are in u_move_line_key_format.
+                    move_line_fields = StockPickingType.get_fields_from_key_format(format_str)
+                    move_line_vals = {
+                        field_name: move_line[field_name]
+                        for field_name in move_line_fields
+                    }
+                    grouping_key = format_str.format(**move_line_vals)
+
+            move_line.u_grouping_key = grouping_key
 
     def group_by_key(self):
         """Check each picking type has a move line key format set and return the groupby"""


### PR DESCRIPTION
When computing the grouping key for Move/Move Line,
if `compute_key` was not in context then the compute method was
previously returning without assigning a value.
In Odoo 14 this is not allowed and will lead to an exception.

To avoid this Move/Move Line will have None set by default.

Signed-off-by: Peter Clark <peter.clark@unipart.io>