### PR TITLE
Change return type of PreciseDatetime.now

### DIFF
--- a/addons/udes_common/models/fields.py
+++ b/addons/udes_common/models/fields.py
@@ -19,7 +19,7 @@ class PreciseDatetime(fields.Datetime):
         """ Return the current day and time in the format expected by the ORM.
             This function may be used to compute default values.
         """
-        return datetime.now().strftime(DATETIME_FORMAT)
+        return datetime.now()
 
     @staticmethod
     def to_datetime(value):
@@ -37,6 +37,9 @@ class PreciseDatetime(fields.Datetime):
         if len(value) == DATE_LENGTH:
             value += " 00:00:00.000000"
         return datetime.strptime(value, DATETIME_FORMAT)
+
+    # Odoo have deprecated from_string in favour of to_datetime
+    from_string = to_datetime
 
     @staticmethod
     def to_string(value):

--- a/addons/udes_common/tests/__init__.py
+++ b/addons/udes_common/tests/__init__.py
@@ -4,3 +4,4 @@ from . import test_iterators
 from . import test_selection_display_name
 from . import test_prevent_bad_dates
 from . import test_record_is_child_of_self
+from . import test_fields

--- a/addons/udes_common/tests/test_fields.py
+++ b/addons/udes_common/tests/test_fields.py
@@ -1,0 +1,31 @@
+"""Unit tests for PreciseDatetime field."""
+
+import datetime as dt
+
+from odoo import fields, models
+from odoo.fields import Datetime
+from odoo.tests.common import SavepointCase, tagged
+
+from ..models.fields import PreciseDatetime
+
+
+@tagged("post_install", "-at_install")
+class PreciseDatetimeTestCase(SavepointCase):
+    """Tests for the PreciseDatetime field type."""
+
+    def test_now_returns_datetime_instance(self):
+        """Our class should return type as the superclass."""
+        imprecise_now = Datetime.now()
+        precise_now = PreciseDatetime.now()
+
+        self.assertTrue(isinstance(imprecise_now, dt.datetime))
+        self.assertTrue(isinstance(precise_now, dt.datetime))
+
+    def test_from_string_can_handle_microseconds(self):
+        """The from string method should handle microseconds."""
+        date_string = '2024-10-10 09:15:05.123'
+        datetime_value = Datetime.from_string(date_string[:4])
+        precise_datetime_value = PreciseDatetime.from_string(date_string)
+
+        self.assertTrue(isinstance(datetime_value, dt.datetime))
+        self.assertTrue(isinstance(precise_datetime_value, dt.datetime))

--- a/addons/udes_common/tests/test_fields.py
+++ b/addons/udes_common/tests/test_fields.py
@@ -23,7 +23,7 @@ class PreciseDatetimeTestCase(SavepointCase):
 
     def test_from_string_can_handle_microseconds(self):
         """The from string method should handle microseconds."""
-        date_string = '2024-10-10 09:15:05.123'
+        date_string = "2024-10-10 09:15:05.123"
         datetime_value = Datetime.from_string(date_string[:4])
         precise_datetime_value = PreciseDatetime.from_string(date_string)
 


### PR DESCRIPTION
- PreciseDatetime.now function returns a datetime.datetime object.
- Functions that invoke PreciseDatetime.now are updated to support the new return object.
- Review use of the from_string method and its aliases.

SE-1471