### PR TITLE
[FIX] udes_stock_cron: Do not reserve stock in draft batches

### DIFF
--- a/addons/udes_stock_cron/models/stock_picking.py
+++ b/addons/udes_stock_cron/models/stock_picking.py
@@ -179,6 +179,9 @@ class StockPicking(models.Model):
 
             pickings = pickings.add_more_pickings_to_reserve(picking_type)
 
+            if pickings in processed:
+                continue
+
             extended_processed_pickings = pickings.add_processed_pickings(processed)
             # If have been added more processed pickings, continue the loop without trying to reserve the pickings
             if extended_processed_pickings != processed:


### PR DESCRIPTION
SE-2137

Signed-off-by: Kevin Dwyer <kevin.dwyer@unipart.com>

The add_processed_pickings method adds all the pickings in a batch to the processed collection, and this messes up the comparison in reserve_stock_for_picking_type.

Don't process if the current picking is in the processed collection.