### PR TITLE
[IMP] udes_stock: Make Source Document (origin) on pickings only in draft

### DIFF
--- a/addons/udes_stock/views/stock_picking.xml
+++ b/addons/udes_stock/views/stock_picking.xml
@@ -148,7 +148,9 @@
                 Origin also set to readonly unless the picking is in draft state
             -->
             <xpath expr="//field[@name='origin']" position="attributes">
-                <attribute name="attrs">{'readonly': [('state', '!=', 'draft')],  'required': [('picking_type_code', '=', 'incoming')]}</attribute>
+                <attribute name="attrs">{'readonly': [('state', '!=', 'draft')],
+                    'required': [('picking_type_code', '=', 'incoming'), ('state', '=', 'draft')]}
+                </attribute>
             </xpath>
 
             <xpath expr="//field[@name='date_done']" position="attributes">


### PR DESCRIPTION
SE-1149

Goods-in, (Receive etc. for van stock) may not have Source set on mobile flow. Editing/cancelling such pickings in waiting/ready state was impossible due to missing source document error. Make it mandatory only in the desktop UI, in draft stage.