### PR TITLE
[TEST] udes_sale_stock: Add client_order_ref param to helper

### DIFF
--- a/addons/udes_sale_stock/tests/common.py
+++ b/addons/udes_sale_stock/tests/common.py
@@ -2,7 +2,6 @@ from odoo.addons.udes_stock.tests.common import BaseUDES
 
 
 class BaseSaleUDES(BaseUDES):
-
     """
     Creating a BaseSaleUDES testing class on top of BaseUDES which we can reuse when we need to have BaseUDES with
     some helper methods related with sale order.
@@ -23,13 +22,26 @@ class BaseSaleUDES(BaseUDES):
         return cls.env["sale.order.line"].create(create_values)
 
     @classmethod
-    def create_sale(cls, customer, **kwargs):
+    def create_sale(cls, customer, client_order_ref, requested_date, **kwargs):
         """Create a sale order"""
         create_values = {
             "partner_id": customer.id,
             "partner_invoice_id": customer.id,
             "partner_shipping_id": customer.id,
             "pricelist_id": cls.env.ref("product.list0").id,
+            "client_order_ref": client_order_ref,
+            "requested_date": requested_date,
         }
         create_values.update(kwargs)
         return cls.env["sale.order"].create(create_values)
+
+    @classmethod
+    def complete_sale(cls, sale):
+        """Complete a sale by completing its pickings."""
+        pickings = sale.picking_ids
+        picks_to_process = pickings.filtered(lambda p: not p.u_prev_picking_ids)
+        while picks_to_process:
+            picks_to_process.action_assign()
+            for picking in picks_to_process:
+                cls.complete_picking(picking)
+            picks_to_process = picks_to_process.u_next_picking_ids


### PR DESCRIPTION
SE-2034

Signed-off-by: Kevin Dwyer <kevin.dwyer@unipart.com>

SaleOrder.client_order_ref is required, so make it required for the create_sale test helper method. Likewise requested_date.