### PR TITLE
[FIX] udes_stock: Removing toggle_active from route tree views

### DIFF
--- a/addons/udes_stock/views/stock_location_route_views.xml
+++ b/addons/udes_stock/views/stock_location_route_views.xml
@@ -9,10 +9,6 @@
             <tree position="attributes">
                 <attribute name="decoration-muted">not active</attribute>
             </tree>
-            <field name="active" position="attributes">
-                <attribute name="widget">boolean_toggle</attribute>
-                <attribute name="invisible">0</attribute>
-            </field>
         </field>
     </record>
 


### PR DESCRIPTION
The way we archive or unarchive routes is from actions, which triggers the method to archive or unarchive the rules as well. It's not needed to have 2 places where to archive/unarchive routes

Story: 3205
Signed-off-by: Armand Cela <armand.cela@unipart.io>