### PR TITLE
[IMP] udes_stock: Adding col=3 for main group

### DIFF
--- a/addons/udes_stock/views/stock_location_views.xml
+++ b/addons/udes_stock/views/stock_location_views.xml
@@ -16,6 +16,10 @@
                 <field name="u_is_countable"/>
             </xpath>
 
+            <xpath expr="//field[@name='removal_strategy_id']/parent::group/parent::group" position="attributes">
+               <attribute name="col">3</attribute>
+            </xpath>
+
             <xpath expr="//field[@name='removal_strategy_id']" position="after">
                 <field name="u_height_category_id" />
                 <field name="u_speed_category_id" />


### PR DESCRIPTION
Main group on stock location has three groups, change the layout to three columns so there is one column per group.

Story: 2002
Signed-off-by: Armand Cela <armand.cela@unipart.io>