### PR TITLE
[FIX] udes_security: Remove "Schedule activity" from all pages

### DIFF
--- a/addons/udes_security/__manifest__.py
+++ b/addons/udes_security/__manifest__.py
@@ -25,5 +25,8 @@
         "data/setup_default_domains.xml",
         "views/domain_allowlist_view.xml",
     ],
+    "qweb": [
+         "static/src/xml/custom_chatter_topbar.xml"
+     ],
     "demo": [],
 }


### PR DESCRIPTION
Added missing XML file to manifest.

Story/4774