### PR TITLE
Story/757 - Prevent internal locations from having child locations

### DIFF
--- a/addons/udes_simple_location_blocking/tests/test_inventory.py
+++ b/addons/udes_simple_location_blocking/tests/test_inventory.py
@@ -3,25 +3,28 @@
 from odoo.exceptions import ValidationError
 from .common import BaseBlocked
 
+
 class TestStockInventory(BaseBlocked):
-    def test01_create_inventory_location_blocked(self):
-        """ Creating an inventory using a blocked location
-            raises an error.
+    def test_create_inventory_location_blocked(self):
+        """Creating an inventory using a blocked location
+        raises an error.
         """
         self.test_location_01.u_blocked_reason = "Stock Damaged"
         self.test_location_01.u_blocked = True
 
         with self.assertRaises(ValidationError) as e:
             inventory = self.create_inventory(self.test_location_01)
-        self.assertEqual(e.exception.name,
-                'Cannot create inventory adjustment. Location %s is'
-                ' blocked (reason: %s). Please speak'
-                ' to a team leader to resolve the issue.' %
-                (self.test_location_01.name, self.test_location_01.u_blocked_reason))
+        self.assertEqual(
+            e.exception.args[0],
+            "Cannot create inventory adjustment. Location %s is"
+            " blocked (reason: %s). Please speak"
+            " to a team leader to resolve the issue."
+            % (self.test_location_01.name, self.test_location_01.u_blocked_reason),
+        )
 
-    def test02_create_inventory_lines_location_blocked(self):
-        """ Creating an inventory line from a blocked location
-            raises an error.
+    def test_create_inventory_lines_location_blocked(self):
+        """Creating an inventory line from a blocked location
+        raises an error.
         """
         inventory = self.create_inventory(self.test_location_01)
         self.create_quant(self.apple.id, self.test_location_01.id, 10)
@@ -29,15 +32,17 @@ class TestStockInventory(BaseBlocked):
         self.test_location_01.u_blocked = True
         with self.assertRaises(ValidationError) as e:
             inventory.action_start()
-        self.assertEqual(e.exception.name,
-                'Cannot create inventory adjustment line. Location %s is'
-                ' blocked (reason: %s). Please speak'
-                ' to a team leader to resolve the issue.' %
-                (self.test_location_01.name, self.test_location_01.u_blocked_reason))
-                
-    def test03_validate_inventory_location_blocked(self):
-        """ Validating an inventory of a blocked location
-            raises an error.
+        self.assertEqual(
+            e.exception.args[0],
+            "Cannot create inventory adjustment line. Location %s is"
+            " blocked (reason: %s). Please speak"
+            " to a team leader to resolve the issue."
+            % (self.test_location_01.name, self.test_location_01.u_blocked_reason),
+        )
+
+    def test_validate_inventory_location_blocked(self):
+        """Validating an inventory of a blocked location
+        raises an error.
         """
         inventory = self.create_inventory(self.test_location_01)
         self.create_quant(self.apple.id, self.test_location_01.id, 10)
@@ -46,15 +51,17 @@ class TestStockInventory(BaseBlocked):
         self.test_location_01.u_blocked = True
         with self.assertRaises(ValidationError) as e:
             inventory._action_done()
-        self.assertEqual(e.exception.name,
-                'Cannot validate inventory adjustment. Location %s is'
-                ' blocked (reason: %s). Please speak'
-                ' to a team leader to resolve the issue.' %
-                (self.test_location_01.name, self.test_location_01.u_blocked_reason))
+        self.assertEqual(
+            e.exception.args[0],
+            "Cannot validate inventory adjustment. Location %s is"
+            " blocked (reason: %s). Please speak"
+            " to a team leader to resolve the issue."
+            % (self.test_location_01.name, self.test_location_01.u_blocked_reason),
+        )
 
-    def test04_validate_inventory_line_location_blocked(self):
-        """ Validating an inventory line of a blocked location
-            raises an error.
+    def test_validate_inventory_line_location_blocked(self):
+        """Validating an inventory line of a blocked location
+        raises an error.
         """
         inventory = self.create_inventory(self.stock_location)
         self.create_quant(self.apple.id, self.test_location_01.id, 10)
@@ -63,31 +70,34 @@ class TestStockInventory(BaseBlocked):
         self.test_location_01.u_blocked = True
         with self.assertRaises(ValidationError) as e:
             inventory._action_done()
-        self.assertEqual(e.exception.name,
-                'Cannot validate inventory adjustment line. Location %s is'
-                ' blocked (reason: %s). Please speak'
-                ' to a team leader to resolve the issue.' %
-                (self.test_location_01.name, self.test_location_01.u_blocked_reason))
+        self.assertEqual(
+            e.exception.args[0],
+            "Cannot validate inventory adjustment line. Location %s is"
+            " blocked (reason: %s). Please speak"
+            " to a team leader to resolve the issue."
+            % (self.test_location_01.name, self.test_location_01.u_blocked_reason),
+        )
 
-    def test05_validate_inventory_location_non_blocked(self):
-        """ Validating an inventory of a non blocked location
-            does not raise an error.
-            Change 10 apples to 9.
+    def test_validate_inventory_location_non_blocked(self):
+        """Validating an inventory of a non blocked location
+        does not raise an error.
+        Change 10 apples to 9.
         """
-        Location = self.env['stock.location']
-        # create sublocation for test_location_01
-        test_location_01_01 = Location.create({
-                'name': "Test location 01 01",
-                'barcode': "LTEST0101",
-                'location_id': self.test_location_01.id,
-            })
-        # create inventory for test_location_01
-        inventory = self.create_inventory(self.test_location_01)
+        Location = self.env["stock.location"]
+        # create new test location
+        new_test_location = Location.create(
+            {
+                "name": "New Test Location",
+                "barcode": "NEWTEST",
+                "location_id": self.stock_location.id,
+            }
+        )
+        # create inventory for new_test_location
+        inventory = self.create_inventory(new_test_location)
         # create quant at the sublocation
-        quant = self.create_quant(self.apple.id, test_location_01_01.id, 10)
+        quant = self.create_quant(self.apple.id, new_test_location.id, 10)
         inventory.action_start()
         apple_line = inventory.line_ids.filtered(lambda l: l.product_id == self.apple)
         apple_line.product_qty = 9
         inventory._action_done()
         self.assertEqual(quant.quantity, 9)
-

--- a/addons/udes_simple_location_blocking/tests/test_move.py
+++ b/addons/udes_simple_location_blocking/tests/test_move.py
@@ -4,7 +4,7 @@ from odoo.exceptions import ValidationError
 from .common import BaseBlocked
 
 class TestStockMove(BaseBlocked):
-    def test01_create_move_source_location_blocked(self):
+    def test_create_move_source_location_blocked(self):
         """ Creating a move using as source location a blocked
             location raises an error.
         """
@@ -14,13 +14,13 @@ class TestStockMove(BaseBlocked):
         with self.assertRaises(ValidationError) as e:
             move = self.create_move(self.apple, 10, picking,
                                     location_id=self.test_location_01.id)
-        self.assertEqual(e.exception.name,
+        self.assertEqual(e.exception.args[0],
                          'Wrong source location creating stock move. Location %s '
                          'is blocked (reason: %s). Please speak'
                          ' to a team leader to resolve the issue.' % 
                          (self.test_location_01.name, self.test_location_01.u_blocked_reason))
 
-    def test02_create_move_destination_location_blocked(self):
+    def test_create_move_destination_location_blocked(self):
         """ Creating a move using as destination location a blocked
             location raises an error.
         """
@@ -30,13 +30,13 @@ class TestStockMove(BaseBlocked):
         with self.assertRaises(ValidationError) as e:
             move = self.create_move(self.apple, 10, picking,
                                     location_dest_id=self.test_location_01.id)
-        self.assertEqual(e.exception.name,
+        self.assertEqual(e.exception.args[0],
                          'Wrong destination location creating stock move. Location %s '
                          'is blocked (reason: %s). Please speak'
                          ' to a team leader to resolve the issue.' % 
                          (self.test_location_01.name, self.test_location_01.u_blocked_reason))
 
-    def test03_update_move_source_location_blocked(self):
+    def test_update_move_source_location_blocked(self):
         """ Updating the source location of a move using a blocked
             location raises an error.
         """
@@ -47,13 +47,13 @@ class TestStockMove(BaseBlocked):
         self.test_location_01.u_blocked = True
         with self.assertRaises(ValidationError) as e:
             move.location_id=self.test_location_01
-        self.assertEqual(e.exception.name,
+        self.assertEqual(e.exception.args[0],
                          'Wrong source location creating stock move. Location %s '
                          'is blocked (reason: %s). Please speak'
                          ' to a team leader to resolve the issue.' % 
                          (self.test_location_01.name, self.test_location_01.u_blocked_reason))
 
-    def test04_update_move_destination_location_blocked(self):
+    def test_update_move_destination_location_blocked(self):
         """ Updating the destination location of a move using a blocked
             location raises an error.
         """
@@ -64,7 +64,7 @@ class TestStockMove(BaseBlocked):
         self.test_location_01.u_blocked = True
         with self.assertRaises(ValidationError) as e:
             move.location_dest_id=self.test_location_01
-        self.assertEqual(e.exception.name,
+        self.assertEqual(e.exception.args[0],
                          'Wrong destination location creating stock move. Location %s '
                          'is blocked (reason: %s). Please speak'
                          ' to a team leader to resolve the issue.' % 

--- a/addons/udes_simple_location_blocking/tests/test_move_line.py
+++ b/addons/udes_simple_location_blocking/tests/test_move_line.py
@@ -4,7 +4,7 @@ from odoo.exceptions import ValidationError
 from .common import BaseBlocked
 
 class TestStockMoveLine(BaseBlocked):
-    def test01_create_move_line_source_location_blocked(self):
+    def test_create_move_line_source_location_blocked(self):
         """ Creating a move line using as source location a blocked
             location raises an error.
         """
@@ -15,13 +15,13 @@ class TestStockMoveLine(BaseBlocked):
         with self.assertRaises(ValidationError) as e:
             move_line = self.create_move_line(move, 10,
                                     location_id=self.test_location_01.id)
-        self.assertEqual(e.exception.name,
+        self.assertEqual(e.exception.args[0],
                          'Wrong source location creating stock move line. Location %s '
                          'is blocked (reason: %s). Please speak'
                          ' to a team leader to resolve the issue.' % 
                          (self.test_location_01.name, self.test_location_01.u_blocked_reason))
 
-    def test02_create_move_line_destination_location_blocked(self):
+    def test_create_move_line_destination_location_blocked(self):
         """ Creating a move line using as destination location a blocked
             location raises an error.
         """
@@ -32,13 +32,13 @@ class TestStockMoveLine(BaseBlocked):
         with self.assertRaises(ValidationError) as e:
             move_line = self.create_move_line(move, 10,
                                     location_dest_id=self.test_location_01.id)
-        self.assertEqual(e.exception.name,
+        self.assertEqual(e.exception.args[0],
                          'Wrong destination location creating stock move line. Location %s '
                          'is blocked (reason: %s). Please speak'
                          ' to a team leader to resolve the issue.' % 
                          (self.test_location_01.name, self.test_location_01.u_blocked_reason))
 
-    def test03_update_move_line_source_location_blocked(self):
+    def test_update_move_line_source_location_blocked(self):
         """ Updating the source location of a move line using a blocked
             location raises an error.
         """
@@ -50,13 +50,13 @@ class TestStockMoveLine(BaseBlocked):
         self.test_location_01.u_blocked = True
         with self.assertRaises(ValidationError) as e:
             move_line.location_id=self.test_location_01
-        self.assertEqual(e.exception.name,
+        self.assertEqual(e.exception.args[0],
                          'Wrong source location creating stock move line. Location %s '
                          'is blocked (reason: %s). Please speak'
                          ' to a team leader to resolve the issue.' % 
                          (self.test_location_01.name, self.test_location_01.u_blocked_reason))
 
-    def test04_update_move_line_destination_location_blocked(self):
+    def test_update_move_line_destination_location_blocked(self):
         """ Updating the destination location of a move line using a blocked
             location raises an error.
         """
@@ -68,7 +68,7 @@ class TestStockMoveLine(BaseBlocked):
         self.test_location_01.u_blocked = True
         with self.assertRaises(ValidationError) as e:
             move_line.location_dest_id=self.test_location_01
-        self.assertEqual(e.exception.name,
+        self.assertEqual(e.exception.args[0],
                          'Wrong destination location creating stock move line. Location %s '
                          'is blocked (reason: %s). Please speak'
                          ' to a team leader to resolve the issue.' % 

--- a/addons/udes_simple_location_blocking/tests/test_picking.py
+++ b/addons/udes_simple_location_blocking/tests/test_picking.py
@@ -4,7 +4,7 @@ from odoo.exceptions import ValidationError
 from .common import BaseBlocked
 
 class TestStockPicking(BaseBlocked):
-    def test01_create_picking_source_location_blocked(self):
+    def test_create_picking_source_location_blocked(self):
         """ Creating a picking using as source location a blocked
             location raises an error.
         """
@@ -13,13 +13,13 @@ class TestStockPicking(BaseBlocked):
         with self.assertRaises(ValidationError) as e:
             picking = self.create_picking(self.picking_type_internal,
                                           location_id=self.test_location_01.id)
-        self.assertEqual(e.exception.name,
+        self.assertEqual(e.exception.args[0],
                          'Wrong source location creating transfer. Location %s '
                          'is blocked (reason: %s). Please speak'
                          ' to a team leader to resolve the issue.' % 
                          (self.test_location_01.name, self.test_location_01.u_blocked_reason))
 
-    def test02_create_picking_destination_location_blocked(self):
+    def test_create_picking_destination_location_blocked(self):
         """ Creating a picking using as destination location a blocked
             location raises an error.
         """
@@ -28,13 +28,13 @@ class TestStockPicking(BaseBlocked):
         with self.assertRaises(ValidationError) as e:
             picking = self.create_picking(self.picking_type_internal,
                                           location_dest_id=self.test_location_01.id)
-        self.assertEqual(e.exception.name,
+        self.assertEqual(e.exception.args[0],
                          'Wrong destination location creating transfer. Location %s '
                          'is blocked (reason: %s). Please speak'
                          ' to a team leader to resolve the issue.' % 
                          (self.test_location_01.name, self.test_location_01.u_blocked_reason))
 
-    def test03_update_picking_source_location_blocked(self):
+    def test_update_picking_source_location_blocked(self):
         """ Updating the source location of a picking using a blocked
             location raises an error.
         """
@@ -44,13 +44,13 @@ class TestStockPicking(BaseBlocked):
         self.test_location_01.u_blocked = True
         with self.assertRaises(ValidationError) as e:
             picking.location_id=self.test_location_01
-        self.assertEqual(e.exception.name,
+        self.assertEqual(e.exception.args[0],
                          'Wrong source location creating transfer. Location %s '
                          'is blocked (reason: %s). Please speak'
                          ' to a team leader to resolve the issue.' % 
                          (self.test_location_01.name, self.test_location_01.u_blocked_reason))
 
-    def test04_update_picking_destination_location_blocked(self):
+    def test_update_picking_destination_location_blocked(self):
         """ Updating the destination location of a picking using a blocked
             location raises an error.
         """
@@ -60,7 +60,7 @@ class TestStockPicking(BaseBlocked):
         self.test_location_01.u_blocked = True
         with self.assertRaises(ValidationError) as e:
             picking.location_dest_id=self.test_location_01
-        self.assertEqual(e.exception.name,
+        self.assertEqual(e.exception.args[0],
                          'Wrong destination location creating transfer. Location %s '
                          'is blocked (reason: %s). Please speak'
                          ' to a team leader to resolve the issue.' % 

--- a/addons/udes_stock/models/stock_quant_package.py
+++ b/addons/udes_stock/models/stock_quant_package.py
@@ -7,8 +7,9 @@ class StockQuantPackage(models.Model):
     _inherit = ["stock.quant.package", "mixin.stock.model"]
     _description = "Package"
 
-    # Enable create packages
+    # Enable create packages with sudo
     MSM_CREATE = True
+    MSM_CREATE_SUDO = True
 
     def _get_current_move_lines(self):
         """ Helper function to return current move lines for the package in self """

--- a/addons/udes_stock/tests/common.py
+++ b/addons/udes_stock/tests/common.py
@@ -64,6 +64,20 @@ class UnconfiguredBaseUDES(common.SavepointCase):
         setattr(cls.warehouse, f"{ptype}_type_id", new_pt)
 
     @classmethod
+    def create_location(cls, name, **kwargs):
+        """Create and return a location"""
+        Location = cls.env["stock.location"]
+
+        vals = {"name": name}
+        vals.update(kwargs)
+
+        usage = vals.get("usage")
+        if not usage or usage == "internal":
+            vals["barcode"] = f"{name.upper()}"
+
+        return Location.create(vals)
+
+    @classmethod
     def create_product(cls, name, **kwargs):
         """Create and return a product"""
         Product = cls.env["product.product"]

--- a/addons/udes_stock/tests/common.py
+++ b/addons/udes_stock/tests/common.py
@@ -104,7 +104,6 @@ class UnconfiguredBaseUDES(common.SavepointCase):
     @classmethod
     def create_lot(cls, product_id, lot_name, **kwargs):
         Lot = cls.env["stock.production.lot"]
-
         vals = {"name": lot_name, "product_id": product_id}
         if "company_id" not in kwargs:
             vals["company_id"] = cls.company.id
@@ -121,14 +120,14 @@ class UnconfiguredBaseUDES(common.SavepointCase):
 
     @classmethod
     def create_orderpoint(cls, product, location, qty_min, qty_max, qty_multiple=1, **kwargs):
-        """ Create and return an orderpoint."""
-        Orderpoint = cls.env['stock.warehouse.orderpoint']
+        """Create and return an orderpoint."""
+        Orderpoint = cls.env["stock.warehouse.orderpoint"]
         vals = {
-            'location_id': location.id,
-            'product_id': product.id,
-            'product_min_qty': qty_min,
-            'product_max_qty': qty_max,
-            'qty_multiple': qty_multiple,
+            "location_id": location.id,
+            "product_id": product.id,
+            "product_min_qty": qty_min,
+            "product_max_qty": qty_max,
+            "qty_multiple": qty_multiple,
         }
         vals.update(kwargs)
         return Orderpoint.create(vals)
@@ -139,8 +138,6 @@ class UnconfiguredBaseUDES(common.SavepointCase):
         Location = cls.env["stock.location"]
 
         cls.stock_location = cls.env.ref("stock.stock_location_stock")
-        # Make it non-view to ease default routes
-        cls.stock_location.write({"usage": "internal"})
         cls.received_location = cls.stock_location.copy({"name": "TEST_INPUT"})
         cls.test_received_locations = Location.create(
             [
@@ -182,9 +179,12 @@ class UnconfiguredBaseUDES(common.SavepointCase):
                 },
             ]
         )
-        cls.test_stock_location_01, cls.test_stock_location_02, cls.test_stock_location_03, cls.test_stock_location_04 = (
-            cls.test_stock_locations
-        )
+        (
+            cls.test_stock_location_01,
+            cls.test_stock_location_02,
+            cls.test_stock_location_03,
+            cls.test_stock_location_04,
+        ) = cls.test_stock_locations
 
         cls.warehouse_location = Location.create({"name": "Warehouse", "usage": "view"})
 

--- a/addons/udes_stock/tests/test_limit_orderpoints.py
+++ b/addons/udes_stock/tests/test_limit_orderpoints.py
@@ -10,21 +10,17 @@ class LimitOrderpointsTestCase(common.BaseUDES):
         super(LimitOrderpointsTestCase, cls).setUpClass()
 
         # Setup an output location, parent and grandparent
-        Location = cls.env["stock.location"]
-        cls.op_warehouse_location = Location.create({"name": "UPL"})
+        cls.op_warehouse_location = cls.create_location("UPL", usage="view")
         cls.op_out_location = cls.picking_type_pick.default_location_dest_id.copy(
             {
                 "name": "TEST_OUT",
                 "active": True,
                 "location_id": cls.op_warehouse_location.id,
+                "usage": "view",
             }
         )
-        cls.op_test_output_location_01 = Location.create(
-            {
-                "name": "Test output location 01",
-                "barcode": "LTESTOUT01",
-                "location_id": cls.op_out_location.id,
-            }
+        cls.op_test_output_location_01 = cls.create_location(
+            "Test output location 01", barcode="LTESTOUT01", location_id=cls.op_out_location.id
         )
 
         # Create an orderpoint with values

--- a/addons/udes_stock/tests/test_mixin_stock_model.py
+++ b/addons/udes_stock/tests/test_mixin_stock_model.py
@@ -11,7 +11,7 @@ class TestMixinModel(BaseUDES):
         cls.Group = cls.env["procurement.group"]
         cls.Package = cls.env["stock.quant.package"]
 
-    def test00_incorrect_identifier_type(self):
+    def test_incorrect_identifier_type(self):
         """Error raised when incorrect identifier type is passed"""
         identifier = ["Test product Apple"]
         with self.assertRaises(TypeError) as e:
@@ -20,23 +20,23 @@ class TestMixinModel(BaseUDES):
             e.exception.args[0], f"Identifier must be either int or str, not {type(identifier)}"
         )
 
-    def test01_correct_identifier_type(self):
+    def test_correct_identifier_type(self):
         """Get domain with correct identifier type"""
         identifier = "Test product Apple"
         domain = self.Product._get_msm_domain(identifier)
         self.assertEqual(domain, ["|", ("name", "=", identifier), ("barcode", "=", identifier)])
 
-    def test02_get_existing_product_by_name(self):
+    def test_get_existing_product_by_name(self):
         """Get a product by name"""
         prod = self.Product.get_or_create("Test product Apple")
         self.assertEqual(prod, self.apple)
 
-    def test03_get_existing_product_by_barcode(self):
+    def test_get_existing_product_by_barcode(self):
         """Get product by barcode"""
         prod = self.Product.get_or_create("productApple")
         self.assertEqual(prod, self.apple)
 
-    def test04_get_existing_product_by_id(self):
+    def test_get_existing_product_by_id(self):
         """Get a product by id"""
         # First get the product via the name (tested above)
         prod = self.Product.get_or_create("Test product Apple")
@@ -44,19 +44,19 @@ class TestMixinModel(BaseUDES):
         prod_id = self.Product.get_or_create(id)
         self.assertEqual(prod_id, prod)
 
-    def test05_error_on_product_not_found(self):
+    def test_error_on_product_not_found(self):
         """Error raised when product not found"""
         with self.assertRaises(ValidationError) as e:
             self.Product.get_or_create("Invisible Apple")
         self.assertEqual(e.exception.args[0], "Product not found for identifier Invisible Apple")
 
-    def test06_error_on_create_product(self):
+    def test_error_on_create_product(self):
         """Cannot create a new product"""
         with self.assertRaises(ValidationError) as e:
             self.Product.get_or_create("Invisible Apple", create=True)
         self.assertEqual(e.exception.args[0], "Cannot create a new Product for product.product")
 
-    def test07_create_and_get_group(self):
+    def test_create_and_get_group(self):
         """Create a group and then get it by name and id"""
         # Check cannot get group to begin with and there are no groups
         self.assertEqual(len(self.Group.search([])), 0)
@@ -73,7 +73,7 @@ class TestMixinModel(BaseUDES):
         # Check get group by id
         self.assertEqual(self.Group.get_or_create(group.id), group)
 
-    def test08_do_not_create_group_with_same_name(self):
+    def test_do_not_create_group_with_same_name(self):
         """Create a group and then get it with create enabled, returns the same group"""
         # Check cannot get group to begin with
         with self.assertRaises(ValidationError) as e:
@@ -87,7 +87,7 @@ class TestMixinModel(BaseUDES):
         new_group = self.Group.get_or_create("TESTGROUP01", create=True)
         self.assertEqual(new_group, group)
 
-    def test09_cannot_create_group_by_id(self):
+    def test_cannot_create_group_by_id(self):
         """Error raised when try to create group by id"""
         id = 100000000
         # Check cannot get group to begin with
@@ -101,7 +101,7 @@ class TestMixinModel(BaseUDES):
             f"Cannot create a new Procurement Group for procurement.group with identifier of type {type(id)}",
         )
 
-    def test10_get_product_by_multiple_domains(self):
+    def test_get_product_by_multiple_domains(self):
         """Test that the way the domain is formatted is correct, by extending what product can
         look for, as in the future we may want to search by more than two domains.
         It's done for three string domains in product, the rest is true by induction.
@@ -115,19 +115,19 @@ class TestMixinModel(BaseUDES):
             self.assertEqual(self.Product.get_or_create(prod.name), prod)
             self.assertEqual(self.Product.get_or_create(prod.barcode), prod)
 
-    def test11_create_then_get_new_package_success_by_name(self):
+    def test_create_then_get_new_package_success_by_name(self):
         """Create a new Package and then get it by name"""
         test_package = self.Package.get_or_create("Test Pack 1", create=True)
         get_package = self.Package.get_or_create("Test Pack 1")
         self.assertEqual(test_package, get_package)
 
-    def test12_create_then_get_new_package_success_by_id(self):
+    def test_create_then_get_new_package_success_by_id(self):
         """Create a new Package and then get it by id"""
         test_package = self.Package.get_or_create("Test Pack 2", create=True)
         get_package = self.Package.get_or_create(test_package.id)
         self.assertEqual(test_package.name, get_package.name)
 
-    def test13_cannot_create_package_with_id(self):
+    def test_cannot_create_package_with_id(self):
         """Cannot create a package with id"""
         # Check id does not exist
         id = 1001
@@ -142,7 +142,7 @@ class TestMixinModel(BaseUDES):
             f"Cannot create a new Package for stock.quant.package with identifier of type {type(id)}",
         )
 
-    def test14_error_on_multiple_instances_group(self):
+    def test_error_on_multiple_instances_group(self):
         """Error raised when existing multiple instances of the same id"""
         # Create initial group using get_or_create
         group = self.Group.get_or_create("TESTGROUP01", create=True)
@@ -154,5 +154,5 @@ class TestMixinModel(BaseUDES):
             self.Group.get_or_create("TESTGROUP01")
         self.assertEqual(
             e.exception.args[0],
-            f"Too many Procurement Groups found for identifier TESTGROUP01 in procurement.group",
+            "Too many Procurement Groups found for identifier TESTGROUP01 in procurement.group",
         )

--- a/addons/udes_stock/tests/test_product.py
+++ b/addons/udes_stock/tests/test_product.py
@@ -7,6 +7,4 @@ class TestProductMethods(BaseUDES):
         self.starwberry_lot = self.create_lot(self.strawberry.id, "strawberry_lot")
 
         with self.assertRaises(ValidationError):
-            self.strawberry.assert_serial_numbers(
-                [self.starwberry_lot.name, "test_lot"]
-            )
+            self.strawberry.assert_serial_numbers([self.starwberry_lot.name, "test_lot"])

--- a/addons/udes_stock/tests/test_res_users.py
+++ b/addons/udes_stock/tests/test_res_users.py
@@ -18,7 +18,7 @@ class TestGetUserWarehouse(common.BaseUDES):
             company_ids=[(6, 0, cls.test_company.ids)],
         )
 
-    def test01_get_user_warehouse_no_user(self):
+    def test_get_user_warehouse_no_user(self):
         """Checking that when no user is found the correct error is raised"""
         # Make it so user isn't found in search
         self.test_user.active = False
@@ -26,7 +26,7 @@ class TestGetUserWarehouse(common.BaseUDES):
             self.User.with_user(self.test_user).get_user_warehouse()
         self.assertEqual(e.exception.args[0], "Cannot find user")
 
-    def test02_get_user_warehouse_no_warehouse(self):
+    def test_get_user_warehouse_no_warehouse(self):
         """Checking that when a user has no warehouse the correct error is raised"""
         # Make it so warehouse isn't found in search
         self.test_warehouse.active = False
@@ -34,7 +34,7 @@ class TestGetUserWarehouse(common.BaseUDES):
             self.User.with_user(self.test_user).get_user_warehouse()
         self.assertEqual(e.exception.args[0], "Cannot find a warehouse for user")
 
-    def test03_get_user_warehouse_multiple_warehouse(self):
+    def test_get_user_warehouse_multiple_warehouse(self):
         """Checking that when a user has multiple warehouses that all the warehouse are returned"""
         # Create new warehouse by copying current one and changing
         # the required fields
@@ -43,12 +43,12 @@ class TestGetUserWarehouse(common.BaseUDES):
         whs = self.User.with_user(self.test_user).get_user_warehouse()
         self.assertEqual(whs, warehouses)
 
-    def test04_get_user_warehouse_single_warehouse(self):
+    def test_get_user_warehouse_single_warehouse(self):
         """Checking that when a user has a single warehouse that the warehouse is returned"""
         whs = self.User.with_user(self.test_user).get_user_warehouse()
         self.assertEqual(whs, self.test_warehouse)
 
-    def test05_get_user_warehouse_single_from_multiple_warehouses(self):
+    def test_get_user_warehouse_single_from_multiple_warehouses(self):
         """Checking that when a user has multiple warehouses that a warehouse is returned if an
         additional domain is used
         """
@@ -60,7 +60,7 @@ class TestGetUserWarehouse(common.BaseUDES):
         )
         self.assertEqual(whs, warehouse2)
 
-    def test06_get_user_warehouse_subset_from_multiple_warehouses(self):
+    def test_get_user_warehouse_subset_from_multiple_warehouses(self):
         """Checking that when a user has multiple warehouses they cannot use aux_domain to return
         a subset"""
         # Create new warehouse by copying current one and changing

--- a/addons/udes_stock/tests/test_stock_picking_type.py
+++ b/addons/udes_stock/tests/test_stock_picking_type.py
@@ -5,13 +5,11 @@ from . import common
 
 class TestStockPickingType(common.BaseUDES):
     def test_writing_to_picking_type_does_reset_prefix_to_Odoo_style(self):
-        Pickingtype = self.env["stock.picking.type"]
-
         goods_out = self.env.ref("stock.picking_type_out")
         goods_out_prefix = goods_out.sequence_id.prefix
         self.assertEqual(goods_out_prefix, "OUT")
 
-        goods_out.write({"name": "Changed goods out", "sequence_code": "out"})
+        goods_out.write({"name": "Changed goods out"})
 
         goods_out = self.env.ref("stock.picking_type_out")
         goods_out_prefix = goods_out.sequence_id.prefix
@@ -33,8 +31,8 @@ class TestStockPickingType(common.BaseUDES):
         self,
     ):
         """
-        Creating a new picking type the same name as an existing picking type, but with no sequence_id 
-        attached. The new picking type will have the same prefix as the old picking type. 
+        Creating a new picking type the same name as an existing picking type, but with no sequence_id
+        attached. The new picking type will have the same prefix as the old picking type.
         """
         Pickingtype = self.env["stock.picking.type"]
 
@@ -58,7 +56,7 @@ class TestStockPickingType(common.BaseUDES):
     def test_create_new_picking_type_with_same_name_as_other_picking_and_sequence_id_attached(self):
         """
         Creating a new picking type with the same name as an existing picking type, but with a new
-        sequence_id attached. The new picking type will have the new sequence_id prefix.  
+        sequence_id attached. The new picking type will have the new sequence_id prefix.
         """
         Pickingtype = self.env["stock.picking.type"]
 
@@ -83,7 +81,7 @@ class TestStockPickingType(common.BaseUDES):
 
     def test_creating_new_warehouse_and_check_prefixes_on_default_picking_types(self):
         """
-        Creating a new warehouse creates new picking types by default, these will have Odoo style prefixes. 
+        Creating a new warehouse creates new picking types by default, these will have Odoo style prefixes.
         """
         Pickingtype = self.env["stock.picking.type"]
         Warehouse = self.env["stock.warehouse"]
@@ -110,7 +108,7 @@ class TestStockPickingType(common.BaseUDES):
         """
         If there is a new warehouse, creating a picking type (for the new warehouse) with the same name as a picking
         type that already exists, and not specifying the sequence_id, will create a new picking type with a
-        prefix that matches the one already stored. 
+        prefix that matches the one already stored.
         """
         Pickingtype = self.env["stock.picking.type"]
         Warehouse = self.env["stock.warehouse"]
@@ -139,8 +137,8 @@ class TestStockPickingType(common.BaseUDES):
 
     def test_creating_new_company_and_check_prefixes_on_picking_types_of_new_warehouse(self):
         """
-        When creating a new company with a new warehouse, by default the new picking types should have an Odoo style 
-        prefix. 
+        When creating a new company with a new warehouse, by default the new picking types should have an Odoo style
+        prefix.
         """
         Pickingtype = self.env["stock.picking.type"]
         Company = self.env["res.company"]
@@ -158,12 +156,12 @@ class TestStockPickingType(common.BaseUDES):
                 self.assertTrue(
                     bool(re.fullmatch(string_to_match, picking_type.sequence_id.prefix))
                 )
-    
+
     def test_creating_new_company_and_create_for_new_company_new_warehouse(self):
         """
         If there is a new company created with a new warehouse, creating a picking type with same name as
         a picking type that already exists, and not specifying the sequence id, will create a new picking type with
-        an Odoo style prefix. 
+        an Odoo style prefix.
         """
         Pickingtype = self.env["stock.picking.type"]
         Company = self.env["res.company"]
@@ -184,7 +182,4 @@ class TestStockPickingType(common.BaseUDES):
         new_goods_in_prefix = new_goods_in.sequence_id.prefix
 
         string_to_match = f'New C\/{new_goods_in.name.upper().replace(" ", "_")}\/'
-        self.assertTrue(
-                    bool(re.fullmatch(string_to_match, new_goods_in_prefix))
-        )
-    
+        self.assertTrue(bool(re.fullmatch(string_to_match, new_goods_in_prefix)))

--- a/addons/udes_stock/tests/test_stock_quant.py
+++ b/addons/udes_stock/tests/test_stock_quant.py
@@ -34,11 +34,11 @@ class TestStockQuantModel(BaseUDES):
         # Total Bananas = 20
         # reserved = 0
 
-    def test01_get_quantity(self):
+    def test_get_quantity(self):
         """Test get_quantity"""
         self.assertEqual(self.test_stock_location_01.quant_ids.get_quantity(), 26)
 
-    def test02_get_quantities_by_key(self):
+    def test_get_quantities_by_key(self):
         """Test get_quantities_by_key"""
         self.assertEqual(
             {self.apple: 16, self.banana: 10},
@@ -69,7 +69,7 @@ class TestStockQuantModel(BaseUDES):
             ),
         )
 
-    def test03_gather_success(self):
+    def test_gather_success(self):
         """Test extended _gather function"""
         gathered_items = self.Quant._gather(self.apple, self.test_stock_location_01)
         # Check the number of apple quants returned is correct
@@ -87,7 +87,7 @@ class TestStockQuantModel(BaseUDES):
         self.assertEqual(gathered_items_subset.product_id, self.apple)
         self.assertEqual(gathered_items_subset, second_quant)
 
-    def test04_gather_location_no_product(self):
+    def test_gather_location_no_product(self):
         """Test extended _gather function on a location without apples"""
         gathered_items = self.Quant._gather(self.apple, self.test_stock_location_02)
         # Check the number of apple quants returned is correct
@@ -104,7 +104,7 @@ class TestCreatePicking(BaseUDES):
 
         cls.test_user = cls.create_user("test_user", "test_user_login")
 
-    def test01_single_quant(self):
+    def test_single_quant(self):
         """Create a picking from a single quant"""
         pick = self.quant_1.create_picking(self.picking_type_pick)
         # Confirm made in state draft
@@ -123,13 +123,13 @@ class TestCreatePicking(BaseUDES):
         self.assertEqual(pick.move_lines.product_id, self.apple)
         self.assertEqual(pick.move_lines.product_qty, 10)
 
-    def test02_single_quant_confirm(self):
+    def test_single_quant_confirm(self):
         """Create a picking from a single quant and confirm"""
         pick = self.quant_1.create_picking(self.picking_type_pick, confirm=True)
         # Check it is confirmed
         self.assertEqual(pick.state, "confirmed")
 
-    def test03_single_quant_assign(self):
+    def test_single_quant_assign(self):
         """Create a picking from a single quant and assign to user"""
         pick = self.quant_1.create_picking(
             self.picking_type_pick, assign=True, user_id=self.test_user.id
@@ -141,7 +141,7 @@ class TestCreatePicking(BaseUDES):
         # Check quant_1 is now reserved
         self.assertEqual(self.quant_1.reserved_quantity, 10)
 
-    def test04_single_quant_assign_correct_quant(self):
+    def test_single_quant_assign_correct_quant(self):
         """Test that create_picking uses the right quant when assigning
         the picking
         """
@@ -158,7 +158,7 @@ class TestCreatePicking(BaseUDES):
         self.assertEqual(pick.state, "assigned")
         self.assertEqual(quant.reserved_quantity, 10)
 
-    def test05_single_quant_priority(self):
+    def test_single_quant_priority(self):
         """Create a picking from a single quant
         Change the priority to Urgent
         Priorities: [('0', 'Normal'), ('1', 'Urgent')]
@@ -167,7 +167,7 @@ class TestCreatePicking(BaseUDES):
         # Check priority is 1 = 'Urgent'
         self.assertEqual(pick.priority, "1")
 
-    def test06_single_quant_non_default_locations(self):
+    def test_single_quant_non_default_locations(self):
         """Create a picking from a single quant
         - non-default location_id
         - non-default location_dest_id
@@ -184,7 +184,7 @@ class TestCreatePicking(BaseUDES):
         self.assertEqual(pick.location_dest_id, self.test_goodsout_location_02)
         self.assertNotEqual(pick.location_id, self.picking_type_pick.default_location_dest_id)
 
-    def test07_multiple_quants(self):
+    def test_multiple_quants(self):
         """Multiple quants for pick"""
         # Get all quants in test package
         quants = self.quant_1 | self.quant_2

--- a/addons/udes_stock/tests/test_stock_quant_package.py
+++ b/addons/udes_stock/tests/test_stock_quant_package.py
@@ -6,9 +6,7 @@ class TestStockQuantPackageModel(BaseUDES):
     def setUpClass(cls):
         super(TestStockQuantPackageModel, cls).setUpClass()
         cls.Package = cls.env["stock.quant.package"]
-        User = cls.env["res.users"]
 
-        warehouse = User.get_user_warehouse()
         # package
         cls.test_package = cls.Package.get_or_create("1001", create=True)
         cls.apple_quant = cls.create_quant(
@@ -19,20 +17,20 @@ class TestStockQuantPackageModel(BaseUDES):
         )
         cls.test_user = cls.create_user("test_user", "test_user_login")
 
-    def test01_get_quantities_by_default_key(self):
+    def test_get_quantities_by_default_key(self):
         """Get the product quantities of the package grouped by the default key - product_id"""
         self.assertEqual(
             self.test_package.get_quantities_by_key(), {self.apple: 10, self.banana: 5}
         )
 
-    def test02_get_product_quantities_by_custom_key(self):
+    def test_get_product_quantities_by_custom_key(self):
         """Get the product quantities by product_id.name"""
         self.assertEqual(
             self.test_package.get_quantities_by_key(get_key=lambda q: q.product_id.name),
             {self.apple.name: 10, self.banana.name: 5},
         )
 
-    def test03_has_same_content(self):
+    def test_has_same_content(self):
         """Test has same content of three packages, two are the same and one is not"""
         # Create two new packages with same content but different content than default package
         test_package_2 = self.Package.get_or_create("1002", create=True)
@@ -46,7 +44,7 @@ class TestStockQuantPackageModel(BaseUDES):
         self.assertFalse(self.test_package.has_same_content(test_package_2))
         self.assertTrue(test_package_2.has_same_content(test_package_3))
 
-    def test04_has_same_product_but_different_lots(self):
+    def test_has_same_product_but_different_lots(self):
         """Test the default key checks the same products and quantities in two
         different packages but different lots.
         """
@@ -73,7 +71,7 @@ class TestStockQuantPackageModel(BaseUDES):
         get_key = lambda p: (p.product_id, p.lot_id)
         self.assertFalse(test_package_1.has_same_content(test_package_2, get_key=get_key))
 
-    def test05_has_same_content_multiple_packages(self):
+    def test_has_same_content_multiple_packages(self):
         """Test the two groups of packages have the same content:
         Group 1: 15 apples (10 + 5)
         Group 2: 15 apples (5 + 5 + 5)
@@ -105,7 +103,7 @@ class TestStockQuantPackageModel(BaseUDES):
         # Check they should have the same content by product
         self.assertTrue(group_1.has_same_content(group_2))
 
-    def test06_get_reserved_quantity(self):
+    def test_get_reserved_quantity(self):
         """Get reserved quantity check"""
         self.assertEqual(self.test_package.get_reserved_quantity(), 0)
         self.apple_quant.reserved_quantity = 5
@@ -120,7 +118,7 @@ class TestStockQuantPackageModel(BaseUDES):
         )
         self.assertEqual(self.test_package.get_reserved_quantity(), 15)
 
-    def test07_find_move_lines_simple(self):
+    def test_find_move_lines_simple(self):
         """Find move lines of package"""
         # Create a picking from test package
         pick = self.create_picking(
@@ -136,7 +134,7 @@ class TestStockQuantPackageModel(BaseUDES):
         mls = self.test_package.find_move_lines()
         self.assertEqual(mls, pick.move_line_ids)
 
-    def test08_find_move_lines_additional_domain(self):
+    def test_find_move_lines_additional_domain(self):
         """Find move lines of package with additional domain"""
         # Create a picking from test package
         pick = self.create_picking(
@@ -153,7 +151,7 @@ class TestStockQuantPackageModel(BaseUDES):
         self.assertEqual(mls, pick.move_line_ids.filtered(lambda ml: ml.product_id == self.apple))
         self.assertEqual(mls.product_id, self.apple)
 
-    def test09_mls_can_fulfill_success_no_excess_multiple_move_lines(self):
+    def test_mls_can_fulfill_success_no_excess_multiple_move_lines(self):
         """Test to check if the move lines can be met by the package, then no excess given"""
         self.create_quant(self.apple.id, self.test_stock_location_02.id, 10)
         self.create_quant(self.banana.id, self.test_stock_location_02.id, 10)
@@ -177,7 +175,7 @@ class TestStockQuantPackageModel(BaseUDES):
         self.assertEqual(can_fulfil_mls.mapped("product_qty"), [10, 2])
         self.assertFalse(excess_mls, "Expected no excess move lines")
 
-    def test10_mls_can_fulfill_success_with_excess_simple(self):
+    def test_mls_can_fulfill_success_with_excess_simple(self):
         """Test to check that when a move line has quantity > package quantity, it returns which
         it can meet, and the excess move line.
         """
@@ -199,7 +197,7 @@ class TestStockQuantPackageModel(BaseUDES):
         self.assertEqual(can_fulfil_mls.product_qty, 10)
         self.assertEqual(excess_mls.product_qty, 8)
 
-    def test11_mls_can_fulfill_success_with_excess_multiple_move_lines(self):
+    def test_mls_can_fulfill_success_with_excess_multiple_move_lines(self):
         """Test to check that when multiple move lines passed, it correctly splits those when
         the move lines quantity > package quantity, and meets those it can
         """
@@ -257,7 +255,7 @@ class TestCreatePicking(BaseUDES):
         )
         cls.test_user = cls.create_user("test_user", "test_user_login")
 
-    def test01_single_package(self):
+    def test_single_package(self):
         """Create a picking from a single quant"""
         pick = self.test_package.create_picking(self.picking_type_goods_out)
         # Confirm made in state draft
@@ -274,7 +272,7 @@ class TestCreatePicking(BaseUDES):
         self.assertEqual(pick.move_lines.mapped("product_id"), (self.apple | self.banana))
         self.assertEqual(pick.move_lines.mapped("product_qty"), [10, 5])
 
-    def test02_single_package_extra_kwargs(self):
+    def test_single_package_extra_kwargs(self):
         """Create a picking from a single package
         - confirm
         - priority
@@ -306,7 +304,7 @@ class TestCreatePicking(BaseUDES):
         self.assertEqual(pick.move_lines.mapped("product_id"), (self.apple | self.banana))
         self.assertEqual(pick.move_lines.mapped("product_qty"), [10, 5])
 
-    def test03_single_package_correct_package(self):
+    def test_single_package_correct_package(self):
         """Test that create_picking uses the right package when assigning
         the picking
         """

--- a/addons/udes_stock/views/stock_location_views.xml
+++ b/addons/udes_stock/views/stock_location_views.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="view_location_form" model="ir.ui.view">
-        <field name="name">Changes to location form</field>
+        <field name="name">stock.location.form.udes_stock</field>
         <field name="model">stock.location</field>
         <field name="inherit_id" ref="stock.view_location_form"/>
         <field name="arch" type="xml">
@@ -29,6 +29,7 @@
                         icon="fa-level-down"
                         type="object"
                         name="button_view_child_locations"
+                        attrs="{'invisible': [('usage', '=', 'internal')]}"
                 />
             </xpath>
 
@@ -40,6 +41,11 @@
                     <field name="u_size"/>
                 </group>
             </group>
+
+            <!-- Prevent internal locations being set as parent location -->
+            <xpath expr="//field[@name='location_id']" position="attributes">
+                <attribute name="domain">[('usage', '!=', 'internal')]</attribute>
+            </xpath>
 
         </field>
     </record>

--- a/addons/udes_stock_routing/tests/test_push_from_drop.py
+++ b/addons/udes_stock_routing/tests/test_push_from_drop.py
@@ -272,7 +272,10 @@ class InitialDemandTestCase(PushFromDropBase):
         """Set the initial demand of a push move to the quantity done of the preceding move."""
         for ml in self.goods_in_picking.move_line_ids:
             ml.write(
-                {"qty_done": ml.product_uom_qty, "location_dest_id": self.received_location.id}
+                {
+                    "qty_done": ml.product_uom_qty,
+                    "location_dest_id": self.test_received_location_01.id,
+                }
             )
         self.goods_in_picking._action_done()
         putaway_move = self.goods_in_picking.u_next_picking_ids.move_lines
@@ -284,7 +287,12 @@ class InitialDemandTestCase(PushFromDropBase):
     ):
         """Set the initial demand of a push move to the quantity done of the partially completed preceding move."""
         for ml in self.goods_in_picking.move_line_ids:
-            ml.write({"qty_done": 10.0, "location_dest_id": self.received_location.id})
+            ml.write(
+                {
+                    "qty_done": 10.0,
+                    "location_dest_id": self.test_received_location_01.id,
+                }
+            )
         self.goods_in_picking._action_done()
         putaway_move = self.goods_in_picking.u_next_picking_ids.move_lines
 

--- a/addons/udes_suggest_location/tests/test_stock_move_line.py
+++ b/addons/udes_suggest_location/tests/test_stock_move_line.py
@@ -53,7 +53,7 @@ class TestStockMoveLine(common.SuggestedLocations):
             cls.MoveLine.__class__, "validate_location_dest", return_value=None
         )
 
-    def test01_get_policy_class(self):
+    def test_get_policy_class(self):
         """Check policy class returns the correct class"""
         # Fetch by product policy
         by_product = self.MoveLine._get_policy_class(self.picking_type_pick)
@@ -65,7 +65,7 @@ class TestStockMoveLine(common.SuggestedLocations):
             self.MoveLine._get_policy_class(self.picking_type_internal)
         self.assertEqual(str(e.exception), f"Policy with name=False could not be found")
 
-    def test02_suggest_locations_errors_with_not_enough_info(self):
+    def test_suggest_locations_errors_with_not_enough_info(self):
         """Suggest locations by picking type should throw error when not enough information is
         given
         """
@@ -95,7 +95,7 @@ class TestStockMoveLine(common.SuggestedLocations):
             + "lines or picking and values!",
         )
 
-    def test03_suggest_locations_errors_with_no_location_policy(self):
+    def test_suggest_locations_errors_with_no_location_policy(self):
         """Suggest locations by picking type should throw an error when the locations policy is
         not set
         """
@@ -106,7 +106,7 @@ class TestStockMoveLine(common.SuggestedLocations):
             self.apple_mls.suggest_locations()
         self.assertEqual(str(e.exception), "No policy set")
 
-    def test04_suggest_locations_via_self_by_product(self):
+    def test_suggest_locations_via_self_by_product(self):
         """Get the suggest locations via self for by product policy, looping through all
         drop location constraints for completeness
         """
@@ -121,7 +121,7 @@ class TestStockMoveLine(common.SuggestedLocations):
             locs = self.apple_mls.suggest_locations()
             self.assertEqual(locs, self.pick_all_locs)
 
-    def test05_suggest_locations_via_picking_and_values_by_product(self):
+    def test_suggest_locations_via_picking_and_values_by_product(self):
         """Get the suggest locations by picking and values, not self
         This is set up for 'by_product' policy and loop through all u_drop_location_constraint
         for completeness
@@ -138,7 +138,7 @@ class TestStockMoveLine(common.SuggestedLocations):
             locs = self.MoveLine.suggest_locations(picking=self.picking_pick, values=values)
             self.assertEqual(locs, self.pick_all_locs)
 
-    def test06_suggest_locations_limit_results(self):
+    def test_suggest_locations_limit_results(self):
         """Get the suggest locations via self and limit the results"""
         # Set u_drop_location_constraint
         self.picking_type_pick.u_drop_location_constraint = "suggest_with_empty"
@@ -148,7 +148,7 @@ class TestStockMoveLine(common.SuggestedLocations):
         self.assertEqual(len(locs), 1)
         self.assertIn(locs, self.pick_all_locs)
 
-    def test07_validate_location_dest_nothing_droppable(self):
+    def test_validate_location_dest_nothing_droppable(self):
         """Check that we just return when nothing is droppable"""
         # Create a pick but do not assign
         picking = self.create_picking(
@@ -164,6 +164,7 @@ class TestStockMoveLine(common.SuggestedLocations):
 
         # Complete the moves
         picking.move_lines.quantity_done = 5
+        picking.move_line_ids.location_id = self.test_stock_location_01
         picking._action_done()
 
         # Sanity check that suggest_locations is not called
@@ -172,7 +173,7 @@ class TestStockMoveLine(common.SuggestedLocations):
             apple_mls.validate_location_dest()
             mock_suggest_locs.assert_not_called()
 
-    def test08_validate_location_dest_view(self):
+    def test_validate_location_dest_view(self):
         """Check that we just return when the drop location is a view"""
         # Check location is a view
         self.assertEqual(self.out_location.usage, "view")
@@ -181,7 +182,7 @@ class TestStockMoveLine(common.SuggestedLocations):
             self.assertIsNone(self.mls.validate_location_dest(locations=self.out_location))
             mock_suggest_locs.assert_not_called()
 
-    def test09_validation_of_locations_no_policy(self):
+    def test_validation_of_locations_no_policy(self):
         """Check validate locations returns if not policy is set"""
         # Create an internal picking, which has no policy
         internal_picking = self.create_picking(
@@ -196,7 +197,7 @@ class TestStockMoveLine(common.SuggestedLocations):
             self.assertIsNone(apple_mls.validate_location_dest())
             mock_get_policy_class.assert_not_called()
 
-    def test10_validation_of_locations_by_product_non_enforced(self):
+    def test_validation_of_locations_by_product_non_enforced(self):
         """Check the validation policy for suggest constraints for by product policy"""
         # Check suggested locations for each product are correct
         self.assertEqual(
@@ -211,7 +212,7 @@ class TestStockMoveLine(common.SuggestedLocations):
             self.assertIsNone(self.mls.validate_location_dest())
             mock_suggest_locs.assert_not_called()
 
-    def test11_validation_of_locations_by_product_enforced(self):
+    def test_validation_of_locations_by_product_enforced(self):
         """Check the validation policy for enforced with product policy"""
         # Check suggested locations for each product are correct
         self.assertEqual(
@@ -235,7 +236,7 @@ class TestStockMoveLine(common.SuggestedLocations):
         # Check that the suggested locations are now correct, and no validation error
         self.assertIsNone(self.mls.validate_location_dest())
 
-    def test12_create_mls_when_no_policy_set(self):
+    def test_create_mls_when_no_policy_set(self):
         """Check that a pick can be created without a suggested locations policy"""
         # Create picking
         pick = self.create_picking(
@@ -247,7 +248,7 @@ class TestStockMoveLine(common.SuggestedLocations):
         # Check mls has correct product
         self.assertEqual(pick.move_line_ids.product_id, self.apple)
 
-    def test13_set_invalid_dest_location(self):
+    def test_set_invalid_dest_location(self):
         """Set an invalid destination location to begin with"""
         # Set constraint to enforce
         self.picking_type_pick.u_drop_location_constraint = "enforce"

--- a/addons/udes_suggest_location/tests/test_suggest_by_empty_location.py
+++ b/addons/udes_suggest_location/tests/test_suggest_by_empty_location.py
@@ -11,13 +11,26 @@ class TestSuggestByEmptyLocation(common.SuggestedLocations):
         cls.ByProduct = SUGGEST_LOCATION_REGISTRY[policy_name](cls.env)
         cls.picking_type_pick.u_suggest_locations_policy = policy_name
 
-        cls.create_quant(cls.apple.id, cls.stock_location.id, 10)
+        cls.create_quant(cls.apple.id, cls.test_stock_location_01.id, 10)
 
         cls._pick_info = [{"product": cls.apple, "uom_qty": 5}]
 
+    def _create_one_non_empty_child_location_for_given_location(self, parent_location):
+        Location = self.env["stock.location"]
+
+        child_location_with_quant = Location.create(
+            {
+                "name": "child_loc_with_quant",
+                "location_id": parent_location.id,
+                "barcode": "childlocation",
+            }
+        )
+
+        self.create_quant(self.banana.id, child_location_with_quant.id, 5)
+
     def test_correct_location_suggested_when_empty_child_location_is_available(self):
         mls = self._generate_move_lines_for_picking_for_given_destination_location(
-            self.out_location.id
+            self.test_goodsout_location_01.id
         )
 
         self._check_move_lines_destination_location_match_expected_location(
@@ -26,11 +39,11 @@ class TestSuggestByEmptyLocation(common.SuggestedLocations):
 
     def test_correct_location_suggested_when_no_empty_child_location_is_available(self):
         mls = self._generate_move_lines_for_picking_for_given_destination_location(
-            self.test_goodsout_location_01.id
+            self.test_goodsout_location_02.id
         )
 
         self._check_move_lines_destination_location_match_expected_location(
-            mls, self.test_goodsout_location_01
+            mls, self.test_goodsout_location_02
         )
 
     def test_correct_location_suggested_when_empty_child_location_but_no_barcode(self):
@@ -47,28 +60,12 @@ class TestSuggestByEmptyLocation(common.SuggestedLocations):
         self._check_move_lines_destination_location_match_expected_location(mls, self.out_location)
 
     def test_correct_location_suggested_when_child_location_but_not_empty(self):
-        self._create_one_non_empty_child_location_for_given_location(self.test_goodsout_location_01)
+        test_location = self.create_location(name="Test Suggest Location", usage="view")
+        self._create_one_non_empty_child_location_for_given_location(test_location)
 
-        mls = self._generate_move_lines_for_picking_for_given_destination_location(
-            self.test_goodsout_location_01.id
-        )
+        mls = self._generate_move_lines_for_picking_for_given_destination_location(test_location.id)
 
-        self._check_move_lines_destination_location_match_expected_location(
-            mls, self.test_goodsout_location_01
-        )
-
-    def _create_one_non_empty_child_location_for_given_location(self, parent_location):
-        Location = self.env["stock.location"]
-
-        child_location_with_quant = Location.create(
-            {
-                "name": "child_loc_with_quant",
-                "location_id": parent_location.id,
-                "barcode": "childlocation",
-            }
-        )
-
-        self.create_quant(self.banana.id, child_location_with_quant.id, 5)
+        self._check_move_lines_destination_location_match_expected_location(mls, test_location)
 
     def test_validate_location_dest_fails_when_bad_location_is_passed(self):
         self.picking_type_pick.write({"u_drop_location_constraint": "enforce"})

--- a/addons/udes_suggest_location/tests/test_suggest_exactly_match_move_line.py
+++ b/addons/udes_suggest_location/tests/test_suggest_exactly_match_move_line.py
@@ -11,7 +11,7 @@ class TestSuggestExactlyMatchMoveLine(common.SuggestedLocations):
         cls.ByProduct = SUGGEST_LOCATION_REGISTRY[policy_name](cls.env)
         cls.picking_type_pick.u_suggest_locations_policy = policy_name
 
-        cls.create_quant(cls.apple.id, cls.stock_location.id, 10)
+        cls.create_quant(cls.apple.id, cls.test_stock_location_01.id, 10)
 
         cls._pick_info = [{"product": cls.apple, "uom_qty": 5}]
 
@@ -20,16 +20,14 @@ class TestSuggestExactlyMatchMoveLine(common.SuggestedLocations):
             self.out_location.id
         )
 
-        self._check_move_lines_destination_location_match_expected_location(
-            mls, self.out_location
-        )
+        self._check_move_lines_destination_location_match_expected_location(mls, self.out_location)
 
     def test_correct_location_suggested_for_view_location_destination(self):
-        self.out_location.write({"usage": "view"})
-        mls = self._generate_move_lines_for_picking_for_given_destination_location(self.out_location.id)
+        mls = self._generate_move_lines_for_picking_for_given_destination_location(
+            self.out_location.id
+        )
         location = mls.suggest_locations()
-        self.assertEqual(self.env['stock.location'], location)
-        
+        self.assertFalse(location)
 
     def test_validate_location_dest_fails_for_given_destination_location(self):
         self.picking_type_pick.write({"u_drop_location_constraint": "enforce"})


### PR DESCRIPTION
Internal locations locked down to prevent being able to have child locations.

Updated various tests to work nicely with this new constraint.

Added and updated helper methods.

Added sudo parameter for get_or_create for stock mixin.