### PR TITLE
[IMP] udes_stock: Set Replen to inactive by default

### DIFF
--- a/addons/udes_stock/data/picking_types.xml
+++ b/addons/udes_stock/data/picking_types.xml
@@ -105,7 +105,7 @@
       <field name="default_location_src_id" ref="stock.stock_location_stock"/>
       <field name="default_location_dest_id" ref="stock.stock_location_output"/>
       <field name="show_operations" eval="1"/>
-      <field name="active">True</field>
+      <field name="active">False</field>
     </record>
 
   </data>

--- a/addons/udes_stock/data/routes.xml
+++ b/addons/udes_stock/data/routes.xml
@@ -6,7 +6,8 @@
       <field name="name">Replen</field>
       <field name="company_id" ref="base.main_company"/>
       <field name="sequence">10</field>
-    </record>    
+       <field name="active">False</field>
+    </record>
 
     <!-- Create new pull rule with stock as procurement location -->
     <record id="procurement_replen" model="stock.rule">
@@ -18,6 +19,7 @@
       <field name="action">pull</field>
       <field name="picking_type_id" ref="udes_stock.picking_type_replen"/>
       <field name="warehouse_id" ref="stock.warehouse0"/>
+       <field name="active">False</field>
     </record>
   </data>
 </odoo>


### PR DESCRIPTION
Set Replen picking type and routes to inactive by default. To be enabled by config in relevant modules.

Signed-off-by: Adam Patrick <adam.patrick@unipart.io>