### PR TITLE
[IMP] udes_security: Remove "Schedule activity" from all pages

### DIFF
--- a/addons/udes_security/static/src/xml/custom_chatter_topbar.xml
+++ b/addons/udes_security/static/src/xml/custom_chatter_topbar.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+    <t t-name="ChatterTopbarExtension" t-inherit="mail.ChatterTopbar" t-inherit-mode="extension" owl="1">
+        <xpath expr="//button[hasclass('o_ChatterTopbar_buttonScheduleActivity')]" position="replace">
+        <!-- Remove the "Schedule activity" button for all users on all screens -->
+        </xpath>
+    </t>
+</templates>
+


### PR DESCRIPTION
"Schedule activity" button removed for all users and all pages.

Story/4774