### PR TITLE
[REM] udes_stock_inventory: Remove Inventory help text override

### DIFF
--- a/addons/udes_stock_inventory/views/stock_inventory_views.xml
+++ b/addons/udes_stock_inventory/views/stock_inventory_views.xml
@@ -1,20 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <!-- Remove the barcode ad from the tree view help text. -->
-    <record id="stock.action_inventory_form" model="ir.actions.act_window">
-        <field name="help" type="html">
-            <p class="oe_view_nocontent_create">
-            Click to start an Inventory Adjustment.
-        </p>
-            <p>
-            Periodical Inventory Adjustments are used to count the number of products
-            available per location. You can use it once a year when you do
-            the general inventory or whenever you need it, to adapt the
-            current inventory level of a product.
-        </p>
-        </field>
-    </record>
-
     <record id="view_inventory_form" model="ir.ui.view">
         <field name="name">stock.inventory.form.udes_stock_inventory</field>
         <field name="model">stock.inventory</field>


### PR DESCRIPTION
Was removed as part of story 2183, but accidentally added back as the
override was moved from udes_stock to udes_stock_inventory.

Story/2466

Signed-off-by: Peter Clark <peter.clark@unipart.io>