### PR TITLE
Fixing Odd Desktop Backorder Behaviour

### DIFF
--- a/addons/udes_stock/models/stock_picking.py
+++ b/addons/udes_stock/models/stock_picking.py
@@ -17,6 +17,8 @@ class StockPicking(models.Model):
     _inherit = "stock.picking"
 
     # Adding fields to be hidden by default from form view.
+    # NB JB: Fields added here will cause test Form class to break. Not sure
+    # on fix, will just have to not use the test Form class.
     DetailedFormViewFields = [
         "u_first_picking_ids",
         "u_prev_picking_ids",


### PR DESCRIPTION
 - If a picking has `u_validate_real_time = True` with 3 move lines, when a move line is updated with qty_done and saved via the desktop, Odoo will send 3 commands to the backend. One updating the move line with qty_done, and another two re-writing the other 2 move lines to the picking. This meant that even when the qty_done was written a backorder would be created (which the 2 other move lines would be written to) they would then be written to the original picking due to the extra commands sent to the backend. The fix was to filter out these commands in this specific situation.
 - Another weird behaviour that happened with goods in, meant we could have extra move lines attached to a backorder when the picking was validated through the desktop. These extra move lines were in the `assigned` state, but had no reserved quantity (which does not make any sense). The fix was to check and remove those move lines.  