### PR TITLE
Fix failing udes_get_info test

### DIFF
--- a/addons/udes_get_info/__manifest__.py
+++ b/addons/udes_get_info/__manifest__.py
@@ -6,7 +6,7 @@
     "website": "http://github/unipartdigital/udes-open",
     "category": "UDES",
     "version": "0.1",
-    "depends": ["base", "stock", "udes_common"],
+    "depends": ["base", "stock", "stock_picking_batch", "udes_common"],
     "data": [],
     "demo": [],
 }

--- a/addons/udes_get_info/models/models.py
+++ b/addons/udes_get_info/models/models.py
@@ -65,8 +65,10 @@ def _get_info(self, level, info_fields, extra_fields):
         result = self[field_name]
         if isinstance(self[field_name], models.BaseModel):
             # Stop recursing once we reach level zero or if the field is empty.
-            if (level == 0) or (not result):
+            if level == 0:
                 continue
+            if not result:
+                _info = False
             # If field is Many2one return dict, otherwise list of dicts.
             # Passing extra fields means that it will look for extra fields on every level.
             # Example if needed default_barcode from product and the field is not
@@ -74,7 +76,7 @@ def _get_info(self, level, info_fields, extra_fields):
             # from quants we can call it like: quants.get_info(extra_fields={"default_barcode"})
             # Note: default_barcode will be picked from every model that field exist and will
             # log a messsage for every model where it is not found.
-            if isinstance(self._fields.get(field_name), fields.Many2one):
+            elif isinstance(self._fields.get(field_name), fields.Many2one):
                 _info = result._get_info(
                     level=level - 1, info_fields=info_fields, extra_fields=extra_fields
                 )

--- a/addons/udes_get_info/tests/test_stock_quant.py
+++ b/addons/udes_get_info/tests/test_stock_quant.py
@@ -30,6 +30,7 @@ class StockQuantGetInfoTestCase(common.BaseTestCase, common.GetInfoTestMixin):
                 "package_id",
                 "product_id",
                 "quantity",
+                "lot_id",
                 "reserved_quantity",
             ]
         )


### PR DESCRIPTION
Returning false for related fields when they don't have value, in
this way we always will have the expected fields on get_info.