### PR TITLE
[ADD] udes_stock: Handle expiry dates for lots

### DIFF
--- a/addons/udes_stock/models/stock_move_line.py
+++ b/addons/udes_stock/models/stock_move_line.py
@@ -347,6 +347,7 @@ class StockMoveLine(models.Model):
             quantity = prod["uom_qty"]
             lot_names = prod.get("lot_names", [])
             lot_quantities = prod.get("lot_quantities", [])
+            lot_expiry_dates = prod.get("lot_expiry_dates", [])
             product_tracking = product.tracking
             is_trackable = product_tracking != "none"
             is_serial = product_tracking == "serial"
@@ -384,6 +385,9 @@ class StockMoveLine(models.Model):
                         qty_done, product, package, lot_name, location
                     )
                     prod_dict = {"qty_done": qty_done, "lot_name": lot_name_val}
+                    if lot_expiry_dates:
+                        # TODO: hidden dep to product_expiry
+                        prod_dict["expiration_date"] = lot_expiry_dates[idx]
                     prod_dict.update(vals)
                     res[prod_mls] = prod_dict
                     quantity_fulfilled += qty_done


### PR DESCRIPTION
This adds a hidden dependency with product_expiry under the assumption that the field will only be populated if the module is installed, hence not hitting that line of code.
This tech debt will be resolved later by a restructing code around prepare method so it can be extensible.