### PR TITLE
[ADD] udes_stock: Move (and partial) cancellation propagation

### DIFF
--- a/addons/udes_stock/README.md
+++ b/addons/udes_stock/README.md
@@ -187,8 +187,8 @@ The type of stock.picking can is defined by this type. It can represent a goods 
 | u_scan_parent_package_end | Boolean | If the system should ask the user to scan a parent package on drop off                                                                   |
 | u_multi_users_enabled     | Boolean | Flag to enable multi users processing same picking simultaneously.                                                                       |
 | u_enable_unpickable_items | Boolean | Flag to indicate if the current picking type should support handling of unpickable items                                                 |
-| u_handle_partials | Boolean | If the picking type is allowed to handle
-partially available pickings. |
+| u_handle_partials | Boolean | If the picking type is allowed to handle partially available pickings. |
+| u_propagate_cancel | Boolean | If the picking type should propagate move cancellations to the next moves |
 
 | Helpers                       | Description                                          |
 |-------------------------------|------------------------------------------------------|

--- a/addons/udes_stock/models/stock_picking_type.py
+++ b/addons/udes_stock/models/stock_picking_type.py
@@ -93,6 +93,20 @@ class StockPickingType(models.Model):
         " * Origin: All pickings of the same picking type, which share a source document \n"
         " * Nothing: No grouping is applied and each picking will be considered separately \n",
     )
+    u_propagate_cancel = fields.Boolean(
+        default=False,
+        string="Propagate Move Cancellations",
+        help="Whether or not to propagate move cancellations to the next picks moves. \n"
+        "Odoo has a built in `propagate_cancel` field on the `stock.rule` which is only \n"
+        "available on pull rules, and does not work for partial cancellations \n"
+        "i.e if move grouping exists on pick type A but not pick type B, then \n"
+        "pick type B's moves will be merged, and if a pick type A move is cancelled \n"
+        "then the qty of the merged moves in pick type B will not be reduced. \n\n"
+        "This toggle however, does support partial cancellations, and will propagate forward \n"
+        "until it reaches a pick type with this setting turned off (or the move can not be found).\n\n"
+        "For this reason, it is suggested to not use this feature on pick types whose rules are \n"
+        "configured to propagate cancellations, to avoid any conflicting functionality.",
+    )
 
     def get_action_picking_tree_draft(self):
         return self._get_action("udes_stock.action_picking_tree_draft")

--- a/addons/udes_stock/views/stock_picking_type.xml
+++ b/addons/udes_stock/views/stock_picking_type.xml
@@ -4,7 +4,7 @@
     <record id="view_picking_type_form_inherit" model="ir.ui.view">
         <field name="name">stock.picking.type.form.inherit</field>
         <field name="model">stock.picking.type</field>
-        <field name="inherit_id" ref="stock.view_picking_type_form"/>
+        <field name="inherit_id" ref="stock.view_picking_type_form" />
         <field name="arch" type="xml">
 
             <!-- Add UDES fields -->
@@ -13,7 +13,7 @@
                     <field name="u_target_storage_format" />
                     <field name="u_user_scans" />
                     <field name="u_scan_parent_package_end" />
-                    <field name="u_under_receive"/>
+                    <field name="u_under_receive" />
                     <field name="u_over_receive" />
                     <field name="u_multi_users_enabled" />
                     <field name="u_auto_unlink_empty" />
@@ -21,11 +21,12 @@
                     <field name="u_validate_real_time" />
                     <field name="u_handle_partials" />
                     <field name="u_group_related_pickings_by" />
+                    <field name="u_propagate_cancel" />
                 </group>
             </xpath>
 
             <!-- Not needed for UDES as in only applicable to Odoo style prefix -->
-            <xpath expr="//field[@name='sequence_code']" position="replace"/>
+            <xpath expr="//field[@name='sequence_code']" position="replace" />
 
         </field>
     </record>


### PR DESCRIPTION
This includes a new option `u_propagate_cancel` on `stock.picking.type`
to turn the functionality on.

Signed-off-by: Peter Alabaster <peter.alabaster@unipart.io>

User-story: 2411