### PR TITLE
[FIX] udes_security: Harden _get_menu_info_from_action_id

### DIFF
--- a/addons/udes_security/controllers/main.py
+++ b/addons/udes_security/controllers/main.py
@@ -80,7 +80,10 @@ class SecureAction(Action):
         parent_path_ids = []
 
         if not isinstance(action_id, int):
-            raise ValidationError("Invalid action ID specified.")
+            try:
+                action_id = int(action_id)
+            except ValueError:
+                raise ValidationError("Invalid action ID specified.")
         query = """
             SELECT
                 menu.id AS menu_id,


### PR DESCRIPTION
Handle case where action_id is string, e.g. if an action is specified
in a view for another XML record.

Signed-off-by: Peter Clark <peter.clark@unipart.io>