### PR TITLE
[IMP] udes_security: Condition password reset link

### DIFF
--- a/addons/udes_security/views/no_desktop_access_template_views.xml
+++ b/addons/udes_security/views/no_desktop_access_template_views.xml
@@ -9,7 +9,7 @@
                         <div t-attf-class="col-12 col-md col-lg-12">
                             <h3>Access Denied</h3>
                             <p>You do not have access to the desktop, please contact your manager if you believe this is an error.</p>
-                            <p>
+                            <p t-if="reset_password_enabled">
                                 Click
                                 <a href="/my/security">here</a>
                                 if you need to update your password.


### PR DESCRIPTION
story/2765

Signed-off-by: Kevin Dwyer <kevin.dwyer@unipart.com>

Condition the appearance of the password reset link for no-desktop users who successfully log in on the value of auth_signup.reset_password.