### PR TITLE
[IMP] udes_stock: Implement delivery slip for multiple source documents

### DIFF
--- a/addons/udes_stock/report/deliveryslip_templates.xml
+++ b/addons/udes_stock/report/deliveryslip_templates.xml
@@ -7,147 +7,152 @@
 
             <t t-call="udes_stock.external_layout">
 
-                <t t-set="o" t-value="o.with_context({'lang':o.partner_id.lang})" />
+                <t t-set="o" t-value="o.with_context({'lang':o.partner_id.lang})"/>
 
-                    <t t-if="o.state != 'done'">
-                        <h1>
-                            DRAFT
-                        </h1>
-                    </t>
+                <t t-if="o.state != 'done'">
+                    <h1>
+                        DRAFT
+                    </h1>
+                </t>
 
-                    <h2>
-                        Delivery Slip
-                    </h2>
+                <h2>
+                    Delivery Slip
+                </h2>
 
-                    <!-- To avoid to break sale_stock -->
-                    <div name="customer_address" />
-                    <div name="div_sched_date" />
+                <!-- To avoid to break sale_stock -->
+                <div name="customer_address"/>
+                <div name="div_sched_date"/>
 
-                    <table class="table table-condensed">
-                        <thead>
-                            <tr>
-                                <th><strong>Trailer number</strong></th>
-                                <th><strong>Trailer unit ID</strong></th>
-                                <th><strong>Vehicle registration</strong></th>
-                                <th><strong>Driver name</strong></th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr>
-                                <td>
-                                    <span t-field="o.u_vehicle_sequence"/>
-                                </td>
-                                <td>
-                                    <span t-field="o.u_vehicle_description"/>
-                                </td>
-                                <td>
-                                    <span t-field="o.u_vehicle_registration"/>
-                                </td>
-                                <td>
-                                    <span t-field="o.u_driver_name"/>
-                                </td>
-                            </tr>
-
-                            <t t-if="o.partner_id">
-                                <tr>
-                                    <th colspan="2" style="padding-top: 40px" />
-                                    <th colspan="2" style="padding-top: 40px"><strong>Customer address</strong></th>
-                                </tr>
-                                <tr>
-                                    <td colspan="2" />
-                                    <td colspan="2">
-                                        <span t-field="o.partner_id"
-                                           t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True}'/>
-                                    </td>
-                                </tr>
-                            </t>
-
-                            <tr>
-                                <th colspan="2" style="padding-top: 40px" t-if="o.origin">
-                                    <strong>Order Reference</strong>
-                                </th>
-                                <th colspan="2" style="padding-top: 40px" name="td_sched_date_h">
-                                    <strong>Date</strong>
-                                </th>
-                            </tr>
-                            <tr>
-                                <td colspan="2">
-                                    <t t-foreach="set(o.mapped('u_first_picking_ids.origin'))" t-as="origin">
-                                        <strong><span t-esc="origin"/></strong>
-                                    </t>
-                                </td>
-                                <td colspan="2" name="td_sched_date">
-                                   <t t-if="o.state == 'done'">
-                                        <span t-field="o.date_done"/>
-                                   </t>
-                                   <t t-if="o.state != 'done'">
-                                        <span t-field="o.scheduled_date"/>
-                                   </t>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-
-                    <table class="table table-condensed">  
-                        <t t-set="has_serial_number" t-value="o.move_line_ids.mapped('lot_id')" groups="stock.group_production_lot"/>
-                        <thead>  
-                            <tr>
-                                  <th style="padding-top: 40px"><strong>Pallet</strong></th>
-                                  <th style="padding-top: 40px"><strong>Product</strong></th>
-                                  <th name="lot_serial" t-if="has_serial_number">
-                                        Lot/Serial Number
-                                  </th>
-                                  <th style="padding-top: 40px"><strong>Ordered Quantity</strong></th>
-                                  <th style="padding-top: 40px"><strong>Sent Quantity</strong></th>
-                            </tr>
-                        </thead>
-                        <tbody>    
-                            <tr t-if="not o.move_line_ids" t-foreach="o.move_lines" t-as="move">
-                                <td></td>
-                                <td><span t-field="move.product_id"/></td>
-                                <td t-if="has_serial_number"></td>
-                                <td><span t-field="move.product_uom_qty"/></td>
-                                <td><span t-field="move.quantity_done"/></td>
-                            </tr>
-                            <tr t-if="o.move_line_ids" t-foreach="o.move_line_ids" t-as="move_line">
-                                <td>
-                                    <t t-if="move_line.package_id">
-                                        <span t-field="move_line.package_id"/>
-                                    </t>
-                                </td>
-                                <td>
-                                    <span t-field="move_line.product_id"/>
-                                    <p t-if="o.picking_type_code == 'outgoing'">
-                                        <span t-field="move_line.product_id.sudo().description_pickingout"/>
-                                    </p>
-                                    <p t-if="o.picking_type_code == 'incoming'">
-                                        <span t-field="move_line.product_id.sudo().description_pickingin"/>
-                                    </p>
-                                </td>
-                                <t t-if="has_serial_number">
-                                   <td>
-                                        <table width="100%">
-                                            <tr>
-                                                <td>
-                                                     <span t-field="move_line.lot_id"/>
-                                                     <t t-if="not move_line.lot_id">
-                                                         <span t-field="move_line.lot_name"/>
-                                                     </t>
-                                                 </td>
-                                                 <td name="lot_qty">
-                                                     <t t-if="move_line.product_qty"> 
-                                                        <span t-field="move_line.product_qty"/>
-                                                    </t>
-                                                </td>
-                                            </tr>
-                                        </table>
-                                  </td>
+                <table class="table" style="border:0px solid transparent;">
+                    <tbody>
+                        <tr style="border:0px solid transparent;">
+                            <td style="border:0px solid transparent;">
+                                <strong>Reference: </strong>
+                                <span t-field="o.name"/>
+                            </td>
+                            <td style="border:0px solid transparent;">
+                                <span style="padding:0 0px 0 50%;">
+                                <strong>Date: </strong>
+                                <t t-if="o.state == 'done'">
+                                    <span t-esc="o.date_done.strftime('%d-%m-%Y %H:%M')"/>
                                 </t>
-                                <td><span t-esc="round(move_line.move_id.u_uom_initial_demand)"/></td>
-                                <td><span t-field="move_line.qty_done"/></td>
+                                <t t-if="o.state != 'done'">
+                                    <span t-esc="o.scheduled_date.strftime('%d-%m-%Y %H:%M')"/>
+                                </t>
+                                </span>
+                            </td>
+                        </tr>
+                        <t t-if="o.partner_id">
+                            <tr style="border:0px solid transparent">
+                                <td style="border:0px solid transparent">
+                                    <strong>Customer address</strong>
+                                </td>
                             </tr>
-                        </tbody>
-                    </table>
+                            <tr style="border:0px solid transparent">
+                                <td style="border:0px solid transparent">
+                                    <span t-field="o.partner_id"
+                                       t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True}'/>
+                                </td>
+                            </tr>
+                        </t>
+                    </tbody>
+                </table>
+
+                <table class="table table-condensed">
+                    <thead>
+                        <tr>
+                            <th><strong>Trailer Number</strong></th>
+                            <th><strong>Trailer Unit ID</strong></th>
+                            <th><strong>Vehicle Registration</strong></th>
+                            <th><strong>Driver Name</strong></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>
+                                <span t-field="o.u_vehicle_sequence"/>
+                            </td>
+                            <td>
+                                <span t-field="o.u_vehicle_description"/>
+                            </td>
+                            <td>
+                                <span t-field="o.u_vehicle_registration"/>
+                            </td>
+                            <td>
+                                <span t-field="o.u_driver_name"/>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+
+                <table class="table table-condensed">
+                    <t t-set="has_serial_number" t-value="o.move_line_ids.mapped('lot_id')"
+                       groups="stock.group_production_lot"/>
+                    <thead>
+                        <tr>
+                            <th style="padding-top: 40px"><strong>Order Ref.</strong></th>
+                            <th style="padding-top: 40px"><strong>Pallet No.</strong></th>
+                            <th style="padding-top: 40px"><strong>Product</strong></th>
+                            <th name="lot_serial" t-if="has_serial_number">
+                                Lot/Serial Number
+                            </th>
+                            <th style="padding-top: 40px"><strong>Ordered Qty.</strong></th>
+                            <th style="padding-top: 40px"><strong>Sent Qty.</strong></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr t-if="not o.move_line_ids" t-foreach="o.move_lines" t-as="move">
+                            <td><span t-field="move.origin"/></td>
+                            <td></td>
+                            <td><span t-field="move.product_id"/></td>
+                            <td t-if="has_serial_number"></td>
+                            <td><span t-field="move.product_uom_qty"/></td>
+                            <td><span t-field="move.quantity_done"/></td>
+                        </tr>
+                        <tr t-if="o.move_line_ids" t-foreach="o.move_line_ids" t-as="move_line">
+                            <td>
+                                <t t-if="move_line.origin">
+                                    <span t-field="move_line.origin"/>
+                                </t>
+                            </td>
+                            <td>
+                                <t t-if="move_line.package_id">
+                                    <span t-field="move_line.package_id"/>
+                                </t>
+                            </td>
+                            <td>
+                                <span t-field="move_line.product_id"/>
+                                <p t-if="o.picking_type_code == 'outgoing'">
+                                    <span t-field="move_line.product_id.sudo().description_pickingout"/>
+                                </p>
+                                <p t-if="o.picking_type_code == 'incoming'">
+                                    <span t-field="move_line.product_id.sudo().description_pickingin"/>
+                                </p>
+                            </td>
+                            <t t-if="has_serial_number">
+                                <td>
+                                    <table width="100%">
+                                        <tr>
+                                            <td>
+                                                <span t-field="move_line.lot_id"/>
+                                                <t t-if="not move_line.lot_id">
+                                                    <span t-field="move_line.lot_name"/>
+                                                </t>
+                                            </td>
+                                            <td name="lot_qty">
+                                                <t t-if="move_line.product_qty">
+                                                    <span t-field="move_line.product_qty"/>
+                                                </t>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </td>
+                            </t>
+                            <td><span t-esc="round(move_line.move_id.u_uom_initial_demand)"/></td>
+                            <td><span t-field="move_line.qty_done"/></td>
+                        </tr>
+                    </tbody>
+                </table>
             </t>
         </t>
     </template>


### PR DESCRIPTION
Add source document to each stock move line. Rename table headings and
add picking reference number.

Story: x2422

Signed-off-by: Lorenzo Cucurachi <lorenzo.cucurachi@unipart.io>