### PR TITLE
[IMP] udes_security: Port of redirection domain filter list

### DIFF
--- a/addons/udes_security/__manifest__.py
+++ b/addons/udes_security/__manifest__.py
@@ -21,6 +21,8 @@
         "views/no_desktop_access_template_views.xml",
         "data/allowed_file_type_data.xml",
         "views/res_config_settings_view.xml",
+        "data/setup_default_domains.xml",
+        "views/domain_allowlist_view.xml",
     ],
     "demo": [],
 }

--- a/addons/udes_security/controllers/redirect.py
+++ b/addons/udes_security/controllers/redirect.py
@@ -1,9 +1,70 @@
 import logging
-from odoo import http
+from odoo import http, _
 from odoo.addons.web.controllers import main
 from odoo.http import request
+from werkzeug import urls, url_unquote
+from werkzeug.exceptions import BadRequest
+from fnmatch import fnmatch
 
 _logger = logging.getLogger(__name__)
+
+
+class no_absolute_redirect(object):
+    """Decorator to mark a route as forbidding absolute redirects
+
+    If the decorated route is called with a "redirect" query parameter
+    containing an absolute URL, the request will be terminated with an
+    exception.
+    """
+
+    def __init__(self, func):
+        self.func = func
+
+    @property
+    def __name__(self):
+        """Copy original method name
+
+        This is required since the method name will be introspected as
+        part of calculating the controller inheritance structure.
+        """
+        return self.func.__name__
+
+    def __call__(self, *args, **kwargs):
+        """Call method"""
+        redirect = kwargs.get("redirect")
+
+        if redirect:
+            redirect = url_unquote(redirect)
+            if redirect.startswith("//"):
+                # remove leading /'s which can trick the url parser but is handled by browsers
+                kwargs["redirect"] = "/" + redirect.lstrip("/")
+            else:
+                parsed_url = urls.url_parse(redirect)
+
+                if self.is_absolute_url(parsed_url) and not self.domain_is_allowlisted(parsed_url):
+                    _logger.error("Invalid redirection attempted: %s", redirect)
+                    raise BadRequest(_("Invalid redirection attempted"))
+
+        return self.func(*args, **kwargs)
+
+    @staticmethod
+    def is_absolute_url(parsed_url):
+        """Returns True if URL is an absolute URL, else False"""
+        return True if bool(parsed_url.scheme) or bool(parsed_url.netloc) else False
+
+    @classmethod
+    def domain_is_allowlisted(cls, parsed_url):
+        """Returns True if a URL domain is listed in the allowlist"""
+        DomainAllowlist = http.request.env["udes_security.domain.allowlist"]
+        query_domain = parsed_url.host
+
+        if DomainAllowlist.search([("domain", "=", parsed_url.host)]):
+            return True
+        else:
+            for allow_domain in DomainAllowlist.search([]):
+                if fnmatch(query_domain, allow_domain.domain):
+                    return True
+        return False
 
 
 class Home(main.Home):
@@ -32,6 +93,7 @@ class Home(main.Home):
             self._disable_debug(request)
 
     @http.route()
+    @no_absolute_redirect
     def web_client(self, *args, **kwargs):
         """
         Override API to check debug privileges. Mostly, ensure right users can activate debug.
@@ -40,6 +102,7 @@ class Home(main.Home):
         return super().web_client(*args, **kwargs)
 
     @http.route()
+    @no_absolute_redirect
     def web_login(self, *args, **kwargs):
         """
         Override API to check debug privileges. In the login case, we also do not want to show

--- a/addons/udes_security/data/res_groups.xml
+++ b/addons/udes_security/data/res_groups.xml
@@ -41,4 +41,13 @@
         <field name="u_required_group_id_to_change" ref="base.group_system" />
     </record>
 
+    <record id="group_edit_allowlist_redirect_domains" model="res.groups">
+        <field name="name">Manage Allowed Redirect Domains</field>
+        <field name="category_id" ref="base.module_category_extra" />
+    </record>
+    <!-- Cannot self reference, so we extend the record after we create it -->
+    <record id="udes_security.group_edit_allowlist_redirect_domains" model="res.groups">
+        <field name="u_required_group_id_to_change" ref="udes_security.group_edit_allowlist_redirect_domains" />
+    </record>
+
 </odoo>

--- a/addons/udes_security/data/res_users.xml
+++ b/addons/udes_security/data/res_users.xml
@@ -5,6 +5,7 @@
                 (4, ref('udes_security.group_can_add_trusted_user')),
                 (4, ref('udes_security.group_trusted_user')),
                 (4, ref('udes_security.group_edit_allowed_file_types')),
+                (4, ref('udes_security.group_edit_allowlist_redirect_domains')),
             ]"/>
         </record>
 
@@ -13,6 +14,7 @@
                 (4, ref('udes_security.group_can_add_trusted_user')),
                 (4, ref('udes_security.group_trusted_user')),
                 (4, ref('udes_security.group_edit_allowed_file_types')),
+                (4, ref('udes_security.group_edit_allowlist_redirect_domains')),
             ]"/>
         </record>
 

--- a/addons/udes_security/data/setup_default_domains.xml
+++ b/addons/udes_security/data/setup_default_domains.xml
@@ -1,0 +1,5 @@
+<odoo>
+    <data>
+        <function model="udes_security.domain.allowlist" name="_setup_default_domains"/>
+    </data>
+</odoo>

--- a/addons/udes_security/models/__init__.py
+++ b/addons/udes_security/models/__init__.py
@@ -3,3 +3,4 @@ from . import res_users
 from . import allowed_file_type
 from . import ir_attachment
 from . import ir_module_category
+from . import domain_allowlist

--- a/addons/udes_security/models/domain_allowlist.py
+++ b/addons/udes_security/models/domain_allowlist.py
@@ -1,0 +1,83 @@
+from odoo import models, fields, api, service, _
+import re
+import ast
+from werkzeug import urls
+
+WILDCARD_PART_CHECK = re.compile("[\*|\?|\]](?!\.)")
+WILDCARD_ENDING_CHECK = re.compile("\*$")
+
+
+class DomainAllowlist(models.Model):
+    _name = "udes_security.domain.allowlist"
+    _description = "List of allowed domains"
+
+    name = fields.Char(required=True)
+    domain = fields.Char(required=True)
+    active = fields.Boolean(default=True)
+
+    def _get_host(self):
+        return urls.url_parse(self.env["ir.config_parameter"].sudo().get_param("web.base.url")).host
+
+    @api.model
+    def _setup_default_domains(self):
+        allowlist = list(
+            ast.literal_eval(service.server.config.get_misc("udes", "domain_allowlist", "[]"))
+        )
+        # Get host url
+        allowlist.append(self._get_host())
+
+        already_in_list = self.search([]).mapped("domain")
+        for allowed_domain in allowlist:
+            if allowed_domain not in already_in_list:
+                self.create(
+                    {
+                        "name": _("Default: %s") % allowed_domain,
+                        "domain": allowed_domain,
+                        "active": True,
+                    }
+                )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        """Extend create to massage domain if someone gives a url"""
+        for values in vals_list:
+            domain = values.get("domain")
+            if domain:
+                parsed_domain = urls.url_parse(domain)
+                # Note: if domain is just the domain then it will appear in path not netloc
+                values["domain"] = parsed_domain.netloc or parsed_domain.path
+        return super().create(vals_list)
+
+    def write(self, values):
+        """Extend write to massage domain if someone gives a url"""
+        domain = values.get("domain")
+        if domain:
+            parsed_domain = urls.url_parse(domain)
+            # Note: if domain is just the domain then it will appear in path not netloc
+            values["domain"] = parsed_domain.netloc or parsed_domain.path
+        super().write(values)
+
+    @api.onchange("domain")
+    def warning_for_risky_wildcards(self):
+        """Warn about risky wildcards
+        Examples:
+         *wholesome.domain would match with "notwholesome.domain"
+         wholesome.* would match with "wholesome.notreally"
+
+        Note: this is only `onchange` so doesn't contrain the value
+        """
+        if self.domain and (WILDCARD_PART_CHECK.search(self.domain) or WILDCARD_ENDING_CHECK.search(self.domain)):
+            msg = "\n".join(
+                [
+                    "%s contains a potentially risky wildcard",
+                    "Examples of risky wildcards:",
+                    "     *wholesome.com would match with notwholesome.com",
+                    "     wholesome.* would match with wholesome.notreally.com",
+                ]
+            )
+            return {
+                "warning": {
+                    "title": _("Potentially risky wildcard"),
+                    "message": _(msg) % self.domain,
+                }
+            }

--- a/addons/udes_security/security/ir.model.access.csv
+++ b/addons/udes_security/security/ir.model.access.csv
@@ -2,3 +2,5 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 ,,,,,,,,
 access_udes_allowed_file_type,udes_allowed_file_type,model_udes_allowed_file_type,base.group_user,1,0,0,0
 access_udes_allowed_file_type_config,udes_allowed_file_type,model_udes_allowed_file_type,udes_security.group_edit_allowed_file_types,1,1,1,1
+access_udes_security_domain_allowlist,access_udes_security_domain_allowlist_user,model_udes_security_domain_allowlist,,1,0,0,0
+access_udes_security_domain_allowlist_tech,access_udes_security_domain_allowlist_tech,model_udes_security_domain_allowlist,udes_security.group_edit_allowlist_redirect_domains,1,1,1,1

--- a/addons/udes_security/tests/__init__.py
+++ b/addons/udes_security/tests/__init__.py
@@ -1,3 +1,4 @@
 from . import test_allowed_file_type
 from . import test_desktop_access
 from . import test_trusted_user
+from . import test_no_redirect

--- a/addons/udes_security/tests/test_no_redirect.py
+++ b/addons/udes_security/tests/test_no_redirect.py
@@ -1,0 +1,113 @@
+from odoo.tests import common
+from odoo.tools import mute_logger
+from werkzeug.urls import url_join
+
+
+class TestRedirect(common.HttpCase):
+    """Tests for password complexity"""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+    def setUp(self):
+        super().setUp()
+        self.base_url = self.env["ir.config_parameter"].sudo().get_param("web.base.url")
+
+    def _get_url(self, url):
+        return url_join(self.base_url, url)
+
+    def assertFailedRedirect(self, response):
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Bad Request", response.text)
+        self.assertIn("Invalid redirection attempted", response.text)
+
+    def assertNotFound(self, response, redirect_url):
+        """ODOO internal redirection to page not found"""
+        self.assertEqual(response.status_code, 404)
+        self.assertIn("We couldn't find the page you're looking for!", response.text)
+        # Look for redirect
+        for resp in response.history:
+            if (
+                resp.status_code == 303
+                and resp.headers["Location"].replace("127.0.0.1", "localhost")
+                == redirect_url
+            ):
+                break
+        else:
+            raise AssertionError("Redirect not found")
+
+    def assertSuccessfulRedirect(self, response, redirect_url):
+        self.assertEqual(response.status_code, 200)
+        # Look for redirect
+        for resp in response.history:
+            if (
+                resp.status_code == 303
+                and resp.headers["Location"].replace("127.0.0.1", "localhost")
+                == redirect_url
+            ):
+                break
+        else:
+            raise AssertionError("Redirect not found")
+
+    @mute_logger("odoo.addons.udes_security.controllers.redirect")
+    def test_absolute_throws_bad_request(self):
+        self.assertFailedRedirect(self.url_open("/web?redirect=http://baddomain.com"))
+
+    def test_local_does_not_throw_bad_request(self):
+        self.assertSuccessfulRedirect(
+            self.url_open("/web?redirect=/web/login"),
+            redirect_url=self._get_url("/web/login"),
+        )
+
+    def test_double_forward_slash_redirects_locally(self):
+        self.authenticate("admin", "admin")
+        self.assertNotFound(
+            self.url_open("/web?redirect=//baddomain.com"),
+            redirect_url=self._get_url("/baddomain.com"),
+        )
+
+    def test_quad_forward_slash_redirects_locally(self):
+        self.authenticate("admin", "admin")
+        self.assertNotFound(
+            self.url_open("/web?redirect=////baddomain.com"),
+            redirect_url=self._get_url("/baddomain.com"),
+        )
+
+    def test_url_encoded_double_forward_slash_redirects_locally(self):
+        self.authenticate("admin", "admin")
+        self.assertNotFound(
+            self.url_open("/web?redirect=%2F%2Fbaddomain.com"),
+            redirect_url=self._get_url("/baddomain.com"),
+        )
+
+    def test_allow_listed_domain_redirects(self):
+        DomainAllowlist = self.env["udes_security.domain.allowlist"]
+
+        self.authenticate("admin", "admin")
+
+        self.assertFailedRedirect(self.url_open("/web?redirect=http://google.com"))
+
+        DomainAllowlist.create({"name": "Google", "domain": "google.com"})
+        self.assertSuccessfulRedirect(
+            self.url_open("/web?redirect=http://google.com"),
+            redirect_url="http://google.com",
+        )
+
+    def test_allow_listed_wildcarded_domain_redirects(self):
+        DomainAllowlist = self.env["udes_security.domain.allowlist"]
+
+        self.authenticate("admin", "admin")
+
+        allowed_domain = DomainAllowlist.create(
+            {"name": "Google", "domain": "google.com"}
+        )
+        self.assertFailedRedirect(
+            self.url_open("/web?redirect=https://support.google.com/")
+        )
+
+        allowed_domain.domain = "*.google.com"
+        self.assertSuccessfulRedirect(
+            self.url_open("/web?redirect=https://support.google.com/"),
+            redirect_url="https://support.google.com/",
+        )

--- a/addons/udes_security/views/domain_allowlist_view.xml
+++ b/addons/udes_security/views/domain_allowlist_view.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0"?>
+<odoo>
+  <data>
+
+    <!-- Form view -->
+    <record id="domain_allowlist_form" model="ir.ui.view">
+      <field name="name">udes_security.domain.allowlist.form</field>
+      <field name="model">udes_security.domain.allowlist</field>
+      <field name="arch" type="xml">
+        <form string="udes_security domain_allowlist">
+          <sheet>
+            <div class="oe_title">
+              <label for="name" class="oe_edit_only"/>
+              <h1>
+                <field name="name" placeholder="e.g. reporting suite"/>
+              </h1>
+            </div>
+            <group>
+              <group name="basic">
+                <field name="domain"/>
+                <field name="active"/>
+              </group>
+            </group>
+          </sheet>
+        </form>
+      </field>
+    </record>
+
+    <!-- Tree view -->
+    <record id="domain_allowlist_tree" model="ir.ui.view">
+      <field name="name">udes_security.domain.allowlist.tree</field>
+      <field name="model">udes_security.domain.allowlist</field>
+      <field name="arch" type="xml">
+        <tree string="Allowlist Redirect Domains">
+          <field name="name"/>
+          <field name="domain"/>
+          <field name="active"/>
+        </tree>
+      </field>
+    </record>
+
+    <!-- Search filter -->
+    <record id="domain_allowlist_search" model="ir.ui.view">
+      <field name="name">udes_security.domain.allowlist.search</field>
+      <field name="model">udes_security.domain.allowlist</field>
+      <field name="arch" type="xml">
+        <search string="Allowlist Redirect Domains">
+          <field name="name"/>
+          <field name="domain"/>
+          <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
+        </search>
+      </field>
+    </record>
+
+    <!-- Action window -->
+    <record id="domain_allowlist_action" model="ir.actions.act_window">
+      <field name="name">Allowlist Redirect Domains</field>
+      <field name="res_model">udes_security.domain.allowlist</field>
+      <field name="view_id" ref="domain_allowlist_tree"/>
+      <field name="search_view_id" ref="domain_allowlist_search"/>
+    </record>
+
+    <!-- Menu item -->
+    <menuitem action="domain_allowlist_action" id="domain_allowlist_menu" parent="base.menu_security" sequence="30"/>
+
+  </data>
+</odoo>


### PR DESCRIPTION
Porting of the code that implements the allowlist domain filter model
for blocking redirections from UDES13. This code implements a list to
filter domains and block redirection requests if the domain is not in
the list filter. The list has been renamed from whitelist to allowlist.

Story: x2536

Signed-off-by: Lorenzo Cucurachi <lorenzo.cucurachi@unipart.io>