### PR TITLE
[IMP] udes_stock: Unskip test_priority_one_remains_on_done_picking

### DIFF
--- a/addons/udes_stock/tests/test_stock_picking.py
+++ b/addons/udes_stock/tests/test_stock_picking.py
@@ -1,4 +1,3 @@
-import unittest
 from unittest.mock import patch
 
 from odoo.exceptions import ValidationError, UserError
@@ -1887,7 +1886,6 @@ class TestStockPickingPriorities(common.BaseUDES):
         self.pick.action_cancel()
         self.assertEqual(self.pick.priority, "0")
 
-    @unittest.skip("Needs odoo-tester:14.0 image rebuilding")
     def test_priority_one_remains_on_done_picking(self):
         """
         Test that priority 1 is not overwritten on done pickings.


### PR DESCRIPTION
Temporary skip removed.

Signed-off-by: Peter Clark <peter.clark@unipart.io>