### PR TITLE
[FIX] udes_stock_cron: Bug in reserving stock with a batch

### DIFF
--- a/addons/udes_stock_cron/models/stock_picking.py
+++ b/addons/udes_stock_cron/models/stock_picking.py
@@ -300,7 +300,7 @@ class StockPicking(models.Model):
         pickings = self
         if self.batch_id:
 
-            if self.u_reserve_batches or picking_type.u_reserve_batches:
+            if picking_type.u_reserve_batches:
                 # Process the batches pickings
                 pickings = pickings.batch_id.picking_ids
 


### PR DESCRIPTION
Fix bug when adding more pickings to reserve. The `u_reserve_batches` field does not exist on the stock.picking model.

Story/SE-1844