### PR TITLE
[FIX] udes_security: Handle XML IDs in _get_menu_info_from_action_id

### DIFF
--- a/addons/udes_security/controllers/main.py
+++ b/addons/udes_security/controllers/main.py
@@ -79,9 +79,11 @@ class SecureAction(Action):
         action_group_ids = []
         parent_path_ids = []
 
-        if not isinstance(action_id, int):
-            try:
-                action_id = int(action_id)
+        try:  # If you middle click a menu, action_id is a string..
+            action_id = int(action_id)
+        except ValueError:
+            try:  # JS `do_action("action_extid")` results in the parameter coming in as a string here
+                action_id = request.env.ref(action_id).id
             except ValueError:
                 raise ValidationError("Invalid action ID specified.")
         query = """


### PR DESCRIPTION
Backported from UDES 14 commit: https://github.com/unipartdigital/udes-open/commit/581cbbeff3563d3af45cbf2242d51bb80476a1df

Story/3337

Signed-off-by: Peter Clark <peter.clark@unipart.com>