### PR TITLE
[FIX] udes_warehouse_classification: Give outbound hht permissions.

### DIFF
--- a/addons/udes_warehouse_classification/data/user_template.xml
+++ b/addons/udes_warehouse_classification/data/user_template.xml
@@ -17,5 +17,15 @@
             ]" />
         </record>
 
+        <!-- Extend Outbound HHT User Template to include warehouse classification permissions.
+        Outbound HHT users need this permission otherwise they cannot check in products with
+        a warehouse classification. Outbound admins will need this permission to view products
+        in the desktop -->
+        <record id="udes_stock_permissions.outbound_hht_template" model="user.template">
+            <field name="group_ids" eval="[
+                (4, ref('udes_warehouse_classification.group_warehouse_classification_view')),
+            ]" />
+        </record>
+
     </data>
 </odoo>


### PR DESCRIPTION

- No outbound flows currently use warehouse classifications, but outbound admins cannot view products without the warehouse classification read permission. Outbound hht will eventually need this permission anyway so it is best to assign it to the outbound hht user.

Set: 173