### PR TITLE
[FIX] udes_security: Allow portal users to browse view website

### DIFF
--- a/addons/udes_security/controllers/web.py
+++ b/addons/udes_security/controllers/web.py
@@ -17,7 +17,7 @@ class Home(Home):
         )
         return has_desktop_access
 
-    @http.route("/", type="http", auth="none")
+    @http.route("/", type="http", auth="public")
     def index(self, *args, **kw):
         """Extend controller to redirect non-desktop user if they try to access the main system"""
         if request.session.uid and not self.user_has_desktop_access():


### PR DESCRIPTION
Update `auth` param to allow public and internal users to browse to the website. When `auth=None` the value of `request.env.user` is lost and hence the `ensure_one()` assertions fail.

Signed-off-by: Adam Patrick <adam.patrick@unipart.com>