### PR TITLE
[ADD] udes_security: Removing exif data when has datas

### DIFF
--- a/addons/udes_security/models/ir_attachment.py
+++ b/addons/udes_security/models/ir_attachment.py
@@ -112,9 +112,10 @@ class IrAttachment(models.Model):
         for attachment in attachments.filtered(
                 lambda att: att.u_file_type in allowed_image_file_types
         ):
-            attachment.datas = attachment.with_context(skip_remove_exif=True)._remove_exif_data(
-                attachment.datas
-            )
+            if attachment.datas:
+                attachment.datas = attachment.with_context(skip_remove_exif=True)._remove_exif_data(
+                    attachment.datas
+                )
         return attachments
 
     def _remove_exif_data(self, datas):


### PR DESCRIPTION
There was an issue when trying to install website module as in the website_data.xml there was an image of type url without datas.