### PR TITLE
[ADD] udes_stock: Security groups added to Admin user by default

### DIFF
--- a/addons/udes_stock/data/res_users.xml
+++ b/addons/udes_stock/data/res_users.xml
@@ -1,7 +1,13 @@
 <odoo>
   <data noupdate="0">
     <record id="base.user_root" model="res.users">
-      <field name="groups_id" eval="[(4, ref('udes_stock.group_manage_reserved_packages'))]"/>
+      <field name="groups_id" eval=
+      "[
+        (4, ref('udes_stock.group_manage_reserved_packages')),
+        (4, ref('udes_stock.group_inbound_user')),
+        (4, ref('udes_stock.group_outbound_user')),
+        (4, ref('udes_stock.group_stock_manager')),
+      ]"/>
     </record>
   </data>
 </odoo>


### PR DESCRIPTION
Admin user is not restricted by ACLs, however there are some instances
where specifc user groups are checked against a user, so the
inbound/outbound/stock groups have been added to the user to ensure
it will not have operations blocked because it lacks any of these
groups.

Issue/2297

Signed-off-by: Peter Clark <peter.clark@unipart.io>