### PR TITLE
Story/2423 - Fix bug for removing all pickings from a batch.

### DIFF
--- a/addons/udes_stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/udes_stock_picking_batch/models/stock_picking_batch.py
@@ -33,9 +33,8 @@ class StockPickingBatch(models.Model):
             "ready": lambda spb: spb.write({"state": "draft"}),
         },
     )
+    # Allow pickings to be editable in waiting and ready states
     picking_ids = fields.One2many(
-        "stock.picking",
-        "batch_id",
         states={
             "draft": [("readonly", False)],
             "waiting": [("readonly", False)],
@@ -43,6 +42,8 @@ class StockPickingBatch(models.Model):
             "in_progress": [("readonly", False)],
         },
     )
+    # Don't allow picking move lines to be edited via batch
+    move_line_ids = fields.One2many(inverse=None, states=None)
     u_last_reserved_pallet_name = fields.Char(
         string="Last Pallet Used",
         index=True,

--- a/addons/udes_stock_picking_batch/views/stock_picking_batch.xml
+++ b/addons/udes_stock_picking_batch/views/stock_picking_batch.xml
@@ -40,6 +40,11 @@
         <xpath expr="//field[@name='picking_ids']" position="attributes">
           <attribute name="force_save">1</attribute>
         </xpath>
+
+        <!-- Show transfers page first -->
+        <xpath expr="//field[@name='move_line_ids']/parent::page" position="before">
+          <xpath expr="//field[@name='picking_ids']/parent::page" position="move"/>
+        </xpath>
       </field>
     </record>
 

--- a/addons/udes_stock_picking_batch/views/stock_picking_batch.xml
+++ b/addons/udes_stock_picking_batch/views/stock_picking_batch.xml
@@ -35,6 +35,11 @@
         <xpath expr="//button[@name='action_done']" position="attributes">
           <attribute name="invisible">1</attribute>
         </xpath>
+
+        <!-- Save changes to picking_ids even when it has been set to readonly via state change -->
+        <xpath expr="//field[@name='picking_ids']" position="attributes">
+          <attribute name="force_save">1</attribute>
+        </xpath>
       </field>
     </record>
 


### PR DESCRIPTION
Removing all pickings sets batch state as done, which makes picking_ids readonly, leading to the changes not being saved.