### PR TITLE
SE-2938 Fix two stage pickings

### DIFF
--- a/addons/udes_stock_cron/models/stock_picking.py
+++ b/addons/udes_stock_cron/models/stock_picking.py
@@ -264,7 +264,7 @@ class StockPicking(models.Model):
         Helper function to actually process the pickings in `self`.
         Called while being wrapped by odoo_retry, hence the return values being a dict.
         """
-        unsatisfied_state = lambda p: p.state not in ("assigned", "cancel", "done")
+        unsatisfied_state = lambda p: p.state not in ("assigned", "cancel", "done", "waiting")
         newly_processed = self._reserve_stock_assign()
         self.batch_id._compute_state()
 

--- a/addons/udes_stock_routing/models/stock_move.py
+++ b/addons/udes_stock_routing/models/stock_move.py
@@ -224,7 +224,7 @@ class StockMove(models.Model):
             if move.exists() and (picking := move.picking_id):
                 if picking.should_two_stage_initiate():
                     processed |= move.picking_id
-                    move.picking_id.initiate_two_stage_split()
+                    res |= move.picking_id.initiate_two_stage_split()
         # Unlink any empty pickings left by two stage split immediately.
         if processed:
             processed.unlink_empty()

--- a/addons/udes_stock_routing/models/stock_picking.py
+++ b/addons/udes_stock_routing/models/stock_picking.py
@@ -96,6 +96,7 @@ class StockPicking(models.Model):
         """
         self.ensure_one()
         Picking = self.env["stock.picking"]
+        Move = self.env["stock.move"]
 
         original_priority = self.priority
         original_origin = self.origin
@@ -104,6 +105,7 @@ class StockPicking(models.Model):
         original_sequence = self.sequence
 
         configuration_move_line_mapping = self._get_two_stage_configuration_move_line_mapping()
+        new_moves = Move.browse()
         for configuration, move_lines in configuration_move_line_mapping.items():
             # Split the reserved two stage move lines to a backorder. This makes it so that even on partial reservation,
             # only the reserved stock will get split to two stage, which means the remaining stock on the original pick
@@ -118,7 +120,17 @@ class StockPicking(models.Model):
                 "u_from_two_stage_split": True,
                 "sequence": original_sequence,
             }
-            stage_2_pick = self.split_move_lines_to_backorder(move_lines, **stage_2_pick_vals)
+
+            # Only create backorder for partial reservation
+            if self.move_lines.get_uncovered_moves(mls=move_lines):
+                stage_2_pick = self.split_move_lines_to_backorder(move_lines, **stage_2_pick_vals)
+            else:
+                stage_2_pick = self
+                stage_2_pick.write({
+                    "location_id": configuration.intermediate_location_id,
+                    "location_dest_id": configuration.intermediate_dest_location_id,
+                    "u_from_two_stage_split": True,
+            })
             stage_2_pick.move_lines.write(
                 {
                     "location_id": configuration.intermediate_location_id,
@@ -162,9 +174,11 @@ class StockPicking(models.Model):
                         "location_dest_id": configuration.intermediate_location_id,
                     }
                 )
+                new_moves |= stage_1_move
             # Flag fully emptied pickings as empty.
             if not self.move_lines:
                 self.u_is_empty = True
+        return new_moves
 
     def do_unreserve(self):
         """Extend to mark empty picks for deletion."""

--- a/addons/udes_stock_routing/tests/test_two_stage_outbound.py
+++ b/addons/udes_stock_routing/tests/test_two_stage_outbound.py
@@ -143,7 +143,7 @@ class TestTwoStageOutbound(TwoStageOutboundBase):
         """
         self.create_quant(self.apple.id, self.test_special_location_01.id, 10)
         self.create_quant(self.banana.id, self.test_special_location_02.id, 5)
-        self.create_picking(
+        new_picking = self.create_picking(
             self.picking_type_pick, products_info=self.products_info, confirm=True, assign=True
         )
         all_picks = self.Picking.search([])
@@ -165,6 +165,7 @@ class TestTwoStageOutbound(TwoStageOutboundBase):
         # The picking type of the next picking should no longer be the Check picking, instead it is the 2nd stage,
         # which will preserve the original picking type.
         stage_2_pick = stage_1_pick.u_next_picking_ids
+        self.assertEqual(new_picking, stage_2_pick)
         self.assertEqual(stage_2_pick.picking_type_id, self.picking_type_pick)
         # It should be waiting for another operation
         self.assertEqual(stage_2_pick.state, "waiting")
@@ -215,7 +216,7 @@ class TestTwoStageOutbound(TwoStageOutboundBase):
         """
         self.create_quant(self.apple.id, self.test_special_location_01.id, 10)
         self.create_quant(self.banana.id, self.test_stock_location_01.id, 5)
-        self.create_picking(
+        new_picking = self.create_picking(
             self.picking_type_pick, products_info=self.products_info, confirm=True, assign=True
         )
         all_picks = self.Picking.search([])
@@ -231,6 +232,8 @@ class TestTwoStageOutbound(TwoStageOutboundBase):
         )
         self.assertEqual(stage_1_pick.state, "assigned")
         stage_2_pick = stage_1_pick.u_next_picking_ids
+        self.assertNotEqual(new_picking, stage_2_pick)
+        self.assertEqual(new_picking, stage_2_pick.backorder_id)
         self.assertEqual(stage_2_pick.picking_type_id, self.picking_type_pick)
         self.assertEqual(stage_2_pick.state, "waiting")
         check_pick = stage_2_pick.u_next_picking_ids


### PR DESCRIPTION
* Return new moves created at _action_assign()
* Only create backorder if necessary
* Reserve cron should ignore waiting pickings